### PR TITLE
feat(taccap): record rectify, show the difference in Rerun

### DIFF
--- a/src/lerobot/robots/bi_taccap_gripper/README.md
+++ b/src/lerobot/robots/bi_taccap_gripper/README.md
@@ -23,7 +23,8 @@ Per side `{s}` ∈ {left, right}:
 | `{s}_gripper.pos` | `{s}_enable_gripper` | normalised jaw, 0=closed / 1=open |
 | `{s}_imu.{accel,gyro,mag}.{x,y,z}` | `{s}_enable_imu` | IMU |
 | `{s}_wrist` | `{s}_enable_wrist_camera` | wrist UVC frame |
-| `{s}_tactile_left` / `{s}_tactile_right` | auto-discovered | tactile frame from the left / right finger sensor |
+| `{s}_tactile_left` / `{s}_tactile_right` | auto-discovered | **recorded** tactile frame from the left / right finger sensor (`rectify`) |
+| `{s}_tactile_{left,right}_difference` | `tactile_display_output_types` | **display-only** amplified-deformation view of the same read — Rerun only, never recorded |
 | `head_rgb` | `enable_head_camera` | latest decoded Insight RGB frame |
 | `head_camera.x/y/z` | `enable_head_camera` | raw Insight VIO position in the camera's own coordinate frame |
 | `head_camera.r1..r6` | `enable_head_camera` | raw Insight VIO orientation as the first two rotation-matrix columns |
@@ -31,6 +32,16 @@ Per side `{s}` ∈ {left, right}:
 `action_features` = the per-side gripper pose + `{s}_gripper.pos` subset; the head
 camera pose and all images remain observation-only. With both Pico4 trackers, both
 grippers and the Insight head camera enabled, `observation.state` has 29 dimensions (20 + 9).
+
+**Two tactile streams, two destinations.** Each sensor is read once per frame for two
+views: `rectify` (recorded) and the amplified `difference` (displayed). Only the
+recorded one is in `observation_features`, so only it reaches the dataset; the
+`*_difference` keys live in `display_features`, which is what the Rerun layout and
+`log_rerun_data` are fed — the recorded stream is not sent to the viewer at all, so
+the tactile grid stays at four tiles. `difference` is the easier view to read contact
+from live, but its baseline is captured at sensor init, so a finger resting on
+something at connect would have that pressure subtracted out of the whole recording —
+which is exactly why the dataset gets `rectify`.
 
 For each fixed-rate robot sample, the adapter calls the Insight SDK's `latest()`
 exactly once and takes the newest cached RGB and VIO values. The source XYZW quaternion
@@ -69,6 +80,12 @@ missing/duplicate/malformed tracker raises a clear error. Set `--robot.enable_tr
 to record tactile + gripper only (no PC service needed). Other knobs: `--robot.role`,
 `--robot.gripper_open_rad`, `--robot.tactile_fps`, `--robot.wrist_camera_{width,height,fps}`,
 `--robot.expected_tactiles_per_side`.
+
+Tactile streams: `--robot.tactile_output_types` (recorded, default `rectify`, exactly
+one type) and `--robot.tactile_display_output_types` (Rerun-only, default `difference`;
+set to `'[]'` to drop the second read and show the recorded stream instead).
+`--robot.tactile_diff_gain` (default `1.0`, sensors ship at `1.5`) scales the difference
+image, i.e. the displayed one only.
 
 To bypass the tracker side rule, pin serials directly with `--robot.left_tracker_serial=<SN>`
 and/or `--robot.right_tracker_serial=<SN>`. A pinned side uses its serial **verbatim** (no

--- a/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
@@ -28,9 +28,16 @@ Observation features (per side ``{s}`` in left/right):
     {s}_gripper.pos                 -- normalised jaw [0=closed, 1=open]
     {s}_imu.accel/gyro/mag.{x,y,z}  -- optional
     {s}_wrist                       -- wrist UVC frame (if enable_wrist_camera)
-    {s}_tactile_left / {s}_tactile_right -- tactile frames (sensor on left/right finger)
+    {s}_tactile_left / {s}_tactile_right -- recorded tactile frames (sensor on
+                                       left/right finger), ``rectify`` by default
     head_rgb                        -- Insight RGB (if enable_head_camera)
     head_camera.x/y/z/r1..r6        -- Insight-frame raw VIO pose
+
+Display-only keys (in ``get_observation()`` and ``display_features``, absent from
+``observation_features``, so Rerun shows them but the dataset never sees them —
+see ``tactile_display_output_types``):
+    {s}_tactile_{left,right}_difference -- amplified deformation view of the same
+                                       sensor read
 """
 
 from __future__ import annotations
@@ -54,6 +61,9 @@ from ..taccap_gripper import serial_discovery as disco
 from ..taccap_gripper.taccap_gripper import (
     prewarm_tactile_config_cache,
     resolve_wrist_camera_path,
+    split_camera_read,
+    tactile_camera_output_types,
+    tactile_display_key,
 )
 from .config_bi_taccap_gripper import BiTaccapGripperConfig
 
@@ -161,7 +171,9 @@ class BiTaccapGripper(Robot):
         # good frame per camera so a hot-unplug degrades to a stale/black frame
         # instead of crashing the record loop, and remember which cameras died
         # so the caller can stop cleanly and save what was recorded.
-        self._last_cam_frame: dict[str, np.ndarray] = {}
+        # Value is a dict of frames for a multi-output tactile sensor (recorded +
+        # display-only views), a single array for every other camera.
+        self._last_cam_frame: dict[str, np.ndarray | dict[str, np.ndarray]] = {}
         self._lost_cameras: set[str] = set()
         # Monotonic time each camera last produced a genuinely new frame object,
         # used to detect a frozen (non-raising) stream — see _read_camera_or_fallback.
@@ -177,6 +189,10 @@ class BiTaccapGripper(Robot):
         digit); wrist cameras (``{side}_wrist``) come from ``/dev/v4l/by-id``.
         Counts are validated per side so a mis-installed sensor is caught here,
         not mid-episode.
+
+        Also fills ``self._tactile_display_keys`` (camera → {output type →
+        display-only observation key}), the map ``get_observation`` and
+        ``display_features`` use to route the extra, unrecorded views.
         """
         n_exp = self.config.expected_tactiles_per_side
         tactiles = disco.discover_tactiles_by_hub(self._role) if n_exp else {"left": {}, "right": {}}
@@ -184,6 +200,11 @@ class BiTaccapGripper(Robot):
         cameras = disco.discover_wrist_cameras(self._role) if want_wrist else {}
 
         configs: dict[str, Any] = {}
+        self._tactile_display_keys: dict[str, dict[str, str]] = {}
+        output_types = tactile_camera_output_types(
+            list(self.config.tactile_output_types),
+            list(self.config.tactile_display_output_types),
+        )
         for side in _SIDES:
             parity = "odd" if side == "left" else "even"
             if n_exp:
@@ -194,12 +215,24 @@ class BiTaccapGripper(Robot):
                         f"gripper's USB hub), found {len(got)}: {sorted(got.values())}."
                     )
                 for finger, sn in sorted(got.items()):
-                    configs[f"{side}_tactile_{finger}"] = XenseTactileCameraConfig(
+                    cam_name = f"{side}_tactile_{finger}"
+                    cfg = XenseTactileCameraConfig(
                         serial_number=sn,
                         fps=self.config.tactile_fps,
-                        output_types=list(self.config.tactile_output_types),
+                        output_types=output_types,
                         diff_gain=self.config.tactile_diff_gain,
                     )
+                    configs[cam_name] = cfg
+                    # Read the types back off the camera config: it normalises the
+                    # config strings ("DIFFERENCE", "XenseOutputType.DIFFERENCE", …)
+                    # into the same enum whose .value keys the read dict. Recorded
+                    # type came first, so everything after it is display-only.
+                    display_keys = {
+                        ot.value: tactile_display_key(cam_name, ot.value)
+                        for ot in cfg.output_types[1:]
+                    }
+                    if display_keys:
+                        self._tactile_display_keys[cam_name] = display_keys
             if getattr(self.config, f"{side}_enable_wrist_camera"):
                 sn = cameras.get(side)
                 if not sn:
@@ -253,6 +286,28 @@ class BiTaccapGripper(Robot):
         for cam_name, cam_cfg in self._camera_configs.items():
             features[cam_name] = (cam_cfg.height, cam_cfg.width, 3)
 
+        return features
+
+    @cached_property
+    def display_features(self) -> dict[str, type | tuple]:
+        """Rerun-facing schema: ``observation_features`` with each tactile camera's
+        recorded stream swapped for its display-only view(s), in place.
+
+        The dataset gets ``rectify`` (``observation_features``), the operator gets
+        the amplified ``difference`` (this). Swapping rather than adding keeps the
+        recorded stream out of the viewer entirely — four tactile tiles, not eight,
+        and no extra Rerun image bandwidth. Cameras with no display-only view are
+        passed through, so without ``tactile_display_output_types`` this is just
+        ``observation_features``.
+        """
+        features: dict[str, type | tuple] = {}
+        for key, spec in self.observation_features.items():
+            display_keys = self._tactile_display_keys.get(key)
+            if display_keys:
+                for display_key in display_keys.values():
+                    features[display_key] = spec
+            else:
+                features[key] = spec
         return features
 
     @cached_property
@@ -473,11 +528,17 @@ class BiTaccapGripper(Robot):
             # together); skip it here so it isn't read twice.
             if cam_name == "head_rgb":
                 continue
-            obs[cam_name] = self._read_camera_or_fallback(cam_name, cam)
+            obs.update(
+                split_camera_read(
+                    cam_name,
+                    self._read_camera_or_fallback(cam_name, cam),
+                    self._tactile_display_keys.get(cam_name),
+                )
+            )
 
         return obs
 
-    def _read_camera_or_fallback(self, cam_name: str, cam: Any) -> np.ndarray:
+    def _read_camera_or_fallback(self, cam_name: str, cam: Any) -> np.ndarray | dict[str, np.ndarray]:
         """Read one camera, degrading gracefully on physical loss.
 
         Two distinct loss modes are handled, because the camera classes behave
@@ -536,14 +597,22 @@ class BiTaccapGripper(Robot):
             self.logger.error(f"  [{cam_name}] {reason}")
             self._lost_cameras.add(cam_name)
 
-    def _fallback_frame(self, cam_name: str) -> np.ndarray:
+    def _fallback_frame(self, cam_name: str) -> np.ndarray | dict[str, np.ndarray]:
         """Last good frame for this camera, or a black frame of the declared
-        (H, W, 3) shape if none was ever captured."""
+        (H, W, 3) shape if none was ever captured.
+
+        A tactile sensor asked for several output types reads as a dict, so the
+        first-read fallback has to be shaped the same way — one black frame per
+        requested type — or the split below would drop the display keys."""
         cached = self._last_cam_frame.get(cam_name)
         if cached is not None:
             return cached
         cfg = self._camera_configs[cam_name]
-        frame = np.zeros((cfg.height, cfg.width, 3), dtype=np.uint8)
+        black = np.zeros((cfg.height, cfg.width, 3), dtype=np.uint8)
+        output_types = getattr(cfg, "output_types", None) or []
+        frame: np.ndarray | dict[str, np.ndarray] = (
+            {ot.value: black.copy() for ot in output_types} if len(output_types) > 1 else black
+        )
         self._last_cam_frame[cam_name] = frame
         return frame
 

--- a/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
@@ -126,20 +126,35 @@ class BiTaccapGripperConfig(RobotConfig):
     """Seconds to wait for the first valid tracker pose at connect time (both sides)."""
 
     tactile_fps: int = 30
-    tactile_output_types: list[str] = field(default_factory=lambda: ["difference"])
-    """Defaults applied to every discovered tactile sensor. Single output type →
-    one (H, W, 3) image. Default is ``difference`` (SDK
-    ``OutputType.AugDifference``), which amplifies deformation the raw
-    ``rectify`` image barely shows; both are inference-free and landscape
-    (400, 700, 3) uint8. Width/height auto-derive from the SDK rectify_size —
-    don't hard-code. The baseline is taken at sensor init, so keep all four
-    fingers unloaded at connect."""
+    tactile_output_types: list[str] = field(default_factory=lambda: ["rectify"])
+    """The **recorded** tactile stream, applied to every discovered sensor. Exactly
+    one output type → one (H, W, 3) image per sensor, i.e. one dataset video key.
+    Default ``rectify``, the unsubtracted image: the amplified ``difference`` view
+    is easier to read live but is taken against a baseline captured at sensor init,
+    so any pressure resting on a gel at connect would be subtracted out of the
+    whole recording. Width/height auto-derive from the SDK rectify_size — don't
+    hard-code."""
+
+    tactile_display_output_types: list[str] = field(default_factory=lambda: ["difference"])
+    """Extra tactile streams requested for **display only**. Default ``difference``
+    (SDK ``OutputType.AugDifference``), which amplifies deformation the raw
+    ``rectify`` image barely shows, so it is what the operator watches in Rerun.
+
+    Each type is published under ``{camera}_{type}`` (e.g.
+    ``left_tactile_right_difference``). Those keys are deliberately absent from
+    ``observation_features`` — they never reach the dataset — and ``display_features``
+    puts them in front of Rerun *instead of* the recorded stream. Both image types
+    are inference-free and come from one ``selectSensorInfo`` call, so the extra
+    stream is cheap; an empty list skips it (Rerun then shows the recorded stream).
+    The difference baseline is taken at sensor init, so keep all four fingers
+    unloaded at connect."""
 
     tactile_diff_gain: float | None = 1.0
     """Linear gain applied to the ``difference`` image
-    (``ctx_patch.process.diff_gain``, stock 1.5). 1.0 roughly a third less
-    per-pixel temporal noise and no clipping; it scales signal and noise alike,
-    so SNR is unchanged. None leaves the sensor's flashed value."""
+    (``ctx_patch.process.diff_gain``, stock 1.5), i.e. to the display stream only.
+    1.0 gives roughly a third less per-pixel temporal noise and no clipping; it
+    scales signal and noise alike, so SNR is unchanged. None leaves the sensor's
+    flashed value."""
 
     wrist_camera_width: int = 640
     wrist_camera_height: int = 480
@@ -188,6 +203,16 @@ class BiTaccapGripperConfig(RobotConfig):
                 raise ValueError("head_camera_stale_after_s must be positive.")
             if self.head_camera_stale_timeout_s <= 0:
                 raise ValueError("head_camera_stale_timeout_s must be positive.")
+        # One recorded stream per sensor: observation_features declares a single
+        # (H, W, 3) per tactile camera, so a second recorded type would silently
+        # hand build_dataset_frame a dict instead of an image. Extra live views
+        # belong in tactile_display_output_types.
+        if len(self.tactile_output_types) != 1:
+            raise ValueError(
+                "tactile_output_types must name exactly one recorded output type, "
+                f"got {self.tactile_output_types}. For an extra Rerun-only view use "
+                "--robot.tactile_display_output_types."
+            )
         for side in _SIDES:
             if getattr(self, f"{side}_enable_gripper") and getattr(
                 self, f"{side}_gripper_open_rad"

--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -172,6 +172,12 @@ On by default; `--show_trajectory=false` suppresses it, and it auto-skips when
 `--robot.enable_tracker=false` (no pose to draw). Implemented in
 [`visualization.py`](visualization.py) and shared by both teleoperate and record.
 
+The viewer is laid out from the robot's `display_features` rather than
+`observation_features` — same schema, except each tactile sensor shows its display-only
+`difference` view in place of the recorded `rectify` one, and `log_rerun_data` is fed the
+matching subset of the observation (`select_display_observation`), so the recorded stream
+never reaches Rerun.
+
 ## Standalone smoke test
 
 Verifies the robot stack independently of `lerobot-record`. Devices are
@@ -228,17 +234,27 @@ serial is used **verbatim**: no enumeration, no rule check (a typo surfaces as a
 at connect). Leave it unset (default) to keep auto-discovery.
 
 - **Tactile** → obs keys `tactile_left` / `tactile_right`; landscape `(400,700,3)` uint8
-  (width/height auto-derive — don't hard-code). Defaults to `difference` (SDK
-  `OutputType.AugDifference`), which amplifies deformation the raw `rectify` image barely
-  shows; its baseline is taken at sensor init, so keep the fingers **unloaded** at connect,
-  or the resting pressure is subtracted away for the whole run. Pass
-  `--robot.tactile_output_types=rectify` for the unsubtracted image.
+  (width/height auto-derive — don't hard-code). Each sensor is read once per frame for
+  **two views with two destinations**:
+  - **recorded** — `--robot.tactile_output_types`, default `rectify` (exactly one type).
+    The unsubtracted image; this is the only tactile key in `observation_features`, so
+    it is the only one that lands in the dataset.
+  - **displayed** — `--robot.tactile_display_output_types`, default `difference` (SDK
+    `OutputType.AugDifference`), published as `tactile_{left,right}_difference`. It
+    amplifies deformation the raw `rectify` image barely shows, which is what you want
+    to watch live, but it is deliberately kept out of `observation_features` and never
+    recorded: its baseline is taken at sensor init, so a finger loaded at connect would
+    have that pressure subtracted out of the whole run. Keep the fingers **unloaded** at
+    connect for a readable live view. Set to `'[]'` to skip the second read; Rerun then
+    shows the recorded stream.
+
+  Rerun is fed `display_features` (recorded stream swapped for the displayed one), so
+  the viewer shows only `difference` and the tile count is unchanged.
   `--robot.tactile_diff_gain` (default `1.0`, sensors ship at `1.5`) is the linear gain on
   that difference: 1.0 cuts per-pixel temporal noise from ~1.77 to ~1.18 grey levels and
   stops the image clipping, but scales signal down with it — raise it if light contact
   becomes invisible, set it to `None` to keep whatever the sensor was flashed with.
-  Tune `--robot.tactile_fps`
-  / `--robot.tactile_output_types`; `--robot.expected_tactiles_per_side` validates the count.
+  Tune `--robot.tactile_fps`; `--robot.expected_tactiles_per_side` validates the count.
   The two sensors are paired to this unit's gripper by **USB hub**; `left`/`right` finger
   comes from the GSPS serial's **last digit** (odd → `left`, even → `right`, 单左双右).
 - **Wrist** → obs key `wrist_cam`; `--robot.enable_wrist_camera=false` skips. Tune
@@ -275,6 +291,11 @@ defensive fallback for callers that don't pre-warm.
 | `imu.gyro.{x,y,z}` (opt) | TacCap IMU | float (rad/s) |
 | `imu.mag.{x,y,z}` (opt) | TacCap IMU | float (µT) |
 | `<camera_name>` per camera | `cameras/` framework | uint8 (H, W, 3) |
+
+Tactile cameras contribute their **recorded** view only (`rectify` by default). The
+`tactile_{left,right}_difference` keys `get_observation()` also returns are display-only:
+they are absent from `observation_features`, so `build_dataset_frame` never sees them and
+nothing is written for them.
 
 The 6-D rotation convention matches `vive_tracker`:
 `r1..r3` is the first column of the rotation matrix, `r4..r6` is the

--- a/src/lerobot/robots/taccap_gripper/config_taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/config_taccap_gripper.py
@@ -121,28 +121,40 @@ class TaccapGripperConfig(RobotConfig):
 
     # ---- Tactile sensors (Xense; auto-discovered by serial) --------------
     tactile_fps: int = 30
-    tactile_output_types: list[str] = field(default_factory=lambda: ["difference"])
-    """Defaults applied to every discovered tactile sensor. A single output type
-    yields one (H, W, 3) image. Default is ``difference`` (SDK
-    ``OutputType.AugDifference``): on this gel the raw ``rectify`` image carries
-    so little visible deformation that contact is hard to read, and the
-    augmented difference against the sensor's rest baseline amplifies it.
-    Both are inference-free, same (400, 700, 3) uint8 shape, so this costs
-    nothing at startup — switch back with ``--robot.tactile_output_types=rectify``
-    if you need the unsubtracted image. Width/height are auto-derived from the
-    SDK's rectify_size (do not hard-code them).
+    tactile_output_types: list[str] = field(default_factory=lambda: ["rectify"])
+    """The **recorded** tactile stream, applied to every discovered sensor. Exactly
+    one output type (each sensor contributes one (H, W, 3) image to
+    ``observation_features``, hence one dataset video key). Default ``rectify``:
+    the unsubtracted image, which keeps every bit the sensor saw. The amplified
+    ``difference`` view is easier to read live but is destructive — it is taken
+    against a baseline captured at sensor init, so any pressure resting on the
+    gel at connect is subtracted away for the whole run, and that must not reach
+    the dataset. See ``tactile_display_output_types`` for the live view.
+    Width/height are auto-derived from the SDK's rectify_size (do not hard-code)."""
 
-    Note the baseline is captured when the sensor initialises, so the fingers
-    must be **unloaded** at connect — start with something already pressed
-    against the gel and that pressure is subtracted away for the whole run."""
+    tactile_display_output_types: list[str] = field(default_factory=lambda: ["difference"])
+    """Extra tactile streams requested from the sensor for **display only**.
+    Default ``difference`` (SDK ``OutputType.AugDifference``): on this gel the raw
+    ``rectify`` image carries so little visible deformation that contact is hard
+    to read, and the augmented difference against the rest baseline amplifies it,
+    so this is what the operator watches in Rerun.
+
+    Each type here is published under ``{camera}_{type}`` (e.g.
+    ``tactile_left_difference``). Those keys are deliberately absent from
+    ``observation_features``, so ``build_dataset_frame`` never sees them and they
+    never land on disk; they are what ``display_features`` puts in front of Rerun
+    *instead of* the recorded stream. Both image types are inference-free and come
+    from the same ``selectSensorInfo`` call, so the extra stream is cheap. Set to
+    an empty list to skip it entirely (Rerun then shows the recorded stream)."""
 
     tactile_diff_gain: float | None = 1.0
     """Linear gain the SDK applies to the ``difference`` image
-    (``ctx_patch.process.diff_gain``). The sensors ship at 1.5, which is noisy
-    and clips on this gel; 1.0 measures ~1.18 grey levels of per-pixel temporal
-    noise instead of ~1.77 and stops saturating. Because it scales signal and
-    noise together the SNR is unchanged — it buys headroom, not clarity. Set to
-    None to leave whatever the sensor was flashed with."""
+    (``ctx_patch.process.diff_gain``), i.e. to the display stream only. The sensors
+    ship at 1.5, which is noisy and clips on this gel; 1.0 measures ~1.18 grey
+    levels of per-pixel temporal noise instead of ~1.77 and stops saturating.
+    Because it scales signal and noise together the SNR is unchanged — it buys
+    headroom, not clarity. Set to None to leave whatever the sensor was flashed
+    with."""
 
     # ---- Wrist camera (OpenCV UVC; auto-discovered by serial) ------------
     enable_wrist_camera: bool = True
@@ -168,4 +180,15 @@ class TaccapGripperConfig(RobotConfig):
                 f"gripper_open_rad must be positive, got {self.gripper_open_rad}. "
                 "Closed=0 is fixed by the SDK's Encoder.set_zero(); open_rad "
                 "is the mechanical-max angle (TC-GU-01 default 1.7)."
+            )
+
+        # One recorded stream per sensor: observation_features declares a single
+        # (H, W, 3) per tactile camera, so a second recorded type would silently
+        # hand build_dataset_frame a dict instead of an image. Extra live views
+        # belong in tactile_display_output_types.
+        if len(self.tactile_output_types) != 1:
+            raise ValueError(
+                "tactile_output_types must name exactly one recorded output type, "
+                f"got {self.tactile_output_types}. For an extra Rerun-only view use "
+                "--robot.tactile_display_output_types."
             )

--- a/src/lerobot/robots/taccap_gripper/taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/taccap_gripper.py
@@ -28,8 +28,15 @@ Observation features:
     imu.accel.{x,y,z} (optional)     -- m/s²
     imu.gyro.{x,y,z}  (optional)     -- rad/s
     imu.mag.{x,y,z}   (optional)     -- µT
-    tactile_left / tactile_right     -- tactile frames (sensor on left/right finger)
+    tactile_left / tactile_right     -- recorded tactile frames (sensor on
+                                        left/right finger), ``rectify`` by default
     wrist_cam                        -- wrist UVC frame (if enable_wrist_camera)
+
+Display-only keys (present in ``get_observation()`` and in ``display_features``,
+absent from ``observation_features``, so Rerun shows them but the dataset never
+sees them — see ``tactile_display_output_types``):
+    tactile_{left,right}_difference  -- amplified deformation view of the same
+                                        sensor read
 """
 
 from __future__ import annotations
@@ -174,6 +181,56 @@ def prewarm_tactile_config_cache(camera_configs: dict[str, Any], logger) -> None
     _wait_nodes_settle(uncached, logger)
 
 
+# ---- Recorded vs display-only tactile streams -------------------------------
+# One sensor read carries two views: the recorded one (rectify — everything the
+# sensor saw) and the display one (the amplified difference the operator reads
+# contact from). The SDK hands both back from a single ``selectSensorInfo``, so
+# the split is purely a matter of which observation key each lands on: the
+# recorded view keeps the camera's own key and is the only one in
+# ``observation_features``; each display view gets a ``{camera}_{type}`` sibling
+# that only Rerun ever sees. Shared with ``bi_taccap_gripper``.
+
+
+def tactile_display_key(cam_name: str, output_type: str) -> str:
+    """Observation key carrying ``output_type`` as a display-only view of ``cam_name``."""
+    return f"{cam_name}_{output_type}"
+
+
+def tactile_camera_output_types(
+    record_types: list[str], display_types: list[str]
+) -> list[str]:
+    """Output types to ask one tactile sensor for: recorded first, then the
+    display-only ones (deduplicated, order preserved).
+
+    A display type that is also the recorded type collapses to a single request —
+    the recorded key then simply doubles as the displayed one.
+    """
+    types = list(record_types)
+    types += [t for t in display_types if t not in types]
+    return types
+
+
+def split_camera_read(
+    cam_name: str, frame: Any, display_keys: dict[str, str] | None = None
+) -> dict[str, Any]:
+    """Fan one camera read out into observation keys.
+
+    A tactile sensor asked for several output types returns
+    ``{output_type: array}`` (``XenseTactileCamera._format_read_result``); every
+    other camera returns a bare array. ``display_keys`` maps output type →
+    display-only observation key for this camera; whichever type is left over is
+    the recorded one and keeps ``cam_name``.
+    """
+    if not isinstance(frame, dict):
+        return {cam_name: frame}
+
+    display_keys = display_keys or {}
+    obs: dict[str, Any] = {}
+    for output_type, data in frame.items():
+        obs[display_keys.get(output_type, cam_name)] = data
+    return obs
+
+
 class TaccapGripper(Robot):
     """TacCap-Gripper handheld data-collection device.
 
@@ -276,9 +333,15 @@ class TaccapGripper(Robot):
         )
 
     def _build_camera_configs(self, side: str) -> dict[str, Any]:
-        """Build ``tactile_{left,right}`` + ``wrist_cam`` configs for ``side``."""
+        """Build ``tactile_{left,right}`` + ``wrist_cam`` configs for ``side``.
+
+        Also fills ``self._tactile_display_keys`` (camera → {output type →
+        display-only observation key}), the map ``get_observation`` and
+        ``display_features`` use to route the extra, unrecorded views.
+        """
         parity = "odd" if side == "left" else "even"
         configs: dict[str, Any] = {}
+        self._tactile_display_keys: dict[str, dict[str, str]] = {}
         n_exp = self.config.expected_tactiles_per_side
         if n_exp:
             got = self._disc_tactiles.get(side, {})
@@ -287,13 +350,29 @@ class TaccapGripper(Robot):
                     f"Expected {n_exp} {side} tactile sensors (on the {side} "
                     f"gripper's USB hub), found {len(got)}: {sorted(got.values())}."
                 )
+            output_types = tactile_camera_output_types(
+                list(self.config.tactile_output_types),
+                list(self.config.tactile_display_output_types),
+            )
             for finger, sn in sorted(got.items()):
-                configs[f"tactile_{finger}"] = XenseTactileCameraConfig(
+                cam_name = f"tactile_{finger}"
+                cfg = XenseTactileCameraConfig(
                     serial_number=sn,
                     fps=self.config.tactile_fps,
-                    output_types=list(self.config.tactile_output_types),
+                    output_types=output_types,
                     diff_gain=self.config.tactile_diff_gain,
                 )
+                configs[cam_name] = cfg
+                # Read the types back off the camera config: it normalises the
+                # config strings ("DIFFERENCE", "XenseOutputType.DIFFERENCE", …)
+                # into the same enum whose .value keys the read dict. Recorded
+                # type came first, so everything after it is display-only.
+                display_keys = {
+                    ot.value: tactile_display_key(cam_name, ot.value)
+                    for ot in cfg.output_types[1:]
+                }
+                if display_keys:
+                    self._tactile_display_keys[cam_name] = display_keys
         if self.config.enable_wrist_camera:
             sn = self._disc_cameras.get(side)
             if not sn:
@@ -331,6 +410,29 @@ class TaccapGripper(Robot):
         for cam_name, cam_cfg in self._camera_configs.items():
             features[cam_name] = (cam_cfg.height, cam_cfg.width, 3)
 
+        return features
+
+    @cached_property
+    def display_features(self) -> dict[str, type | tuple]:
+        """Rerun-facing schema: ``observation_features`` with each tactile camera's
+        recorded stream swapped for its display-only view(s), in place.
+
+        The dataset gets ``rectify`` (``observation_features``), the operator gets
+        the amplified ``difference`` (this). Swapping rather than adding keeps the
+        recorded stream out of the viewer entirely — same tile count, same Rerun
+        image bandwidth as before the split — and keeps tactile in the same slot
+        of the blueprint. Cameras with no display-only view are passed through, so
+        without ``tactile_display_output_types`` this is just
+        ``observation_features``.
+        """
+        features: dict[str, type | tuple] = {}
+        for key, spec in self.observation_features.items():
+            display_keys = self._tactile_display_keys.get(key)
+            if display_keys:
+                for display_key in display_keys.values():
+                    features[display_key] = spec
+            else:
+                features[key] = spec
         return features
 
     @cached_property
@@ -526,7 +628,11 @@ class TaccapGripper(Robot):
                 self.logger.warn(f"IMU read failed: {e}")
 
         for cam_name, cam in self.cameras.items():
-            obs[cam_name] = cam.async_read()
+            obs.update(
+                split_camera_read(
+                    cam_name, cam.async_read(), self._tactile_display_keys.get(cam_name)
+                )
+            )
 
         return obs
 

--- a/src/lerobot/scripts/client_commands.md
+++ b/src/lerobot/scripts/client_commands.md
@@ -166,3 +166,5 @@ lerobot-record \
 > `tactile_left/right` + `wrist_cam` + `tcp.*` (single), or
 > `left_/right_tactile_left/right` + `{side}_wrist` + `{side}_tcp.*` (bi). Tactile
 > rectify is landscape `(400,700,3)` — width/height auto-derive, don't hard-code.
+> Each tactile key records `rectify`; the matching `*_difference` key is display-only
+> (Rerun shows it instead of the recorded one, and it never enters the dataset).

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -90,7 +90,11 @@ from lerobot.utils.utils import (
     init_logging,
     log_say,
 )
-from lerobot.utils.visualization_utils import init_rerun, log_rerun_data
+from lerobot.utils.visualization_utils import (
+    init_rerun,
+    log_rerun_data,
+    select_display_observation,
+)
 from lerobot.robots.taccap_gripper.visualization import TaccapTrajectoryViz
 
 logger = get_logger("lerobot_record")
@@ -291,6 +295,7 @@ def self_driven_record_loop(
     single_task: str | None = None,
     display_data: bool = False,
     traj_viz: TaccapTrajectoryViz | None = None,
+    display_features: dict | None = None,
 ):
     """Record loop for self-driven handheld devices (e.g. TacCap-Gripper).
 
@@ -311,6 +316,11 @@ def self_driven_record_loop(
     With ``dataset=None`` (the between-episode reset phase) the loop is a
     passive wait: it still honours the keyboard/stop events but reads no
     hardware and records nothing, so the operator can reposition the device.
+
+    ``display_features`` (the robot's viewer-facing schema, if it has one) only
+    narrows what reaches Rerun — the dataset always gets the full observation.
+    On the TacCap grippers that is what sends the amplified tactile difference
+    to the screen while the recorded ``rectify`` image goes to disk.
     """
     if dataset is not None and dataset.fps != fps:
         raise ValueError(
@@ -380,9 +390,10 @@ def self_driven_record_loop(
             prev_observation_frame = current_observation_frame
 
         if display_data and observation is not None:
-            log_rerun_data(observation=observation, action=action or {})
+            display_observation = select_display_observation(observation, display_features)
+            log_rerun_data(observation=display_observation, action=action or {})
             if traj_viz is not None:
-                traj_viz.log(observation)
+                traj_viz.log(display_observation)
 
         _record_loop_sleep(
             start_loop_t=start_loop_t,
@@ -456,10 +467,15 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
             teleop.connect()
 
         # 3D pose + trajectory overlay (no-op if the device emits no tcp.* poses).
+        # The viewer is laid out from display_features when the robot has one —
+        # same schema as observation_features except each tactile sensor shows its
+        # display-only view (difference) in place of the recorded one (rectify).
+        display_features = getattr(robot, "display_features", None)
         traj_viz = None
         if cfg.display_data:
             traj_viz = TaccapTrajectoryViz(
-                robot.observation_features, show_trajectory=cfg.show_trajectory
+                display_features or robot.observation_features,
+                show_trajectory=cfg.show_trajectory,
             )
             if traj_viz.active:
                 traj_viz.setup()
@@ -496,6 +512,7 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                     single_task=cfg.dataset.single_task,
                     display_data=cfg.display_data,
                     traj_viz=traj_viz,
+                    display_features=display_features,
                 )
 
                 # Execute a few seconds without recording to give time to manually reset the environment
@@ -514,6 +531,7 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                         single_task=cfg.dataset.single_task,
                         display_data=cfg.display_data,
                         traj_viz=traj_viz,
+                        display_features=display_features,
                     )
 
                 if events["rerecord_episode"]:

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -67,7 +67,11 @@ from lerobot.utils.robot_utils import (
     get_logger,
 )
 from lerobot.utils.utils import move_cursor_up
-from lerobot.utils.visualization_utils import init_rerun, log_rerun_data
+from lerobot.utils.visualization_utils import (
+    init_rerun,
+    log_rerun_data,
+    select_display_observation,
+)
 from lerobot.robots.taccap_gripper.visualization import TaccapTrajectoryViz
 
 logger = get_logger("Teleoperate")
@@ -221,6 +225,7 @@ def self_driven_teleop_loop(
     display_compressed_images: bool = True,
     debug_timing: bool = False,
     traj_viz: TaccapTrajectoryViz | None = None,
+    display_features: dict | None = None,
 ):
     """Data-stream + Rerun visualisation loop for self-driven, sensor-only robots
     (``taccap_gripper`` / ``bi_taccap_gripper``).
@@ -228,6 +233,11 @@ def self_driven_teleop_loop(
     These robots have no teleoperator: we only read ``robot.get_observation()`` and
     stream it to Rerun with an empty action. ``send_action`` is a no-op, so nothing
     is ever commanded. Mirrors v0.4.4's ``bi_xense_flare_grippers_teleop_loop``.
+
+    ``display_features`` (the robot's viewer-facing schema, if it has one) narrows
+    what reaches Rerun: on the TacCap grippers it swaps each tactile sensor's
+    recorded ``rectify`` frame for the amplified ``difference`` one. The terminal
+    table below still prints the full observation.
     """
     display_len = max((len(key) for key in robot.observation_features), default=20)
     start = time.perf_counter()
@@ -246,13 +256,14 @@ def self_driven_teleop_loop(
             obs_time_ms = (time.perf_counter() - obs_t0) * 1e3
 
             if display_data:
+                display_obs = select_display_observation(obs, display_features)
                 log_rerun_data(
-                    observation=obs,
+                    observation=display_obs,
                     action={},
                     compress_images=display_compressed_images,
                 )
                 if traj_viz is not None:
-                    traj_viz.log(obs)
+                    traj_viz.log(display_obs)
                 if not debug_timing:
                     scalar_items = [
                         (k, v) for k, v in obs.items() if not isinstance(v, np.ndarray)
@@ -342,12 +353,16 @@ def teleoperate(cfg: TeleoperateConfig):
         # Viewer layout, plus the 3D pose trail when a tracker supplies poses.
         # Built whenever data is displayed: --show_trajectory=false suppresses the
         # trail, not the blueprint, since dropping the blueprint would leave Rerun
-        # auto-laying-out every camera and scalar into equal tiles.
+        # auto-laying-out every camera and scalar into equal tiles. Laid out from
+        # display_features when the robot has one — same schema as
+        # observation_features except each tactile sensor shows its display-only
+        # view (difference) in place of the recorded one (rectify).
+        display_features = getattr(robot, "display_features", None)
         traj_viz = None
         if cfg.display_data:
             # teleop signals panel: default to the gripper position channel(s).
             traj_viz = TaccapTrajectoryViz(
-                robot.observation_features,
+                display_features or robot.observation_features,
                 signals="gripper",
                 show_trajectory=cfg.show_trajectory,
             )
@@ -365,6 +380,7 @@ def teleoperate(cfg: TeleoperateConfig):
                 display_compressed_images=display_compressed_images,
                 debug_timing=cfg.debug_timing,
                 traj_viz=traj_viz,
+                display_features=display_features,
             )
         except KeyboardInterrupt:
             pass

--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -46,6 +46,25 @@ def init_rerun(
         rr.spawn(memory_limit=memory_limit)
 
 
+def select_display_observation(
+    observation: RobotObservation | None, display_features: dict[str, Any] | None
+) -> RobotObservation | None:
+    """Narrow an observation to the keys a robot wants on screen.
+
+    A robot may emit keys meant for one consumer only: the TacCap grippers read
+    each tactile sensor twice per frame, recording the ``rectify`` image while
+    showing the amplified ``difference`` one, and expose the viewer's half of
+    that split as ``display_features``. Filtering here keeps the recorded stream
+    out of Rerun without touching what goes to ``dataset.add_frame``.
+
+    ``display_features`` of None (any robot that draws no such distinction)
+    passes the observation straight through.
+    """
+    if not display_features or observation is None:
+        return observation
+    return {k: v for k, v in observation.items() if k in display_features}
+
+
 def _is_scalar(x):
     return isinstance(x, (float | numbers.Real | np.integer | np.floating)) or (
         isinstance(x, np.ndarray) and x.ndim == 0


### PR DESCRIPTION
触觉传感器的数据链路拆成两路:**数据集存 `rectify`,Rerun 显示 AugDifference**。

## 为什么

之前两路是同一路 —— 触觉 obs key 就是 `tactile_output_types` 指定的那一种,operator 在 Rerun 里读接触用的图,也正是落进数据集的图。这两者要的东西相反:

- `AugDifference` 放大了原始凝胶几乎看不出的形变,**看**的时候必须用它;
- 但它减的基线是传感器初始化那一刻拍的,连接时若指腹已受压,这个偏置会被从整段录制里减掉 —— 屏幕上无所谓,落盘不行。

## 怎么做

一次 `selectSensorInfo` 同时取两种输出,按 observation key 分流:

| | key | 去向 |
|---|---|---|
| 落盘 | `tactile_left` / `{s}_tactile_right` … | `observation_features` → `build_dataset_frame` → 数据集 |
| 显示 | `tactile_left_difference` … | 新增的 `display_features` → Rerun |

- 两种都是 inference-free,`disable_infer` 仍自动推导为 `True`,启动开销不变。
- Rerun 侧用 `select_display_observation` 按 `display_features` 过滤后再 log,布局也由它生成 —— rectify 一帧都不发给 viewer,tactile 网格格数和图像带宽都和改之前一样。
- `tactile_output_types` 现在校验必须恰好一项(以前配两项会把 dict 交给声明为图像的 dataset feature,静默出错);新增 `tactile_display_output_types` 默认 `["difference"]`,设成 `[]` 就完全跳过第二路读取。
- 没有 `display_features` 的机器人走原路径,行为不变。

## 三个 commit

1. `fc6c9429` — 两个 config + 两个 robot 的数据链路拆分
2. `95bd8887` — Rerun 侧接线(`select_display_observation` + record/teleoperate)
3. `90dc8509` — 文档

每个 commit 单独 checkout 出来都能跑:第一个之后是"录 rectify、Rerun 同时显示两路",第二个把 rectify 从 viewer 拿掉。

## 验证

无硬件(env `xense-taccap`)已验证:

- 合并后的相机 config:`disable_infer` 仍为 `True`,宽高仍从 `rectify_size` 推导;`"RECTIFY"` / `"XenseOutputType.DIFFERENCE"` 这类 CLI 写法能归一到读取 dict 的 key;
- 假相机跑完整 `get_observation` → `build_dataset_frame`,只产出 `observation.images.tactile_left` 且像素值是 rectify 那张;`select_display_observation` 只剩 `*_difference`;
- 合成的双臂 schema 生成的 blueprint,四个 tactile view 全是 `*_difference`,没有 rectify view;
- 两个 config 的默认值 + "两个 record type 报错" 校验;bi 的 dict 版 fallback 帧形状与 `observation_features` 一致且保持对象 identity(冻结检测不受影响)。

**未验证:** 硬件端到端 —— 当前机器上没插 TacCap 设备。合并后请按下面顺序确认(上电时保持指腹不受压):

```bash
lerobot-teleoperate --robot.type=taccap_gripper --fps=30 --display_data=true   # 格子里应是 difference
lerobot-record --robot.type=taccap_gripper --dataset.num_episodes=1 --dataset.episode_time_s=5 ...
lerobot-dataset-viz ...   # 落盘的应是 rectify(看得见凝胶纹理,不是静止时接近全黑的 diff)
```

仓库测试套件也没跑:本仓库对应的 `xense-taccap` env 里没装 pytest。对 `visualization_utils.py` 的改动是纯新增函数。

🤖 Generated with [Claude Code](https://claude.com/claude-code)