### PR TITLE
feat(insight9): add Insight9 head camera support and configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "third_party/XenseVR-RobotVision-PC"]
 	path = third_party/XenseVR-RobotVision-PC
 	url = git@github.com:Vertax42/XenseVR-RobotVision-PC.git
+[submodule "third_party/insight9-python-interface"]
+	path = third_party/insight9-python-interface
+	url = git@192.168.1.61:physical-ai/grippersdk/insight9-python-interface.git

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ It is scoped to a single device: the **TacCap-Gripper** (**TacCap** = *Tactile
 Capture* Gripper) — a handheld **UMI** leader gripper for tactile data
 collection. This branch tracks **upstream lerobot v5.1**, slimmed to the
 TacCap-Gripper (single + bimanual) and its **Pico4** teleoperator/tracker, with
-Xense tactile cameras layered on top. See
+Xense tactile cameras layered on top. The bimanual rig can optionally record an
+**Insight9 head camera** as RGB plus a raw-frame VIO pose represented in the same
+position + 6D rotation format as the gripper trackers. See
 [`src/lerobot/robots/taccap_gripper/README.md`](src/lerobot/robots/taccap_gripper/README.md)
 for device-specific usage. For generic lerobot usage (datasets, policies,
 training scripts) refer to the
@@ -49,6 +51,11 @@ This repository uses `third_party/` git submodules to manage hardware SDK depend
 | `third_party/taccap-gripper` | `xense.taccap` (TacCap UMI tactile gripper SDK) |
 | `third_party/XenseVR-PC-Service` | `xensevr_pc_service_sdk` (Pico4 teleop/tracker) |
 | `third_party/XenseVR-RobotVision-PC` | ZED-M → Pico4 stereo passthrough (built separately) |
+| `third_party/insight9-python-interface` | `insight9-python-interface` (Insight9 native RGB/VIO/IMU bridge) |
+
+`taccap-gripper` and `insight9-python-interface` are installed in editable mode.
+Changes made inside those initialized submodules are therefore picked up by the
+environment without rebuilding the main `lerobot` package.
 
 > `xensesdk` is **not** a submodule and is **not** vendored in-repo — it is
 > published to PyPI (cp312 manylinux wheel that bundles the patched
@@ -92,7 +99,7 @@ This step will:
 - Update the conda environment from `conda_environment.yaml`
 - Install the main package from `pyproject.toml`
 - Install `xensesdk` from PyPI (`uv pip install xensesdk`; see the note above — override with a local wheel via `$XENSESDK_WHEEL` for offline/patched builds)
-- Install the XenseVR PC Service daemon from its `.deb` (resolved out-of-band — see the note above), then build the `third_party` SDK packages: `xensevr_pc_service_sdk` (Pico4) and `xense.taccap` (TacCap UMI gripper)
+- Install the XenseVR PC Service daemon from its `.deb` (resolved out-of-band — see the note above), then build/install the `third_party` SDK packages: `xensevr_pc_service_sdk` (Pico4), `xense.taccap` (TacCap UMI gripper), and the editable `insight9-python-interface`
 
 **Step 4:** ✅ Verify the installation:
 
@@ -100,6 +107,7 @@ This step will:
 python -c 'import xensevr_pc_service_sdk; print("xensevr_pc_service_sdk OK ->", xensevr_pc_service_sdk.__file__)'
 python -c 'import xensesdk; print("xensesdk OK ->", xensesdk.__file__)'
 python -c 'import xense.taccap; print("xense.taccap OK ->", xense.taccap.__file__)'
+python -c 'from insight9_native import find_library; print("Insight9 OK ->", find_library())'
 ```
 
 **Step 5:** 📌 **Note on FFmpeg / video:** v5.1 no longer pins `ffmpeg`
@@ -181,6 +189,31 @@ mmcli -L                                                               # gripper
 
 Revert by deleting the rule file and reloading. (Alternatively, on a dedicated
 robot PC with no cellular modem: `sudo systemctl disable --now ModemManager`.)
+
+**Step 8:** 🎥 **Insight9 native/HID readiness (only when using the head camera).**
+The Python package and bundled `libinsight9.so` can be checked without opening the
+device:
+
+```bash
+insight9-check-env --hidraw
+```
+
+The relevant `/dev/hidraw*` node must report `read=True write=True`. On the current
+Deep Mirror Insight9 hardware (`1d6b:0104`, product `insight 9`), a host can grant
+the `plugdev` group access with:
+
+```bash
+sudo tee /etc/udev/rules.d/99-insight9.rules >/dev/null <<'EOF'
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1d6b", ATTRS{idProduct}=="0104", ATTRS{product}=="insight 9", MODE="0660", GROUP="plugdev"
+EOF
+sudo usermod -aG plugdev "$USER"
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+# Log out/in, then reconnect the camera and rerun insight9-check-env --hidraw.
+```
+
+If a different Insight9 revision has another VID/PID, obtain it with `lsusb` and
+adjust the rule rather than granting access to every HID device.
 
 ## 🔑 The `LeRobotDataset` format
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -416,6 +416,33 @@ install_taccap() {
     echo "[taccap] Done. Verify with: python -c 'import xense.taccap; print(xense.taccap.__file__)'"
 }
 
+# ── Hardware module: Insight9 head camera ------------------------------------
+
+install_insight9() {
+    echo ""
+    echo "══════════════════════════════════════════"
+    echo " Insight9 Python interface"
+    echo "══════════════════════════════════════════"
+
+    local SDK_DIR="$PROJECT_ROOT/third_party/insight9-python-interface"
+    if [[ ! -f "$SDK_DIR/pyproject.toml" ]]; then
+        echo "ERROR: $SDK_DIR not found (submodule not initialized)."
+        echo "  Run: git submodule update --init third_party/insight9-python-interface"
+        return 1
+    fi
+
+    uv pip install -e "$SDK_DIR" --no-deps
+
+    python - <<'PY'
+from insight9_native import find_library
+from insight9_umi_camera import Insight9HeadCamera
+
+print("Insight9HeadCamera ->", Insight9HeadCamera)
+print("libinsight9.so ->", find_library())
+PY
+    echo "[insight9] Done. Device/HID readiness: insight9-check-env --hidraw"
+}
+
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 # Check if an environment name is provided
@@ -566,6 +593,7 @@ elif [[ "$1" == "--install" ]]; then
     ( install_pico4 ) || echo "[WARN] pico4 installation skipped or failed (see above)"
     install_xense     || echo "[WARN] xense installation skipped or failed (see above)"
     install_taccap    || echo "[WARN] taccap installation skipped or failed (see above)"
+    install_insight9  || echo "[WARN] insight9 installation skipped or failed (see above)"
 
 
     # ── Post-install verification ────────────────────────────────────────────
@@ -584,6 +612,7 @@ xensevr_pc_service_sdk|import importlib.metadata as M, xensevr_pc_service_sdk; p
 xensesdk|import importlib.metadata as M, xensesdk; print("v"+M.version("xensesdk"), "->", xensesdk.__file__)
 xensesdk flash|from xensesdk.flash.linux_backend import LinuxFlashBackend; print("available" if LinuxFlashBackend().available else "NOT available")
 taccap-gripper|import importlib.metadata as M, xense.taccap; print("v"+M.version("taccap-gripper"), "->", xense.taccap.__file__)
+insight9-python-interface|import importlib.metadata as M; from insight9_native import find_library; print("v"+M.version("insight9-python-interface"), "->", find_library())
 VERIFY
 
     echo ""

--- a/src/lerobot/cameras/insight9/__init__.py
+++ b/src/lerobot/cameras/insight9/__init__.py
@@ -1,0 +1,4 @@
+from .camera_insight9 import Insight9Camera, Insight9Snapshot
+from .configuration_insight9 import Insight9CameraConfig
+
+__all__ = ["Insight9Camera", "Insight9CameraConfig", "Insight9Snapshot"]

--- a/src/lerobot/cameras/insight9/camera_insight9.py
+++ b/src/lerobot/cameras/insight9/camera_insight9.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The XenseRobotics Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LeRobot camera adapter for the multimodal Insight9 head camera."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+
+from lerobot.utils.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
+from lerobot.utils.robot_utils import get_logger, quaternion_to_rotation_6d
+
+from ..camera import Camera
+from .configuration_insight9 import Insight9CameraConfig
+
+
+@dataclass(frozen=True)
+class Insight9Snapshot:
+    """Latest decoded RGB frame and raw-frame VIO pose from one SDK snapshot."""
+
+    rgb: NDArray[np.uint8]
+    vio_position: tuple[float, float, float]
+    vio_rotation_6d: tuple[float, float, float, float, float, float]
+
+
+class Insight9Camera(Camera):
+    """Own the Insight9 SDK once and expose RGB plus raw VIO snapshots.
+
+    The generic Camera methods return RGB only. ``read_snapshot_latest`` is the
+    API used by ``BiTaccapGripper`` so RGB and VIO are sampled together without
+    opening the native SDK more than once.
+    """
+
+    config_class = Insight9CameraConfig
+
+    def __init__(self, config: Insight9CameraConfig):
+        super().__init__(config)
+        self.config = config
+        self.logger = get_logger("Insight9Camera")
+
+        self._sdk_camera: Any | None = None
+        self._is_connected = False
+        self._last_good_rgb: NDArray[np.uint8] | None = None
+        self._last_good_color: Any | None = None
+        self._last_vio: Any | None = None
+        self._last_seen_color_frame_index: int | None = None
+        self._last_stale_warning_t = 0.0
+        self._last_decode_warning_t = 0.0
+
+    def __str__(self) -> str:
+        return "Insight9Camera(head_rgb)"
+
+    @property
+    def is_connected(self) -> bool:
+        return self._is_connected
+
+    @staticmethod
+    def find_cameras() -> list[dict[str, Any]]:
+        # The native SDK performs its own UVC/HID discovery during connect().
+        # Returning an empty list keeps generic camera discovery side-effect free.
+        return []
+
+    def connect(self, warmup: bool = True) -> None:
+        if self.is_connected:
+            raise DeviceAlreadyConnectedError(f"{self} already connected")
+
+        try:
+            from insight9_umi_camera import Insight9HeadCamera
+        except ImportError as e:
+            raise ImportError(
+                "insight9-python-interface is required for the Insight9 head camera. "
+                "Initialize third_party/insight9-python-interface and run setup_env.sh --install."
+            ) from e
+
+        self._reset_cache()
+        self._sdk_camera = Insight9HeadCamera(
+            library_path=self.config.library_path,
+            enable_images=True,
+            enable_imu=False,
+            enable_vio=True,
+        )
+        try:
+            self._sdk_camera.start()
+            self._is_connected = True
+            if warmup:
+                self._wait_until_ready()
+            self.logger.info(
+                f"{self} connected via {self._sdk_camera.library_path} "
+                f"({self.width}x{self.height} @ dataset {self.fps}fps)"
+            )
+        except Exception:
+            self._close_sdk()
+            raise
+
+    def _wait_until_ready(self) -> None:
+        deadline = time.monotonic() + self.config.startup_timeout_s
+        last_error = "no samples received"
+        while time.monotonic() < deadline:
+            try:
+                self.read_snapshot_latest()
+                return
+            except (RuntimeError, TimeoutError) as e:
+                last_error = str(e)
+            time.sleep(0.02)
+        raise ConnectionError(
+            "Insight9 did not produce a complete decodable RGB/VIO sample within "
+            f"{self.config.startup_timeout_s:.1f}s: {last_error}. Check native/UVC mode, "
+            "USB bandwidth, and /dev/hidraw* permissions."
+        )
+
+    def read(self) -> NDArray[np.uint8]:
+        return self.read_snapshot_latest().rgb
+
+    def async_read(self, timeout_ms: float = 200) -> NDArray[np.uint8]:
+        # Intentional latest-cache semantics for UMI recording. ``timeout_ms`` is
+        # accepted for Camera API compatibility but no fresh-frame wait occurs.
+        del timeout_ms
+        return self.read_snapshot_latest().rgb
+
+    def read_latest(self, max_age_ms: int = 500) -> NDArray[np.uint8]:
+        snapshot = self.read_snapshot_latest()
+        if self._last_good_color is None:
+            raise RuntimeError("no decodable Insight9 RGB frame received yet")
+        age_ms = _age_seconds(time.time_ns(), self._last_good_color.host_time_ns) * 1000
+        if age_ms > max_age_ms:
+            raise TimeoutError(
+                f"Insight9 RGB cache is {age_ms:.1f}ms old (limit={max_age_ms}ms)."
+            )
+        return snapshot.rgb
+
+    def read_snapshot_latest(self) -> Insight9Snapshot:
+        if not self.is_connected or self._sdk_camera is None:
+            raise DeviceNotConnectedError(f"{self} is not connected")
+
+        raw = self._sdk_camera.latest()
+        sample_host_time_ns = time.time_ns()
+
+        if raw.vio is not None:
+            self._last_vio = raw.vio
+
+        color = raw.color
+        if color is not None and color.frame_index != self._last_seen_color_frame_index:
+            self._last_seen_color_frame_index = int(color.frame_index)
+            decoded, error = self._decode_color(color)
+            if decoded is not None:
+                self._last_good_rgb = decoded
+                self._last_good_color = color
+            else:
+                self._warn_decode(error)
+
+        if self._last_good_rgb is None or self._last_good_color is None:
+            raise RuntimeError("no decodable Insight9 RGB frame received yet")
+        if self._last_vio is None:
+            raise RuntimeError("no Insight9 VIO sample received yet")
+
+        color_age_s = _age_seconds(sample_host_time_ns, self._last_good_color.host_time_ns)
+        vio_age_s = _age_seconds(sample_host_time_ns, self._last_vio.host_time_ns)
+        ages = (color_age_s, vio_age_s)
+        self._raise_if_stale(ages)
+        self._warn_if_stale(ages)
+
+        rotation_6d = quaternion_to_rotation_6d(
+            float(self._last_vio.qw),
+            float(self._last_vio.qx),
+            float(self._last_vio.qy),
+            float(self._last_vio.qz),
+        )
+        return Insight9Snapshot(
+            rgb=self._last_good_rgb,
+            vio_position=(
+                float(self._last_vio.px),
+                float(self._last_vio.py),
+                float(self._last_vio.pz),
+            ),
+            vio_rotation_6d=tuple(float(value) for value in rotation_6d),
+        )
+
+    def _decode_color(self, image: Any) -> tuple[NDArray[np.uint8] | None, str]:
+        if image.pixel_format != "mjpeg":
+            return None, f"unsupported pixel format {image.pixel_format!r}"
+
+        payload = image.data
+        if self.config.strict_jpeg:
+            payload, error = _jpeg_payload(payload)
+            if payload is None:
+                return None, error
+
+        encoded = np.frombuffer(payload, dtype=np.uint8)
+        bgr = cv2.imdecode(encoded, cv2.IMREAD_COLOR)
+        if bgr is None:
+            return None, "cv2.imdecode returned None"
+
+        expected_shape = (int(self.height), int(self.width), 3)
+        if bgr.shape != expected_shape:
+            raise RuntimeError(
+                "Insight9 RGB shape does not match the configured dataset schema: "
+                f"actual={bgr.shape}, expected={expected_shape}. Update head_camera_width/height; "
+                "the adapter intentionally does not write resolution settings to the device."
+            )
+        return cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB), ""
+
+    def _warn_decode(self, error: str) -> None:
+        now = time.monotonic()
+        if now - self._last_decode_warning_t >= 1.0:
+            self.logger.warn(f"Insight9 RGB decode failed; holding last good frame: {error}")
+            self._last_decode_warning_t = now
+
+    def _warn_if_stale(self, ages: tuple[float, float]) -> None:
+        if max(ages) <= self.config.stale_after_s:
+            return
+        now = time.monotonic()
+        if now - self._last_stale_warning_t < 1.0:
+            return
+        self.logger.warn(
+            "Insight9 latest cache is stale: "
+            f"rgb={ages[0]:.3f}s vio={ages[1]:.3f}s "
+            f"threshold={self.config.stale_after_s:.3f}s"
+        )
+        self._last_stale_warning_t = now
+
+    def _raise_if_stale(self, ages: tuple[float, float]) -> None:
+        stale_streams = [
+            f"{name}={age_s:.3f}s"
+            for name, age_s in zip(("rgb", "vio"), ages, strict=True)
+            if age_s > self.config.stale_timeout_s
+        ]
+        if not stale_streams:
+            return
+        raise TimeoutError(
+            "Insight9 head data stopped updating; aborting recording: "
+            f"{' '.join(stale_streams)} limit={self.config.stale_timeout_s:.3f}s"
+        )
+
+    def disconnect(self) -> None:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected")
+        self._close_sdk()
+        self.logger.info(f"{self} disconnected")
+
+    def _close_sdk(self) -> None:
+        camera = self._sdk_camera
+        self._sdk_camera = None
+        self._is_connected = False
+        try:
+            if camera is not None:
+                camera.close()
+        finally:
+            self._reset_cache()
+
+    def _reset_cache(self) -> None:
+        self._last_good_rgb = None
+        self._last_good_color = None
+        self._last_vio = None
+        self._last_seen_color_frame_index = None
+        self._last_stale_warning_t = 0.0
+        self._last_decode_warning_t = 0.0
+
+
+def _age_seconds(sample_host_time_ns: int, callback_host_time_ns: int) -> float:
+    return max(0.0, (int(sample_host_time_ns) - int(callback_host_time_ns)) / 1e9)
+
+
+def _jpeg_payload(data: bytes) -> tuple[bytes | None, str]:
+    """Validate an MJPEG/JPEG payload and trim bytes following the first EOI."""
+
+    if len(data) < 4:
+        return None, "too_short"
+    if data[:2] != b"\xff\xd8":
+        return None, "missing_soi"
+
+    i = 2
+    while i < len(data):
+        if data[i] != 0xFF:
+            return None, f"expected_marker_at_{i}"
+        while i < len(data) and data[i] == 0xFF:
+            i += 1
+        if i >= len(data):
+            return None, "missing_marker_after_ff"
+
+        marker = data[i]
+        i += 1
+        if marker == 0xD9:
+            return data[:i], "ok"
+        if marker == 0xDA:
+            if i + 2 > len(data):
+                return None, "truncated_sos_length"
+            segment_length = int.from_bytes(data[i : i + 2], "big")
+            if segment_length < 2:
+                return None, "invalid_sos_length"
+            scan_start = i + segment_length
+            if scan_start > len(data):
+                return None, "truncated_sos_segment"
+            end = data.find(b"\xff\xd9", scan_start)
+            if end < 0:
+                return None, "missing_eoi"
+            return data[: end + 2], "ok"
+        if marker == 0x01 or 0xD0 <= marker <= 0xD8:
+            continue
+
+        if i + 2 > len(data):
+            return None, f"truncated_segment_length_0x{marker:02x}"
+        segment_length = int.from_bytes(data[i : i + 2], "big")
+        if segment_length < 2:
+            return None, f"invalid_segment_length_0x{marker:02x}"
+        segment_end = i + segment_length
+        if segment_end > len(data):
+            return None, f"truncated_segment_0x{marker:02x}"
+        i = segment_end
+
+    return None, "missing_eoi"

--- a/src/lerobot/cameras/insight9/configuration_insight9.py
+++ b/src/lerobot/cameras/insight9/configuration_insight9.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The XenseRobotics Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from ..configs import CameraConfig
+
+
+@CameraConfig.register_subclass("insight9")
+@dataclass
+class Insight9CameraConfig(CameraConfig):
+    """LeRobot adapter configuration for the Insight9 RGB/VIO head camera.
+
+    ``width``/``height`` describe the frame shape expected by the dataset. They
+    are validated against the first decoded frame and are intentionally not
+    written back to the device: the current Insight9 firmware keeps emitting
+    1088x1920 even when its resolution parameter is changed.
+    """
+
+    library_path: str | None = None
+    startup_timeout_s: float = 5.0
+    stale_after_s: float = 0.2
+    stale_timeout_s: float = 3.0
+    strict_jpeg: bool = True
+
+    def __post_init__(self) -> None:
+        if self.fps is None:
+            self.fps = 30
+        if self.width is None:
+            self.width = 1088
+        if self.height is None:
+            self.height = 1920
+        if self.fps <= 0:
+            raise ValueError("Insight9 fps must be positive.")
+        if self.width <= 0 or self.height <= 0:
+            raise ValueError(f"Insight9 width/height must be positive, got {self.width}x{self.height}.")
+        if self.startup_timeout_s <= 0:
+            raise ValueError("Insight9 startup_timeout_s must be positive.")
+        if self.stale_after_s <= 0:
+            raise ValueError("Insight9 stale_after_s must be positive.")
+        if self.stale_timeout_s <= 0:
+            raise ValueError("Insight9 stale_timeout_s must be positive.")

--- a/src/lerobot/robots/bi_taccap_gripper/README.md
+++ b/src/lerobot/robots/bi_taccap_gripper/README.md
@@ -4,6 +4,9 @@ Bimanual TacCap-Gripper handheld data-collection rig — two `taccap_gripper` un
 (left + right) driven as one robot. Passive/self-driven: `send_action()` is a no-op
 (jaw motors stay disabled, encoders read-only); pose comes from a per-side Pico4
 Ultra tracker, tactile + wrist cameras go through the standard `cameras` framework.
+An optional Insight9 head camera uses the same robot observation path and contributes
+RGB plus a raw-frame VIO pose; no head-to-gripper extrinsic calibration is required
+at capture time.
 
 Implemented with the **reimplement-with-prefixes** pattern (cf. `bi_elite_cs66_rt`):
 one `Robot` class, per-side handles in dicts keyed `"left"`/`"right"`, and every
@@ -21,8 +24,20 @@ Per side `{s}` ∈ {left, right}:
 | `{s}_imu.{accel,gyro,mag}.{x,y,z}` | `{s}_enable_imu` | IMU |
 | `{s}_wrist` | `{s}_enable_wrist_camera` | wrist UVC frame |
 | `{s}_tactile_left` / `{s}_tactile_right` | auto-discovered | tactile frame from the left / right finger sensor |
+| `head_rgb` | `enable_head_camera` | latest decoded Insight9 RGB frame |
+| `head_camera.x/y/z` | `enable_head_camera` | raw Insight9 VIO position in the Insight9 coordinate frame |
+| `head_camera.r1..r6` | `enable_head_camera` | raw Insight9 VIO orientation as the first two rotation-matrix columns |
 
-`action_features` = the pose + `{s}_gripper.pos` subset (no cameras).
+`action_features` = the per-side gripper pose + `{s}_gripper.pos` subset; the head
+camera pose and all images remain observation-only. With both Pico4 trackers, both
+grippers and Insight9 enabled, `observation.state` has 29 dimensions (20 + 9).
+
+For each fixed-rate robot sample, the adapter calls the Insight9 SDK's `latest()`
+exactly once and takes the newest cached RGB and VIO values. The source XYZW quaternion
+is converted inside the camera adapter with the shared 6D conversion used by the Pico4
+trackers. A corrupt new JPEG holds the previous good RGB frame, and stale RGB/VIO caches
+produce a rate-limited runtime warning; no timing, age, status or IMU fields are stored
+in the dataset.
 
 ## Config — auto-discovered by serial rule
 
@@ -60,6 +75,20 @@ and/or `--robot.right_tracker_serial=<SN>`. A pinned side uses its serial **verb
 enumeration, no rule check); un-pinned sides still auto-discover by the second-to-last-digit
 rule. Use this for a tracker whose serial does not follow the rule, or when enumeration is flaky.
 
+Enable the head camera with `--robot.enable_head_camera=true`. The defaults match the
+currently observed native stream (`width=1088`, `height=1920`, dataset FPS 30). Width
+and height define and validate the dataset schema; the adapter intentionally does not
+write resolution settings back to the device. Override the native library lookup with
+`--robot.head_camera_library_path=/path/to/libinsight9.so` when needed. During recording,
+RGB or VIO staleness first warns after 0.2 s; if either stream remains unchanged for more
+than 3 s, recording aborts with a timeout instead of silently repeating old head data.
+
+Raw acquisition is isolated in
+[`../../cameras/insight9/camera_insight9.py`](../../cameras/insight9/camera_insight9.py).
+The camera adapter keeps the original Insight9 VIO coordinate frame and converts only
+the quaternion representation to `r1..r6`; the robot adapter applies no
+head-to-gripper extrinsic.
+
 ## Usage
 
 Self-driven — **no `--teleop`**. Prerequisite: `xense.taccap` importable in the
@@ -82,6 +111,7 @@ add `--robot.enable_tracker=false` to record tactile + gripper only:
 ```bash
 lerobot-record \
     --robot.type=bi_taccap_gripper \
+    --robot.enable_head_camera=true \
     --dataset.repo_id=Xense/<dataset_name> \
     --dataset.single_task="Pick up the cube" \
     --dataset.num_episodes=20 \
@@ -90,6 +120,9 @@ lerobot-record \
     --dataset.reset_time_s=30 \
     --display_data=true
 ```
+
+Before enabling it, run `insight9-check-env --hidraw`; the Insight9 HID node must be
+readable and writable by the recording user.
 
 ## 3D trajectory visualization
 

--- a/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
@@ -29,6 +29,8 @@ Observation features (per side ``{s}`` in left/right):
     {s}_imu.accel/gyro/mag.{x,y,z}  -- optional
     {s}_wrist                       -- wrist UVC frame (if enable_wrist_camera)
     {s}_tactile_left / {s}_tactile_right -- tactile frames (sensor on left/right finger)
+    head_rgb                        -- Insight9 RGB (if enable_head_camera)
+    head_camera.x/y/z/r1..r6        -- Insight9-frame raw VIO pose
 """
 
 from __future__ import annotations
@@ -39,6 +41,7 @@ from typing import Any
 
 import numpy as np
 
+from lerobot.cameras.insight9 import Insight9Camera, Insight9CameraConfig
 from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
 from lerobot.cameras.utils import make_cameras_from_configs
 from lerobot.cameras.xense.configuration_xense import XenseTactileCameraConfig
@@ -117,13 +120,14 @@ class BiTaccapGripper(Robot):
         self._gripper: dict[str, Any] = {s: None for s in _SIDES}  # Leader/FollowerGripper
         self._endpoints: dict[str, Any] = {s: None for s in _SIDES}  # GripperEndpoints
         self._tracker: dict[str, Pico4TrackerReader | None] = {s: None for s in _SIDES}
-
         # Auto-discover tactile + wrist cameras and build their configs so the
         # observation schema is ready before connect(). Tactiles are paired to a
         # gripper by USB hub, so this scans the serial bus (grippers must be
         # powered at construction); wrist cameras are filesystem-only.
         self._camera_configs = self._discover_camera_configs()
         self.cameras = make_cameras_from_configs(self._camera_configs)
+        head_camera = self.cameras.get("head_rgb")
+        self._head_camera = head_camera if isinstance(head_camera, Insight9Camera) else None
 
         # Auto-discover the Pico4 motion tracker(s): enumerate from the XenseVR PC
         # service and assign one per side by serial (second-to-last digit, strict).
@@ -187,6 +191,17 @@ class BiTaccapGripper(Robot):
                     height=self.config.wrist_camera_height,
                     fps=self.config.wrist_camera_fps,
                 )
+
+        if self.config.enable_head_camera:
+            configs["head_rgb"] = Insight9CameraConfig(
+                library_path=self.config.head_camera_library_path,
+                width=self.config.head_camera_width,
+                height=self.config.head_camera_height,
+                fps=self.config.head_camera_fps,
+                startup_timeout_s=self.config.head_camera_startup_timeout_s,
+                stale_after_s=self.config.head_camera_stale_after_s,
+                stale_timeout_s=self.config.head_camera_stale_timeout_s,
+            )
         return configs
 
     # ------------------------------------------------------------------ schema
@@ -206,6 +221,10 @@ class BiTaccapGripper(Robot):
                     features[f"{side}_imu.accel.{axis}"] = float
                     features[f"{side}_imu.gyro.{axis}"] = float
                     features[f"{side}_imu.mag.{axis}"] = float
+
+        if self.config.enable_head_camera:
+            for key in ("x", "y", "z", "r1", "r2", "r3", "r4", "r5", "r6"):
+                features[f"head_camera.{key}"] = float
 
         # Tactile + wrist cameras (keys already left_/right_ prefixed).
         for cam_name, cam_cfg in self._camera_configs.items():
@@ -409,7 +428,19 @@ class BiTaccapGripper(Robot):
                 except Exception as e:
                     self.logger.warn(f"  [{side}] IMU read failed: {e}")
 
+        if self._head_camera is not None:
+            head = self._head_camera.read_snapshot_latest()
+            obs["head_rgb"] = head.rgb
+            for axis, value in zip(("x", "y", "z"), head.vio_position, strict=True):
+                obs[f"head_camera.{axis}"] = value
+            for key, value in zip(
+                ("r1", "r2", "r3", "r4", "r5", "r6"), head.vio_rotation_6d, strict=True
+            ):
+                obs[f"head_camera.{key}"] = float(value)
+
         for cam_name, cam in self.cameras.items():
+            if cam_name == "head_rgb":
+                continue
             obs[cam_name] = cam.async_read()
 
         return obs

--- a/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
@@ -135,6 +135,17 @@ class BiTaccapGripperConfig(RobotConfig):
     wrist_camera_height: int = 480
     wrist_camera_fps: int = 30
 
+    # ---- Insight9 head camera ---------------------------------------------
+    enable_head_camera: bool = False
+    """Enable one process-global Insight9 RGB/VIO head camera."""
+    head_camera_library_path: str | None = None
+    head_camera_width: int = 1088
+    head_camera_height: int = 1920
+    head_camera_fps: int = 30
+    head_camera_startup_timeout_s: float = 5.0
+    head_camera_stale_after_s: float = 0.2
+    head_camera_stale_timeout_s: float = 3.0
+
     def __post_init__(self):
         super().__post_init__()
         if self.role.strip().lower() not in (
@@ -146,6 +157,20 @@ class BiTaccapGripperConfig(RobotConfig):
             raise ValueError(
                 f"role must be leader/master or follower/slave, got {self.role!r}."
             )
+        if self.enable_head_camera:
+            if self.head_camera_width <= 0 or self.head_camera_height <= 0:
+                raise ValueError(
+                    "head_camera_width/head_camera_height must be positive, got "
+                    f"{self.head_camera_width}x{self.head_camera_height}."
+                )
+            if self.head_camera_fps <= 0:
+                raise ValueError("head_camera_fps must be positive.")
+            if self.head_camera_startup_timeout_s <= 0:
+                raise ValueError("head_camera_startup_timeout_s must be positive.")
+            if self.head_camera_stale_after_s <= 0:
+                raise ValueError("head_camera_stale_after_s must be positive.")
+            if self.head_camera_stale_timeout_s <= 0:
+                raise ValueError("head_camera_stale_timeout_s must be positive.")
         for side in _SIDES:
             if getattr(self, f"{side}_enable_gripper") and getattr(
                 self, f"{side}_gripper_open_rad"

--- a/src/lerobot/scripts/client_commands.md
+++ b/src/lerobot/scripts/client_commands.md
@@ -20,7 +20,9 @@ Paste your HuggingFace access token (write permission) when prompted; it is stor
 `~/.cache/huggingface/token` and persists across sessions.
 
 Also ensure `xense.taccap` is importable (`bash ./setup_env.sh --install`) and, for
-6-DoF pose, the XenseVR PC service + Pico4 trackers are running.
+6-DoF pose, the XenseVR PC service + Pico4 trackers are running. For the optional
+Insight9 head camera, run `insight9-check-env --hidraw` and make sure its HID node is
+readable/writable.
 
 ## Teleoperate (live Rerun visualization)
 
@@ -70,6 +72,19 @@ A pinned side is used verbatim (no enumeration, no rule check); un-pinned sides 
 auto-discover. Other knobs: `--robot.role=follower` (bind Slave units), `--robot.gripper_open_rad`,
 `--robot.tactile_fps`, `--robot.wrist_camera_width/height/fps`.
 
+The bimanual rig can add the Insight9 RGB/VIO stream with:
+
+```bash
+    --robot.enable_head_camera=true \
+    --robot.head_camera_width=1088 \
+    --robot.head_camera_height=1920 \
+```
+
+Capture stores `head_rgb` plus the raw device-frame VIO pose as
+`head_camera.x/y/z/r1..r6`. The quaternion is converted to the same rotation-matrix
+first-two-columns representation used by the left/right gripper poses; no IMU or
+timing/age/status metadata is stored.
+
 ### Single (`taccap_gripper`)
 
 ```bash
@@ -92,7 +107,8 @@ Recording is self-driven (`self_driven_record_loop`, shifted-frame: `action[t]` 
 ```bash
 lerobot-record \
     --robot.type=bi_taccap_gripper \
-    --dataset.repo_id=Xense/taccap-g1-test-0624 \
+    --robot.enable_head_camera=true \
+    --dataset.repo_id=Xense/taccap-g1-test-0722 \
     --dataset.single_task="Pick up the cube" \
     --dataset.num_episodes=2 \
     --dataset.fps=30 \
@@ -100,7 +116,7 @@ lerobot-record \
     --dataset.reset_time_s=30 \
     --dataset.streaming_encoding=true \
     --dataset.push_to_hub=false \
-    --display_data=true
+    --display_data=false
 ```
 
 ### Single (`taccap_gripper`)


### PR DESCRIPTION
feat(insight9): add Insight9 head camera support and configuration

Integrate the Insight9 head camera into the bimanual TacCap-Gripper recording pipeline as an optional RGB/VIO observation source.
- Add the Insight9 Python interface as a git submodule and integrate its editable installation and environment verification into setup_env.sh.
- Implement a LeRobot camera adapter for Insight9 RGB and VIO data.
- Decode and validate MJPEG frames, hold the last valid RGB frame when a new frame is corrupted, and convert the Insight9 quaternion into the shared 6D rotation representation.
- Add stale-data monitoring with rate-limited warnings and abort recording when RGB or VIO data remains unchanged for more than three seconds.
- Extend BiTaccapGripper configuration, observation features, and sampling logic with optional head_rgb and head_camera.x/y/z/r1..r6 fields.
- Keep the head camera pose and image observation-only; do not include them in the action features or apply head-to-gripper extrinsic calibration.
- Update project documentation, client commands, HID permission requirements, and Insight9 recording instructions.