### PR TITLE
Handle camera loss and Pico4 SDK shutdown

### DIFF
--- a/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
@@ -33,6 +33,7 @@ Observation features (per side ``{s}`` in left/right):
 
 from __future__ import annotations
 
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import cached_property
 from typing import Any
@@ -54,6 +55,16 @@ from ..taccap_gripper.taccap_gripper import (
 from .config_bi_taccap_gripper import BiTaccapGripperConfig
 
 _SIDES = ("left", "right")
+
+# Freeze timeout for graceful degradation. If a camera's ``async_read`` keeps
+# returning the *same* frame object for this long, the stream is treated as
+# physically lost. This covers Xense tactile sensors, whose background read
+# thread survives a hot-unplug (it only stops on ``DeviceNotConnectedError``)
+# and whose ``async_read`` restarts the thread and returns the last cached
+# frame forever without raising — unlike the OpenCV wrist camera, which raises
+# once its read thread dies. Keep this well above the slowest camera's frame
+# interval so a sensor-slower-than-the-sample-loop rate mismatch never trips it.
+_CAM_FREEZE_TIMEOUT_S = 2.0
 
 # ---- TacCap-Gripper SDK -----------------------------------------------------
 try:
@@ -148,6 +159,9 @@ class BiTaccapGripper(Robot):
         # so the caller can stop cleanly and save what was recorded.
         self._last_cam_frame: dict[str, np.ndarray] = {}
         self._lost_cameras: set[str] = set()
+        # Monotonic time each camera last produced a genuinely new frame object,
+        # used to detect a frozen (non-raising) stream — see _read_camera_or_fallback.
+        self._last_new_frame_t: dict[str, float] = {}
 
     # ------------------------------------------------------------------ discovery
 
@@ -431,27 +445,61 @@ class BiTaccapGripper(Robot):
     def _read_camera_or_fallback(self, cam_name: str, cam: Any) -> np.ndarray:
         """Read one camera, degrading gracefully on physical loss.
 
-        A hot-unplugged camera (USB drop / hub power loss) makes its background
-        read thread die; the next ``async_read`` raises ``RuntimeError`` ("read
-        thread is not running"). Letting that propagate crashes the record loop
-        and loses the in-progress episode. Instead we substitute the last good
-        frame (or a black frame on first-read loss), flag the camera as lost so
-        ``device_lost`` trips, and let the caller stop cleanly and save.
+        Two distinct loss modes are handled, because the camera classes behave
+        differently on a hot-unplug:
 
-        ``TimeoutError`` (a transient slow/dropped frame) is treated the same way
+        * **Read raises** — an OpenCV/UVC wrist camera's background thread dies
+          after repeated failures and the next ``async_read`` raises
+          ``RuntimeError`` ("read thread is not running"). Letting that propagate
+          crashes the record loop and loses the in-progress episode.
+        * **Read freezes** — a Xense tactile sensor keeps its background thread
+          alive on error (it only stops on ``DeviceNotConnectedError``) and its
+          ``async_read`` restarts the thread and returns the *same* cached frame
+          object indefinitely, so an unplug never raises. We detect this by
+          watching for a genuinely new frame object; if none arrives within
+          ``_CAM_FREEZE_TIMEOUT_S`` the stream is treated as lost. Without this,
+          recording would silently continue writing stale tactile frames.
+
+        In both cases we substitute the last good frame (or a black frame on
+        first-read loss), flag the camera as lost so ``device_lost`` trips, and
+        let the caller stop cleanly and save.
+
+        ``TimeoutError`` (a transient slow/dropped frame) reuses the last frame
         but is NOT flagged as lost — those recover on their own."""
+        now = time.monotonic()
         try:
             frame = cam.async_read()
-            self._last_cam_frame[cam_name] = frame
-            return frame
         except TimeoutError as e:
             self.logger.warning(f"  [{cam_name}] frame timeout, reusing last frame: {e}")
             return self._fallback_frame(cam_name)
         except Exception as e:
-            if cam_name not in self._lost_cameras:
-                self.logger.error(f"  [{cam_name}] camera lost mid-episode: {e}")
-                self._lost_cameras.add(cam_name)
+            self._flag_lost(cam_name, f"camera lost mid-episode: {e}")
             return self._fallback_frame(cam_name)
+
+        # Freeze detection: a live stream yields a fresh array each frame; a
+        # frozen one returns the identical cached object every call. Only reset
+        # the clock on a genuinely new object, so a sensor slower than the sample
+        # loop (which legitimately re-reads one frame) does not trip it.
+        prev = self._last_cam_frame.get(cam_name)
+        if prev is None or frame is not prev:
+            self._last_new_frame_t[cam_name] = now
+        else:
+            frozen_for = now - self._last_new_frame_t.get(cam_name, now)
+            if frozen_for > _CAM_FREEZE_TIMEOUT_S:
+                self._flag_lost(
+                    cam_name,
+                    f"no new frame for {frozen_for:.1f}s (stream frozen, sensor likely unplugged)",
+                )
+
+        self._last_cam_frame[cam_name] = frame
+        return frame
+
+    def _flag_lost(self, cam_name: str, reason: str) -> None:
+        """Mark a camera as physically lost so ``device_lost`` trips. Idempotent;
+        logs once per camera."""
+        if cam_name not in self._lost_cameras:
+            self.logger.error(f"  [{cam_name}] {reason}")
+            self._lost_cameras.add(cam_name)
 
     def _fallback_frame(self, cam_name: str) -> np.ndarray:
         """Last good frame for this camera, or a black frame of the declared

--- a/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
@@ -142,6 +142,13 @@ class BiTaccapGripper(Robot):
 
         self._is_connected = False
 
+        # Graceful-degradation state for mid-episode camera loss: keep the last
+        # good frame per camera so a hot-unplug degrades to a stale/black frame
+        # instead of crashing the record loop, and remember which cameras died
+        # so the caller can stop cleanly and save what was recorded.
+        self._last_cam_frame: dict[str, np.ndarray] = {}
+        self._lost_cameras: set[str] = set()
+
     # ------------------------------------------------------------------ discovery
 
     def _discover_camera_configs(self) -> dict[str, Any]:
@@ -228,6 +235,13 @@ class BiTaccapGripper(Robot):
     @property
     def is_connected(self) -> bool:
         return self._is_connected
+
+    @property
+    def device_lost(self) -> bool:
+        """True once any camera has been detected as physically lost mid-episode
+        (hot-unplug / hub drop). The record loop polls this to stop cleanly and
+        save the in-progress episode instead of crashing on the next read."""
+        return bool(self._lost_cameras)
 
     @property
     def is_calibrated(self) -> bool:
@@ -410,9 +424,45 @@ class BiTaccapGripper(Robot):
                     self.logger.warn(f"  [{side}] IMU read failed: {e}")
 
         for cam_name, cam in self.cameras.items():
-            obs[cam_name] = cam.async_read()
+            obs[cam_name] = self._read_camera_or_fallback(cam_name, cam)
 
         return obs
+
+    def _read_camera_or_fallback(self, cam_name: str, cam: Any) -> np.ndarray:
+        """Read one camera, degrading gracefully on physical loss.
+
+        A hot-unplugged camera (USB drop / hub power loss) makes its background
+        read thread die; the next ``async_read`` raises ``RuntimeError`` ("read
+        thread is not running"). Letting that propagate crashes the record loop
+        and loses the in-progress episode. Instead we substitute the last good
+        frame (or a black frame on first-read loss), flag the camera as lost so
+        ``device_lost`` trips, and let the caller stop cleanly and save.
+
+        ``TimeoutError`` (a transient slow/dropped frame) is treated the same way
+        but is NOT flagged as lost — those recover on their own."""
+        try:
+            frame = cam.async_read()
+            self._last_cam_frame[cam_name] = frame
+            return frame
+        except TimeoutError as e:
+            self.logger.warning(f"  [{cam_name}] frame timeout, reusing last frame: {e}")
+            return self._fallback_frame(cam_name)
+        except Exception as e:
+            if cam_name not in self._lost_cameras:
+                self.logger.error(f"  [{cam_name}] camera lost mid-episode: {e}")
+                self._lost_cameras.add(cam_name)
+            return self._fallback_frame(cam_name)
+
+    def _fallback_frame(self, cam_name: str) -> np.ndarray:
+        """Last good frame for this camera, or a black frame of the declared
+        (H, W, 3) shape if none was ever captured."""
+        cached = self._last_cam_frame.get(cam_name)
+        if cached is not None:
+            return cached
+        cfg = self._camera_configs[cam_name]
+        frame = np.zeros((cfg.height, cfg.width, 3), dtype=np.uint8)
+        self._last_cam_frame[cam_name] = frame
+        return frame
 
     def send_action(self, action: dict[str, Any] | None = None) -> dict[str, Any]:
         """No-op: passive demonstration device. The operators drive the jaws

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -342,6 +342,17 @@ def self_driven_record_loop(
         action = None
         if dataset is not None or display_data:
             observation = robot.get_observation()
+
+            # Graceful degradation on mid-episode hardware loss (e.g. a wrist
+            # camera hot-unplug): the robot returns fallback frames instead of
+            # raising, and flags device_lost. Stop the whole session cleanly so
+            # the in-progress episode is saved rather than crashing the loop.
+            if getattr(robot, "device_lost", False):
+                logger.error(
+                    "Device lost mid-recording; stopping to save recorded data."
+                )
+                events["stop_recording"] = True
+                break
             # Self-driven device: the demonstrated action is the pose + gripper
             # subset of this same observation sample (images excluded — we
             # iterate action_features, not the full obs). Single hardware read.

--- a/src/lerobot/teleoperators/pico4/tracker.py
+++ b/src/lerobot/teleoperators/pico4/tracker.py
@@ -48,9 +48,16 @@ Concurrency
 -----------
 ``xrt.init()`` is a process-level singleton. This module guards it with
 a class-level flag so multiple readers in one process share the same
-SDK instance. ``xrt.close()`` is intentionally NOT called on disconnect
-— if a second subscriber is still alive, closing tears it down too.
-Rely on process exit.
+SDK instance. A class-level counter tracks how many readers have the SDK
+open; ``disconnect()`` only calls ``xrt.close()`` once the last reader
+releases it, so a still-alive subscriber is never torn down early. An
+``atexit`` hook closes the SDK on interpreter shutdown as a fallback for
+paths that never call ``disconnect()`` (e.g. discovery-only use via
+``list_serial_numbers()``). This matters because the underlying SDK
+spawns background ``std::thread``s that are only joined by
+``xrt.close()``; leaving them joinable at process teardown makes their
+destructor call ``std::terminate()`` (observed as
+``terminate called without an active exception`` / core dump).
 
 Threading model — background poller
 -----------------------------------
@@ -71,6 +78,7 @@ Matches the architecture of the SDK's
 
 from __future__ import annotations
 
+import atexit
 import threading
 import time
 from typing import Any
@@ -146,11 +154,38 @@ class Pico4TrackerReader:
     _xrt_initialized: bool = False
     _xrt = None  # module reference, set on first connect
     _init_lock = threading.Lock()
+    # Number of readers currently holding the SDK open. Incremented on a
+    # successful connect(), decremented on disconnect(); the SDK is closed
+    # (which joins its background threads) only when this hits zero. Guarded
+    # by _init_lock. An atexit fallback (see _shutdown_sdk) closes the SDK
+    # even if some path never calls disconnect().
+    _active_readers: int = 0
+    _atexit_registered: bool = False
     # spdlog rejects duplicate logger names; use an instance counter to
     # disambiguate when multiple readers share the same logger_name (e.g.
     # both default to "auto").
     _instance_counter: int = 0
     _counter_lock = threading.Lock()
+
+    @classmethod
+    def _shutdown_sdk(cls) -> None:
+        """Close the XenseVR SDK, joining its background threads.
+
+        Registered as an atexit hook on first init so that discovery-only
+        use (``list_serial_numbers``) or any path that skips
+        ``disconnect()`` still tears the SDK down cleanly. Without this,
+        the SDK's joinable ``std::thread``s are destroyed at process exit
+        and call ``std::terminate()`` (core dump). Idempotent.
+        """
+        with cls._init_lock:
+            if cls._xrt_initialized and cls._xrt is not None:
+                try:
+                    cls._xrt.close()
+                except Exception:  # pragma: no cover — best-effort at teardown
+                    pass
+            cls._xrt_initialized = False
+            cls._xrt = None
+            cls._active_readers = 0
 
     def __init__(
         self,
@@ -258,6 +293,9 @@ class Pico4TrackerReader:
                 xrt.init()
                 cls._xrt = xrt
                 cls._xrt_initialized = True
+                if not cls._atexit_registered:
+                    atexit.register(cls._shutdown_sdk)
+                    cls._atexit_registered = True
         xrt = cls._xrt
 
         deadline = time.monotonic() + float(device_wait_timeout)
@@ -340,6 +378,9 @@ class Pico4TrackerReader:
                 xrt.init()
                 Pico4TrackerReader._xrt = xrt
                 Pico4TrackerReader._xrt_initialized = True
+                if not Pico4TrackerReader._atexit_registered:
+                    atexit.register(Pico4TrackerReader._shutdown_sdk)
+                    Pico4TrackerReader._atexit_registered = True
                 self.logger.info("XenseVR SDK initialized.")
             else:
                 self.logger.info("XenseVR SDK already initialized; reusing singleton.")
@@ -386,6 +427,8 @@ class Pico4TrackerReader:
             daemon=True,
         )
         self._poller_thread.start()
+        with Pico4TrackerReader._init_lock:
+            Pico4TrackerReader._active_readers += 1
         self.logger.info(
             f"Pico4TrackerReader connected to tracker idx={self._tracker_index} "
             f"sn={self._resolved_sn!r} after {attempt + 1} polls; "
@@ -418,10 +461,13 @@ class Pico4TrackerReader:
     def disconnect(self) -> None:
         """Stop the poller thread and mark the reader disconnected.
 
-        NOTE: we deliberately do NOT call ``xrt.close()`` — the service
-        is a process-level singleton and other readers in the same
-        process may still need it. The OS reclaims the service
-        connection at process exit.
+        The XenseVR SDK is a process-level singleton shared by every
+        reader in the process. This reader releases its hold on the SDK
+        and, only when it was the last active reader, calls
+        ``xrt.close()`` to join the SDK's background threads. Closing
+        earlier would tear down a still-alive subscriber; not closing at
+        all leaves those threads joinable at process exit, whose
+        destructor calls ``std::terminate()`` (core dump).
         """
         if not self._is_connected:
             return
@@ -442,7 +488,30 @@ class Pico4TrackerReader:
             self._latest_ts = None
             self._align_matrix = None
         self._ee_init_matrix = None
-        self.logger.info("Pico4TrackerReader disconnected (xrt left open for other subscribers).")
+
+        closed = False
+        with Pico4TrackerReader._init_lock:
+            if Pico4TrackerReader._active_readers > 0:
+                Pico4TrackerReader._active_readers -= 1
+            if (
+                Pico4TrackerReader._active_readers == 0
+                and Pico4TrackerReader._xrt_initialized
+                and Pico4TrackerReader._xrt is not None
+            ):
+                try:
+                    Pico4TrackerReader._xrt.close()
+                except Exception as e:  # pragma: no cover — best-effort at teardown
+                    self.logger.warn(f"xrt.close() failed: {e}")
+                Pico4TrackerReader._xrt_initialized = False
+                Pico4TrackerReader._xrt = None
+                closed = True
+
+        if closed:
+            self.logger.info("Pico4TrackerReader disconnected (last reader; XenseVR SDK closed).")
+        else:
+            self.logger.info(
+                "Pico4TrackerReader disconnected (xrt left open for other subscribers)."
+            )
 
     # ---- Background poller --------------------------------------------------
 


### PR DESCRIPTION
## Summary
- degrade gracefully when a bi_taccap wrist/tactile camera is lost mid-recording so the loop stops cleanly and preserves the buffered episode
- cache the last good camera frame, fall back to a black frame on first-read loss, and surface device loss to the record loop for safe shutdown
- close the Pico4 XenseVR SDK when the last tracker reader disconnects and via an atexit fallback to avoid process-exit crashes

## Test plan
- [x] `python -m py_compile src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py src/lerobot/scripts/lerobot_record.py`
- [ ] Run `lerobot-record` on the real bi_taccap rig and hot-unplug a camera during recording/reset to confirm the episode is saved and the session exits cleanly
- [ ] Run Pico4 tracker connect/disconnect on the real rig and confirm shutdown no longer ends with `std::terminate()` / core dump