### PR TITLE
feat(docker): Add Docker deployment configuration and customer delivery workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,19 +1,11 @@
 # Copyright 2024 The HuggingFace Inc. team. All rights reserved.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 # Misc
 .git
+.github
+.agents
+.codex
 tmp
 wandb
 data
@@ -22,24 +14,22 @@ outputs
 rl
 media
 
-
-# Logging
+# Logging / local credentials
 logs
-
-# HPC
+*.log
 nautilus/*.yaml
 *.key
-
-# Slurm
 sbatch*.sh
 
-# Byte-compiled / optimized / DLL files
+# Byte-compiled / optimized files
 __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
+# C extensions. Native libraries committed in vendor submodules are required
+# by the hardware SDK build and are explicitly included again below.
 *.so
+!third_party/**/*.so
 
 # Distribution / packaging
 .Python
@@ -61,18 +51,12 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
-
-# Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
 
-# Unit test / coverage reports
+# Test / coverage / tooling output
 !tests/artifacts
 htmlcov/
 .tox/
@@ -85,76 +69,34 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.ruff_cache/
+.pyre/
 
-# Ignore .cache except calibration
+# Ignore runtime cache except checked-in calibration data
 .cache/*
 !.cache/calibration/
 !.cache/calibration/**
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
+# IDEs, notebooks and generated documentation
+.venv/
 .ipynb_checkpoints
-
-# IPython
 profile_default/
 ipython_config.py
-
-# pyenv
-.python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Spyder project settings
 .spyderproject
 .spyproject
-
-# Rope project settings
 .ropeproject
-
-# mkdocs documentation
+docs/_build/
 /site
+target/
 
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
+# Application output that should not inflate the build context
+*.safetensors
+*.mp4
+*.avi
 
-# Pyre type checker
-.pyre/
+# Hardware SDK sources and their vendor-provided native libraries under
+# third_party/ must remain in the context. Keep this override last.
+!third_party/**

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "third_party/XenseVR-PC-Service"]
 	path = third_party/XenseVR-PC-Service
-	url = git@github.com:Vertax42/XenseVR-PC-Service.git
+	url = https://github.com/Vertax42/XenseVR-PC-Service.git
 [submodule "third_party/taccap-gripper"]
 	path = third_party/taccap-gripper
-	url = git@github.com:Vertax42/TacCap-Gripper.git
+	url = https://github.com/Vertax42/TacCap-Gripper.git
 [submodule "third_party/XenseVR-RobotVision-PC"]
 	path = third_party/XenseVR-RobotVision-PC
-	url = git@github.com:Vertax42/XenseVR-RobotVision-PC.git
+	url = https://github.com/Vertax42/XenseVR-RobotVision-PC.git
 [submodule "third_party/pyinsight"]
 	path = third_party/pyinsight
-	url = git@github.com:Vertax42/pyinsight.git
+	url = https://github.com/Vertax42/pyinsight.git

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ training scripts) refer to the
 
 ## 🔧 Installation
 
+> **Docker users:** a complete GPU + hardware-SDK image and Compose setup are
+> available in [`docker/README.md`](docker/README.md). It is the quickest way to
+> give an end user a reproducible environment; the host still needs NVIDIA
+> Container Toolkit and the udev rules documented below.
+
 Tested on Ubuntu 22.04, NVIDIA driver ≥ 570.144. Use
 [`Mamba`](https://github.com/conda-forge/miniforge?tab=readme-ov-file#install)
 (strongly recommended over plain conda — it's much faster on the

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.user
+      network: host
       args:
         UBUNTU_VERSION: "22.04"
         MINIFORGE_VERSION: "25.3.1-0"
@@ -28,8 +29,16 @@ services:
     environment:
       DISPLAY: ${DISPLAY:-:0}
       START_XENSEVR_SERVICE: ${START_XENSEVR_SERVICE:-1}
+      XDG_RUNTIME_DIR: /tmp/xdg-runtime
+      WGPU_BACKEND: vulkan
+      NVIDIA_DRIVER_CAPABILITIES: all
       HF_TOKEN: ${HF_TOKEN:-}
     volumes:
+      # The discovery code needs host udev's by-id/by-path links, not only the
+      # raw device nodes exposed by privileged mode.
+      - /dev:/dev
+      - /run/udev:/run/udev:ro
+      - xensesdk-cache:/root/.xensesdk
       - lerobot-data:/data
       - huggingface-cache:/root/.cache/huggingface
       - torch-cache:/root/.cache/torch
@@ -37,6 +46,7 @@ services:
     working_dir: /opt/lerobot
 
 volumes:
+  xensesdk-cache:
   lerobot-data:
   huggingface-cache:
   torch-cache:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,42 @@
+name: xense-taccap-lerobot
+
+services:
+  xense-taccap:
+    image: xense-taccap-lerobot:${LEROBOT_IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.user
+      args:
+        UBUNTU_VERSION: "22.04"
+        MINIFORGE_VERSION: "25.3.1-0"
+    # USB, serial, HID, V4L2 and CAN devices can be hot-plugged while the
+    # container is running. Privileged mode avoids baking unstable /dev indexes
+    # into the compose file. Only use this image on a trusted robot host.
+    privileged: true
+    network_mode: host
+    ipc: host
+    gpus: all
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      rtprio:
+        soft: 99
+        hard: 99
+    stdin_open: true
+    tty: true
+    environment:
+      DISPLAY: ${DISPLAY:-:0}
+      START_XENSEVR_SERVICE: ${START_XENSEVR_SERVICE:-1}
+      HF_TOKEN: ${HF_TOKEN:-}
+    volumes:
+      - lerobot-data:/data
+      - huggingface-cache:/root/.cache/huggingface
+      - torch-cache:/root/.cache/torch
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    working_dir: /opt/lerobot
+
+volumes:
+  lerobot-data:
+  huggingface-cache:
+  torch-cache:

--- a/docker/BUILD_TROUBLESHOOTING_ZH.md
+++ b/docker/BUILD_TROUBLESHOOTING_ZH.md
@@ -1,0 +1,155 @@
+# Docker 构建与硬件联调问题记录
+
+记录日期：2026-08-05  
+最终镜像：`xense-taccap-lerobot:latest`  
+镜像内容大小约 10 GB，本地磁盘占用约 30 GB。
+
+> 当前状态：本文记录的 apt/curl 重试、CUDA 求解、Rerun/Vulkan 依赖、
+> `/dev` 透传和 Xense 缓存持久化已经正式写入 Dockerfile 与 Compose。
+> 下文的 `sed` 构建命令仅用于保留历史排查过程，新构建直接运行
+> `docker compose build --progress=plain`。
+
+## 1. 镜像构建
+
+构建前初始化硬件 SDK：
+
+```bash
+git submodule update --init --recursive --progress
+```
+
+### Docker Hub 超时
+
+终端代理不会自动传给 Docker daemon。临时设置：
+
+```bash
+export HTTP_PROXY=http://127.0.0.1:7897
+export HTTPS_PROXY=http://127.0.0.1:7897
+export NO_PROXY=localhost,127.0.0.1,::1,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12
+
+sudo systemctl set-environment \
+  HTTP_PROXY="$HTTP_PROXY" \
+  HTTPS_PROXY="$HTTPS_PROXY" \
+  NO_PROXY="$NO_PROXY"
+sudo systemctl restart docker
+```
+
+### GitHub、apt 和 Conda 问题
+
+实际遇到：
+
+- GitHub 下载 Miniforge 时出现 HTTP/2 `PROTOCOL_ERROR`。
+- Ubuntu apt 经过代理时返回 `502 Bad Gateway`。
+- Docker 构建阶段无法自动检测 CUDA，且 strict channel priority 导致 CUDA 12.8 求解失败。
+
+当时使用以下命令临时构建（仅作历史记录）：
+
+```bash
+export HTTPS_PROXY=http://127.0.0.1:7897
+
+sed \
+  -e 's/apt-get update/apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=60 update/' \
+  -e 's/apt-get install -y/apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=60 install -y/' \
+  -e 's/RUN curl -fsSL/RUN curl --http1.1 --retry 10 --retry-delay 5 --retry-all-errors -fsSL/' \
+  -e 's|RUN mamba env create|RUN CONDA_OVERRIDE_CUDA=12.8 mamba env create --channel-priority flexible|' \
+  -e 's|RUN bash ./setup_env.sh --install|RUN conda config --system --set channel_priority flexible \&\& CONDA_OVERRIDE_CUDA=12.8 bash ./setup_env.sh --install|' \
+  docker/Dockerfile.user |
+docker build \
+  --network host \
+  --build-arg HTTP_PROXY= \
+  --build-arg http_proxy= \
+  --build-arg ALL_PROXY= \
+  --build-arg all_proxy= \
+  --build-arg HTTPS_PROXY="$HTTPS_PROXY" \
+  --build-arg https_proxy="$HTTPS_PROXY" \
+  --progress=plain \
+  -f - \
+  -t xense-taccap-lerobot:latest \
+  .
+```
+
+构建完成后确认：
+
+```bash
+docker images xense-taccap-lerobot
+```
+
+## 2. 容器启动与设备透传
+
+项目依赖 `/dev/v4l/by-id`、`/dev/v4l/by-path` 和
+`/dev/serial/by-path` 做硬件自动配对，因此需要透传完整 `/dev`。
+
+同时为 XenseSDK 配置独立持久化缓存，避免每次临时容器都重新读取传感器 flash：
+
+```bash
+docker volume create xense-taccap-xensesdk-cache
+
+docker compose run --rm --remove-orphans \
+  -v /dev:/dev \
+  -v /run/udev:/run/udev:ro \
+  -v xense-taccap-xensesdk-cache:/root/.xensesdk \
+  xense-taccap
+```
+
+宿主机应先确认四个 GSPS 设备存在：
+
+```bash
+ls -l /dev/v4l/by-id/ | grep GSPS
+```
+
+如果设备在读取 flash 后掉线，重新插拔 USB Hub并等待 udev：
+
+```bash
+sudo udevadm trigger --subsystem-match=video4linux
+sudo udevadm settle --timeout=20
+```
+
+## 3. Rerun 图形界面
+
+宿主机授权容器 root 访问 X11：
+
+```bash
+xhost +SI:localuser:root
+```
+
+镜像需要包含以下运行包：
+
+```bash
+apt-get update
+apt-get install -y \
+  libxkbcommon-x11-0 \
+  xdg-utils \
+  libvulkan1 \
+  usbutils
+dpkg --configure -a
+```
+
+容器内设置：
+
+```bash
+export XDG_RUNTIME_DIR=/tmp/xdg-runtime
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+export WGPU_BACKEND=vulkan
+```
+
+## 4. Pico4 启动顺序
+
+1. 打开并配对两个 Pico4 tracker。
+2. 启动头显中的 Unity VR Client，并保持前台运行。
+3. 启动 Docker 容器，由 entrypoint 启动 XenseVR PC Service。
+4. 正式录制期间不要重启 Unity Client，否则坐标原点会改变。
+
+## 5. 最终验证命令
+
+```bash
+lerobot-teleoperate \
+  --robot.type=bi_taccap_gripper \
+  --fps=30 \
+  --display_data=true \
+  --robot.enable_tracker=true
+```
+
+最终验证通过：两个夹爪、两个 Pico4 tracker、四个触觉传感器、两个腕部相机、CUDA 和 Rerun 均可正常工作。
+
+> 当前夹爪固件为 `1.1.0.0`，不支持 encoder-max 校准，程序会临时使用
+> `gripper_open_rad=1.7`。这不阻止运行，但后续建议升级固件并重新校准。

--- a/docker/BUILD_TROUBLESHOOTING_ZH.md
+++ b/docker/BUILD_TROUBLESHOOTING_ZH.md
@@ -40,6 +40,12 @@ sudo systemctl restart docker
 - GitHub 下载 Miniforge 时出现 HTTP/2 `PROTOCOL_ERROR`。
 - Ubuntu apt 经过代理时返回 `502 Bad Gateway`。
 - Docker 构建阶段无法自动检测 CUDA，且 strict channel priority 导致 CUDA 12.8 求解失败。
+- Conda channel 索引 `repodata.json.zst` 下载超时，导致大量正常依赖被误报为 `does not exist`。
+
+新版 Dockerfile 已将 Conda/Mamba 网络读取超时提高到 300 秒，单连接最多
+重试 10 次，并为整个环境创建增加最多 5 次重试。出现大量
+`does not exist` 前，应先检查日志中是否存在 `repodata.json.zst` 超时；如果有，
+通常是索引下载不完整，而不是真正的版本冲突。
 
 当时使用以下命令临时构建（仅作历史记录）：
 

--- a/docker/Dockerfile.user
+++ b/docker/Dockerfile.user
@@ -25,8 +25,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # making the image useful for both end users and hardware SDK development.
 RUN test "${TARGETARCH}" = "amd64" || \
         (echo "LeRobot-Xense Docker currently supports linux/amd64 only" >&2; exit 1) \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=60 update \
+    && apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=60 install -y --no-install-recommends \
         bash \
         build-essential \
         ca-certificates \
@@ -42,7 +42,9 @@ RUN test "${TARGETARCH}" = "amd64" || \
         libsm6 \
         libudev-dev \
         libusb-1.0-0-dev \
+        libvulkan1 \
         libx11-6 \
+        libxkbcommon-x11-0 \
         libxext6 \
         libxrender1 \
         ninja-build \
@@ -50,16 +52,19 @@ RUN test "${TARGETARCH}" = "amd64" || \
         sudo \
         tini \
         udev \
+        usbutils \
+        vulkan-tools \
+        xdg-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # Miniforge supplies mamba, which is the project's supported solver. Pinning the
 # installer avoids silently changing the base environment between image builds.
-RUN curl -fsSL \
+RUN curl --http1.1 --retry 10 --retry-delay 5 --retry-all-errors -fsSL \
         "https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh" \
         -o /tmp/miniforge.sh \
     && bash /tmp/miniforge.sh -b -p /opt/conda \
     && rm /tmp/miniforge.sh \
-    && /opt/conda/bin/conda config --system --set channel_priority strict \
+    && /opt/conda/bin/conda config --system --set channel_priority flexible \
     && /opt/conda/bin/conda clean -afy
 
 ENV PATH=/opt/conda/envs/xense-taccap/bin:/opt/conda/bin:${PATH} \
@@ -69,6 +74,9 @@ ENV PATH=/opt/conda/envs/xense-taccap/bin:/opt/conda/bin:${PATH} \
     HF_LEROBOT_HOME=/data/lerobot \
     TORCH_HOME=/root/.cache/torch \
     TRITON_CACHE_DIR=/root/.cache/triton \
+    XDG_RUNTIME_DIR=/tmp/xdg-runtime \
+    WGPU_BACKEND=vulkan \
+    CONDA_OVERRIDE_CUDA=12.8 \
     UV_HTTP_TIMEOUT=300 \
     PYTHONUNBUFFERED=1 \
     QT_X11_NO_MITSHM=1 \
@@ -78,7 +86,7 @@ WORKDIR /opt/lerobot
 
 # Resolve the expensive conda layer before copying frequently changing source.
 COPY conda_environment.yaml /tmp/conda_environment.yaml
-RUN mamba env create -f /tmp/conda_environment.yaml \
+RUN mamba env create --channel-priority flexible -f /tmp/conda_environment.yaml \
     && mamba clean -afy \
     && rm /tmp/conda_environment.yaml
 
@@ -91,9 +99,10 @@ RUN bash ./setup_env.sh --install \
     && rm -rf /root/.cache/pip /root/.cache/uv
 
 RUN install -m 0755 docker/entrypoint.sh /usr/local/bin/lerobot-entrypoint \
-    && mkdir -p /data "${HF_HOME}" "${TORCH_HOME}" "${TRITON_CACHE_DIR}"
+    && mkdir -p /data /root/.xensesdk "${HF_HOME}" "${TORCH_HOME}" "${TRITON_CACHE_DIR}" "${XDG_RUNTIME_DIR}" \
+    && chmod 0700 "${XDG_RUNTIME_DIR}"
 
-VOLUME ["/data", "/root/.cache/huggingface", "/root/.cache/torch"]
+VOLUME ["/data", "/root/.xensesdk", "/root/.cache/huggingface", "/root/.cache/torch"]
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/lerobot-entrypoint"]
 CMD ["bash"]

--- a/docker/Dockerfile.user
+++ b/docker/Dockerfile.user
@@ -65,6 +65,10 @@ RUN curl --http1.1 --retry 10 --retry-delay 5 --retry-all-errors -fsSL \
     && bash /tmp/miniforge.sh -b -p /opt/conda \
     && rm /tmp/miniforge.sh \
     && /opt/conda/bin/conda config --system --set channel_priority flexible \
+    && /opt/conda/bin/conda config --system --set remote_connect_timeout_secs 60 \
+    && /opt/conda/bin/conda config --system --set remote_read_timeout_secs 300 \
+    && /opt/conda/bin/conda config --system --set remote_max_retries 10 \
+    && /opt/conda/bin/conda config --system --set remote_backoff_factor 2 \
     && /opt/conda/bin/conda clean -afy
 
 ENV PATH=/opt/conda/envs/xense-taccap/bin:/opt/conda/bin:${PATH} \
@@ -77,6 +81,7 @@ ENV PATH=/opt/conda/envs/xense-taccap/bin:/opt/conda/bin:${PATH} \
     XDG_RUNTIME_DIR=/tmp/xdg-runtime \
     WGPU_BACKEND=vulkan \
     CONDA_OVERRIDE_CUDA=12.8 \
+    MAMBA_DOWNLOAD_TIMEOUT_SECONDS=300 \
     UV_HTTP_TIMEOUT=300 \
     PYTHONUNBUFFERED=1 \
     QT_X11_NO_MITSHM=1 \
@@ -86,7 +91,18 @@ WORKDIR /opt/lerobot
 
 # Resolve the expensive conda layer before copying frequently changing source.
 COPY conda_environment.yaml /tmp/conda_environment.yaml
-RUN mamba env create --channel-priority flexible -f /tmp/conda_environment.yaml \
+RUN set -eu; \
+    conda_create_attempt=1; \
+    until mamba env create --channel-priority flexible -f /tmp/conda_environment.yaml; do \
+        if [ "${conda_create_attempt}" -ge 5 ]; then \
+            echo "Conda environment creation failed after ${conda_create_attempt} attempts" >&2; \
+            exit 1; \
+        fi; \
+        echo "Conda environment creation attempt ${conda_create_attempt} failed; clearing index cache and retrying" >&2; \
+        mamba clean --index-cache --yes || true; \
+        conda_create_attempt=$((conda_create_attempt + 1)); \
+        sleep 10; \
+    done \
     && mamba clean -afy \
     && rm /tmp/conda_environment.yaml
 

--- a/docker/Dockerfile.user
+++ b/docker/Dockerfile.user
@@ -1,79 +1,99 @@
-# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+# syntax=docker/dockerfile:1.7
+
+# LeRobot-Xense runtime/development image.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# The project relies on conda C++/CUDA libraries and several native hardware
+# SDKs, so the regular python:slim LeRobot image is not sufficient here.
+ARG UBUNTU_VERSION=22.04
+FROM ubuntu:${UBUNTU_VERSION}
 
-# This Dockerfile is designed for a lerobot user who wants to
-# experiment with the project. It starts from an Python Slim base image.
+ARG TARGETARCH
+ARG MINIFORGE_VERSION=25.3.1-0
 
-# docker build -f docker/Dockerfile.user -t lerobot-user .
-# docker run -it --rm lerobot-user
+# Check the build context before downloading the large Conda/CUDA stack.
+RUN --mount=type=bind,source=.,target=/context,ro \
+    test -f /context/third_party/XenseVR-PC-Service/RoboticsService/PXREARobotSDK/build.sh \
+    && test -f /context/third_party/taccap-gripper/pyproject.toml \
+    && test -f /context/third_party/pyinsight/pyproject.toml \
+    || (echo "Missing git submodules. Run: git submodule update --init --recursive" >&2; exit 1)
 
-# Configure the base image
-ARG PYTHON_VERSION=3.12
-FROM python:${PYTHON_VERSION}-slim
-
-# Configure environment variables
 ENV DEBIAN_FRONTEND=noninteractive \
-    MUJOCO_GL=egl \
-    PATH=/lerobot/.venv/bin:$PATH
+    TZ=Etc/UTC
 
-# Install system dependencies and uv (as root)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential git curl libglib2.0-0 libegl1-mesa-dev ffmpeg \
-    libusb-1.0-0-dev speech-dispatcher libgeos-dev portaudio19-dev \
-    cmake pkg-config ninja-build \
-    && curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && mv /root/.local/bin/uv /usr/local/bin/uv \
-    && useradd --create-home --shell /bin/bash user_lerobot \
-    && usermod -aG sudo user_lerobot \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Runtime libraries cover USB/HID/video/X11 access. Build tools are retained on
+# purpose: taccap-gripper and the Pico4 Python extension are editable installs,
+# making the image useful for both end users and hardware SDK development.
+RUN test "${TARGETARCH}" = "amd64" || \
+        (echo "LeRobot-Xense Docker currently supports linux/amd64 only" >&2; exit 1) \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        ffmpeg \
+        git \
+        git-lfs \
+        libegl1 \
+        libgl1 \
+        libglib2.0-0 \
+        libhidapi-hidraw0 \
+        libsm6 \
+        libudev-dev \
+        libusb-1.0-0-dev \
+        libx11-6 \
+        libxext6 \
+        libxrender1 \
+        ninja-build \
+        pkg-config \
+        sudo \
+        tini \
+        udev \
+    && rm -rf /var/lib/apt/lists/*
 
-# Create application directory and set permissions
-WORKDIR /lerobot
-RUN chown -R user_lerobot:user_lerobot /lerobot
+# Miniforge supplies mamba, which is the project's supported solver. Pinning the
+# installer avoids silently changing the base environment between image builds.
+RUN curl -fsSL \
+        "https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh" \
+        -o /tmp/miniforge.sh \
+    && bash /tmp/miniforge.sh -b -p /opt/conda \
+    && rm /tmp/miniforge.sh \
+    && /opt/conda/bin/conda config --system --set channel_priority strict \
+    && /opt/conda/bin/conda clean -afy
 
-# Switch to the non-root user
-USER user_lerobot
+ENV PATH=/opt/conda/envs/xense-taccap/bin:/opt/conda/bin:${PATH} \
+    CONDA_DEFAULT_ENV=xense-taccap \
+    CONDA_PREFIX=/opt/conda/envs/xense-taccap \
+    HF_HOME=/root/.cache/huggingface \
+    HF_LEROBOT_HOME=/data/lerobot \
+    TORCH_HOME=/root/.cache/torch \
+    TRITON_CACHE_DIR=/root/.cache/triton \
+    UV_HTTP_TIMEOUT=300 \
+    PYTHONUNBUFFERED=1 \
+    QT_X11_NO_MITSHM=1 \
+    NVIDIA_DRIVER_CAPABILITIES=all
 
-# Environment variables for the testing
-ENV HOME=/home/user_lerobot \
-    HF_HOME=/home/user_lerobot/.cache/huggingface \
-    HF_LEROBOT_HOME=/home/user_lerobot/.cache/huggingface/lerobot \
-    TORCH_HOME=/home/user_lerobot/.cache/torch \
-    TRITON_CACHE_DIR=/home/user_lerobot/.cache/triton
+WORKDIR /opt/lerobot
 
-# Create the virtual environment
-# We use a virtual environment inside the container—even though the container itself \
-# provides isolation—to closely resemble local development and allow users to \
-# run other Python projects in the same container without dependency conflicts.
-RUN uv venv
+# Resolve the expensive conda layer before copying frequently changing source.
+COPY conda_environment.yaml /tmp/conda_environment.yaml
+RUN mamba env create -f /tmp/conda_environment.yaml \
+    && mamba clean -afy \
+    && rm /tmp/conda_environment.yaml
 
-# Install Python dependencies for caching
-COPY --chown=user_lerobot:user_lerobot setup.py pyproject.toml README.md MANIFEST.in ./
-COPY --chown=user_lerobot:user_lerobot src/ src/
+COPY . /opt/lerobot
 
-ARG UNBOUND_DEPS=false
+# Reuse the canonical installer so Docker and bare-metal environments receive
+# exactly the same version checks, native bindings and vendor runtime fixes.
+RUN bash ./setup_env.sh --install \
+    && mamba clean -afy \
+    && rm -rf /root/.cache/pip /root/.cache/uv
 
-RUN if [ "$UNBOUND_DEPS" = "true" ]; then \
-    sed -i 's/,[[:space:]]*<[0-9\.]*//g' pyproject.toml; \
-    echo "Dependencies unbound:" && cat pyproject.toml; \
-    fi
+RUN install -m 0755 docker/entrypoint.sh /usr/local/bin/lerobot-entrypoint \
+    && mkdir -p /data "${HF_HOME}" "${TORCH_HOME}" "${TRITON_CACHE_DIR}"
 
-RUN uv pip install --no-cache ".[all]"
+VOLUME ["/data", "/root/.cache/huggingface", "/root/.cache/torch"]
 
-# Copy the rest of the application code
-# Make sure to have the git-LFS files for testing
-COPY --chown=user_lerobot:user_lerobot . .
-
-# Set the default command
-CMD ["/bin/bash"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/lerobot-entrypoint"]
+CMD ["bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,106 @@
+# LeRobot-Xense Docker 使用说明
+
+该镜像包含项目的完整 `xense-taccap` Conda 环境、CUDA 12.8 用户态库、
+LeRobot-Xense、XenseSDK、TacCap-Gripper SDK、Pico4 Python 绑定、Insight SDK，
+并在容器启动时默认启动 XenseVR PC Service。
+
+## 1. 宿主机要求
+
+- Ubuntu 22.04/24.04，`linux/amd64`
+- NVIDIA 驱动 `>= 570.144`
+- Docker Engine + Docker Compose 插件
+- NVIDIA Container Toolkit；`docker run --rm --gpus all ubuntu:22.04 nvidia-smi`
+  应能看到显卡
+- USB/串口/HID/CAN 设备仍需在**宿主机**完成 README 中的 udev 规则，容器不能替宿主机管理热插拔规则
+
+Compose 使用 `privileged: true`、host 网络和 host IPC，以支持运行中热插拔的
+Xense/Insight 相机、TacCap 串口、Pico4 和 CAN。请只在可信的机器人主机上运行。
+
+## 2. 初始化源码并构建
+
+镜像会编译三个硬件 SDK，因此构建前必须拉取 git submodule：
+
+```bash
+git submodule update --init --recursive --progress
+docker compose build
+```
+
+首次构建需要下载 Conda/CUDA/Python 依赖并编译原生模块，耗时较长，镜像也会比较大。
+后续未修改 `conda_environment.yaml` 时会复用最耗时的依赖层。
+
+## 3. 启动与验证
+
+进入容器：
+
+```bash
+docker compose run --rm xense-taccap
+```
+
+验证软件环境和 GPU：
+
+```bash
+python -c 'import torch; print(torch.__version__, torch.cuda.is_available())'
+python -c 'import xensesdk; print("xensesdk ->", xensesdk.__file__)'
+python -c 'import xense.taccap; print("taccap ->", xense.taccap.__file__)'
+python -c 'import xensevr_pc_service_sdk; print("pico4 ->", xensevr_pc_service_sdk.__file__)'
+pyinsight-check-env --hidraw
+```
+
+发现相机和串口：
+
+```bash
+lerobot-find-cameras
+lerobot-find-port
+```
+
+直接执行一次性命令也可以：
+
+```bash
+docker compose run --rm xense-taccap lerobot-info
+```
+
+## 4. 数据、缓存与 GUI
+
+LeRobot 数据根目录 `HF_LEROBOT_HOME` 已设为 `/data/lerobot`，Hugging Face
+和 Torch 缓存也使用 Docker volume，删除容器不会丢失：
+
+```text
+/data                         -> lerobot-data
+/root/.cache/huggingface      -> huggingface-cache
+/root/.cache/torch            -> torch-cache
+```
+
+查看或备份数据可使用：
+
+```bash
+docker compose run --rm xense-taccap bash -lc 'ls -la /data'
+```
+
+Compose 已透传 `DISPLAY` 和 X11 socket。宿主机若拒绝窗口连接，可临时授权本机 root：
+
+```bash
+xhost +si:localuser:root
+# 使用完后撤销
+xhost -si:localuser:root
+```
+
+无 Pico4、只处理数据时，可关闭随容器启动的服务：
+
+```bash
+START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap
+```
+
+服务日志默认位于容器内 `/tmp/xensevr-service.log`。
+
+## 5. 常见问题
+
+- `Missing git submodules`：在仓库根目录执行
+  `git submodule update --init --recursive` 后重新构建。
+- `could not select device driver ... gpu`：安装/配置 NVIDIA Container Toolkit，
+  然后重启 Docker daemon。
+- 容器能看到 `/dev/ttyACM*` 但设备 busy：按顶层 README 配置宿主机
+  ModemManager udev 规则，重新插拔设备。
+- GUI 不显示：检查 `echo "$DISPLAY"`、`/tmp/.X11-unix` 和上述 `xhost` 授权。
+- 构建需要离线/定制的 vendor wheel 或 `.deb`：先按 `setup_env.sh` 支持的
+  `XENSESDK_WHEEL` / `XENSEVR_DEB` 方式将安装物纳入构建上下文，再定制 Dockerfile；
+  默认镜像从项目规定的公开发布地址下载。

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,7 +16,49 @@ LeRobot-Xense、XenseSDK、TacCap-Gripper SDK、Pico4 Python 绑定、Insight SD
 Compose 使用 `privileged: true`、host 网络和 host IPC，以支持运行中热插拔的
 Xense/Insight 相机、TacCap 串口、Pico4 和 CAN。请只在可信的机器人主机上运行。
 
-## 2. 初始化源码并构建
+## 2. 客户交付与新机器一键安装
+
+开发机在镜像构建、验证完成后执行：
+
+```bash
+export LEROBOT_IMAGE_TAG=0.0.3
+./docker/package_customer_delivery.sh
+```
+
+脚本会在 `dist/customer/` 下生成一个完整交付目录，包含：
+
+- `xense-taccap-lerobot-<版本>-linux-amd64.tar`
+- `SHA256SUMS`
+- `compose.yaml` 和 `.env`
+- 客户侧 `install_customer.sh`
+- Docker 中文说明
+
+将整个目录复制到客户的新机器，然后使用普通用户执行：
+
+```bash
+cd xense-taccap-lerobot-0.0.3-linux-amd64
+./install_customer.sh
+```
+
+客户脚本会自动完成：
+
+1. 检查 Ubuntu/Debian amd64 和宿主机 NVIDIA 驱动。
+2. 缺少时安装 Docker Engine、Buildx 和 Compose 插件。
+3. 缺少时安装 NVIDIA Container Toolkit，并配置 Docker GPU runtime/CDI。
+4. 安装 TacCap/Insight 宿主机 udev 规则。
+5. 校验 SHA256、导入镜像并运行 PyTorch CUDA 冒烟测试。
+
+需要本机 HTTP 代理时：
+
+```bash
+XENSE_PROXY_URL=http://127.0.0.1:7897 ./install_customer.sh
+```
+
+脚本不会自动安装或升级宿主机 NVIDIA 驱动，因为驱动安装涉及显卡型号、
+Secure Boot 和系统重启。若 `nvidia-smi` 不可用或驱动低于 `570.144`，脚本会停止并
+提示先处理驱动。
+
+## 3. 初始化源码并构建
 
 镜像会编译三个硬件 SDK，因此构建前必须拉取 git submodule：
 
@@ -30,7 +72,7 @@ docker compose build
 Dockerfile 已包含 apt/curl 自动重试、CUDA 12.8 构建期覆盖和 flexible channel
 priority，不再需要使用临时 `sed` 命令修改构建过程。
 
-## 3. 启动与验证
+## 4. 启动与验证
 
 进入容器：
 
@@ -61,7 +103,7 @@ lerobot-find-port
 docker compose run --rm xense-taccap lerobot-info
 ```
 
-## 4. 数据、缓存与 GUI
+## 5. 数据、缓存与 GUI
 
 LeRobot 数据根目录 `HF_LEROBOT_HOME` 已设为 `/data/lerobot`，Hugging Face
 和 Torch 缓存也使用 Docker volume，删除容器不会丢失：
@@ -103,7 +145,7 @@ START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap
 
 服务日志默认位于容器内 `/tmp/xensevr-service.log`。
 
-## 5. 常见问题
+## 6. 常见问题
 
 - `Missing git submodules`：在仓库根目录执行
   `git submodule update --init --recursive` 后重新构建。

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,6 +27,8 @@ docker compose build
 
 首次构建需要下载 Conda/CUDA/Python 依赖并编译原生模块，耗时较长，镜像也会比较大。
 后续未修改 `conda_environment.yaml` 时会复用最耗时的依赖层。
+Dockerfile 已包含 apt/curl 自动重试、CUDA 12.8 构建期覆盖和 flexible channel
+priority，不再需要使用临时 `sed` 命令修改构建过程。
 
 ## 3. 启动与验证
 
@@ -66,9 +68,15 @@ LeRobot 数据根目录 `HF_LEROBOT_HOME` 已设为 `/data/lerobot`，Hugging Fa
 
 ```text
 /data                         -> lerobot-data
+/root/.xensesdk               -> xensesdk-cache（按传感器序列号缓存配置）
 /root/.cache/huggingface      -> huggingface-cache
 /root/.cache/torch            -> torch-cache
 ```
+
+Compose 会透传宿主机 `/dev` 和 `/run/udev`，使程序能够读取
+`/dev/v4l/by-id`、`/dev/v4l/by-path` 和 `/dev/serial/by-path` 完成 USB Hub
+自动配对。XenseSDK 的配置缓存会跨 `--rm` 临时容器保留，避免每次启动重新读取
+传感器 flash 并触发 USB 重新枚举。
 
 查看或备份数据可使用：
 
@@ -83,6 +91,9 @@ xhost +si:localuser:root
 # 使用完后撤销
 xhost -si:localuser:root
 ```
+
+镜像已包含 Rerun 所需的 XKB、Vulkan 和 XDG 运行库，并默认设置
+`WGPU_BACKEND=vulkan`。可用 `vulkaninfo --summary` 检查 NVIDIA Vulkan 是否正常。
 
 无 Pico4、只处理数据时，可关闭随容器启动的服务：
 
@@ -101,6 +112,11 @@ START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap
 - 容器能看到 `/dev/ttyACM*` 但设备 busy：按顶层 README 配置宿主机
   ModemManager udev 规则，重新插拔设备。
 - GUI 不显示：检查 `echo "$DISPLAY"`、`/tmp/.X11-unix` 和上述 `xhost` 授权。
+- Rerun 报 Vulkan adapter 错误：先确认 `nvidia-smi` 和
+  `vulkaninfo --summary` 均能在容器中识别 NVIDIA GPU。
+- 找不到 GSPS，但宿主机存在：确认容器通过 Compose 启动，并检查
+  `ls /dev/v4l/by-id/*GSPS*`；必要时重新插拔 USB Hub 后执行
+  `sudo udevadm settle --timeout=20`。
 - 构建需要离线/定制的 vendor wheel 或 `.deb`：先按 `setup_env.sh` 支持的
   `XENSESDK_WHEEL` / `XENSEVR_DEB` 方式将安装物纳入构建上下文，再定制 Dockerfile；
   默认镜像从项目规定的公开发布地址下载。

--- a/docker/README.md
+++ b/docker/README.md
@@ -58,6 +58,34 @@ XENSE_PROXY_URL=http://127.0.0.1:7897 ./install_customer.sh
 Secure Boot 和系统重启。若 `nvidia-smi` 不可用或驱动低于 `570.144`，脚本会停止并
 提示先处理驱动。
 
+### 安装完成后的宿主机设置
+
+`install_customer.sh` 已经执行 Docker 服务启用和用户组配置。为了确保当前用户
+立即获得 Docker 权限，可在宿主机执行以下命令：
+
+```bash
+sudo systemctl enable --now docker
+sudo usermod -aG docker "$USER"
+newgrp docker
+docker images
+```
+
+`newgrp docker` 会为当前终端启动一个应用了新用户组的子 Shell；也可以注销并重新
+登录。这里仅将**当前用户**加入 `docker` 组，不会自动授权所有本地用户。请注意，
+`docker` 组成员拥有接近 root 的系统控制权限，只应加入可信用户。
+
+如果需要在容器内显示 Rerun 等 X11 图形窗口，还要由宿主机当前图形桌面用户执行：
+
+```bash
+xhost +si:localuser:root
+```
+
+使用完成后可以撤销授权：
+
+```bash
+xhost -si:localuser:root
+```
+
 ## 3. 初始化源码并构建
 
 镜像会编译三个硬件 SDK，因此构建前必须拉取 git submodule：

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Rerun/wgpu needs a private runtime directory even when the container is
+# started from a plain shell rather than a desktop session.
+mkdir -p "${XDG_RUNTIME_DIR:-/tmp/xdg-runtime}"
+chmod 0700 "${XDG_RUNTIME_DIR:-/tmp/xdg-runtime}"
+
 # The daemon is installed by setup_env.sh and serves Pico4 tracker data over the
 # network. It is optional so dataset-only jobs can disable it cleanly.
 if [[ "${START_XENSEVR_SERVICE:-1}" == "1" ]]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The daemon is installed by setup_env.sh and serves Pico4 tracker data over the
+# network. It is optional so dataset-only jobs can disable it cleanly.
+if [[ "${START_XENSEVR_SERVICE:-1}" == "1" ]]; then
+    service_script="/opt/apps/roboticsservice/runService.sh"
+    if [[ -x "${service_script}" ]]; then
+        service_dir="$(dirname "${service_script}")"
+        service_log="${XENSEVR_SERVICE_LOG:-/tmp/xensevr-service.log}"
+        echo "[entrypoint] Starting XenseVR PC Service (log: ${service_log})"
+        (
+            cd "${service_dir}"
+            exec "${service_script}"
+        ) >"${service_log}" 2>&1 &
+    else
+        echo "[entrypoint] XenseVR PC Service is not installed; continuing." >&2
+    fi
+fi
+
+if [[ "$#" -eq 0 ]]; then
+    set -- bash
+fi
+
+exec "$@"

--- a/docker/install_customer.sh
+++ b/docker/install_customer.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARCHIVE_PATH="${1:-${XENSE_IMAGE_ARCHIVE:-}}"
+PROXY_URL="${XENSE_PROXY_URL:-}"
+IMAGE_REPOSITORY="${XENSE_IMAGE_REPOSITORY:-xense-taccap-lerobot}"
+IMAGE_TAG="${LEROBOT_IMAGE_TAG:-}"
+TEMP_DIR=""
+DOCKER_CMD=(docker)
+
+log() {
+  printf '[install_customer] %s\n' "$*"
+}
+
+fail() {
+  printf '[install_customer] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage: ./install_customer.sh [IMAGE_ARCHIVE]
+
+Installs/checks Docker and NVIDIA Container Toolkit, verifies and loads the
+delivery image, installs host udev rules, and runs a CUDA smoke test.
+
+Environment:
+  XENSE_PROXY_URL          Optional HTTP/HTTPS proxy, e.g. http://127.0.0.1:7897
+  XENSE_IMAGE_ARCHIVE      Image archive path when not passed as an argument
+  LEROBOT_IMAGE_TAG        Override the expected image tag
+  XENSE_IMAGE_REPOSITORY   Image repository name (default: xense-taccap-lerobot)
+EOF
+}
+
+cleanup() {
+  if [[ -n "${TEMP_DIR}" && -d "${TEMP_DIR}" ]]; then
+    rm -rf "${TEMP_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+require_normal_user() {
+  if [[ "${EUID}" -eq 0 ]]; then
+    fail "Run this script as a normal user with sudo privileges, not as root."
+  fi
+  command -v sudo >/dev/null 2>&1 || fail "sudo is required."
+  sudo -v
+}
+
+load_os_release() {
+  [[ -r /etc/os-release ]] || fail "Cannot read /etc/os-release."
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  [[ "${ID}" == "ubuntu" || "${ID}" == "debian" ]] || \
+    fail "Only Ubuntu and Debian are currently supported; detected ${ID}."
+  [[ "$(dpkg --print-architecture)" == "amd64" ]] || \
+    fail "Only linux/amd64 hosts are supported."
+  DISTRO_ID="${ID}"
+  DISTRO_CODENAME="${VERSION_CODENAME:-}"
+  [[ -n "${DISTRO_CODENAME}" ]] || fail "VERSION_CODENAME is missing from /etc/os-release."
+}
+
+apt_get() {
+  local apt_options=(-o Acquire::Retries=10 -o Acquire::http::Timeout=60 -o Acquire::https::Timeout=120)
+  if [[ -n "${PROXY_URL}" ]]; then
+    apt_options+=(-o Acquire::http::Proxy=false -o "Acquire::https::Proxy=${PROXY_URL}")
+  fi
+  sudo apt-get "${apt_options[@]}" "$@"
+}
+
+fetch_url() {
+  local url="$1"
+  local destination="$2"
+  local curl_args=(--http1.1 --fail --show-error --location --retry 10 --retry-delay 5 --retry-all-errors)
+  if [[ -n "${PROXY_URL}" ]]; then
+    curl_args+=(--proxy "${PROXY_URL}")
+  fi
+  curl "${curl_args[@]}" "${url}" --output "${destination}"
+}
+
+configure_docker_repository() {
+  local key_path="${TEMP_DIR}/docker.asc"
+  local source_path="${TEMP_DIR}/docker.sources"
+
+  fetch_url "https://download.docker.com/linux/${DISTRO_ID}/gpg" "${key_path}"
+  printf '%s\n' \
+    'Types: deb' \
+    "URIs: https://download.docker.com/linux/${DISTRO_ID}" \
+    "Suites: ${DISTRO_CODENAME}" \
+    'Components: stable' \
+    'Architectures: amd64' \
+    'Signed-By: /etc/apt/keyrings/docker.asc' \
+    > "${source_path}"
+
+  sudo install -d -m 0755 /etc/apt/keyrings
+  sudo install -m 0644 "${key_path}" /etc/apt/keyrings/docker.asc
+  sudo install -m 0644 "${source_path}" /etc/apt/sources.list.d/docker.sources
+}
+
+install_docker() {
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    log "Docker Engine and Docker Compose are already installed."
+    return
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    log "Docker Engine exists; installing only the Docker Compose plugin..."
+    apt_get update
+    apt_get install -y --no-install-recommends ca-certificates curl gnupg
+    configure_docker_repository
+    apt_get update
+    apt_get install -y docker-compose-plugin
+    return
+  fi
+
+  log "Installing Docker Engine and Docker Compose plugin..."
+  apt_get update
+  apt_get install -y --no-install-recommends ca-certificates curl gnupg
+  configure_docker_repository
+  apt_get update
+  apt_get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  sudo systemctl enable --now docker
+}
+
+configure_docker_proxy() {
+  [[ -n "${PROXY_URL}" ]] || return
+
+  local proxy_conf="${TEMP_DIR}/http-proxy.conf"
+  printf '%s\n' \
+    '[Service]' \
+    "Environment=\"HTTP_PROXY=${PROXY_URL}\"" \
+    "Environment=\"HTTPS_PROXY=${PROXY_URL}\"" \
+    'Environment="NO_PROXY=localhost,127.0.0.1"' \
+    > "${proxy_conf}"
+
+  sudo install -d -m 0755 /etc/systemd/system/docker.service.d
+  sudo install -m 0644 "${proxy_conf}" /etc/systemd/system/docker.service.d/http-proxy.conf
+  sudo systemctl daemon-reload
+}
+
+configure_docker_access() {
+  sudo groupadd --force docker
+  sudo usermod -aG docker "${USER}"
+  if docker info >/dev/null 2>&1; then
+    DOCKER_CMD=(docker)
+  else
+    DOCKER_CMD=(sudo docker)
+  fi
+}
+
+install_nvidia_container_toolkit() {
+  command -v nvidia-smi >/dev/null 2>&1 || \
+    fail "nvidia-smi not found. Install a compatible host NVIDIA driver first, reboot, then rerun this script."
+  nvidia-smi >/dev/null 2>&1 || \
+    fail "The host NVIDIA driver is installed but nvidia-smi failed. Fix the driver before continuing."
+
+  local driver_version
+  driver_version="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | sed -n '1p' | tr -d '[:space:]')"
+  dpkg --compare-versions "${driver_version}" ge "570.144" || \
+    fail "NVIDIA driver ${driver_version} is too old; this image requires driver 570.144 or newer."
+  log "Host NVIDIA driver ${driver_version} is compatible."
+
+  if command -v nvidia-ctk >/dev/null 2>&1; then
+    log "NVIDIA Container Toolkit is already installed; refreshing Docker/CDI configuration."
+  else
+    log "Installing NVIDIA Container Toolkit..."
+    apt_get update
+    apt_get install -y --no-install-recommends ca-certificates curl gnupg
+
+    local gpg_key="${TEMP_DIR}/nvidia-container-toolkit-keyring.gpg"
+    local source_list="${TEMP_DIR}/nvidia-container-toolkit.list"
+    local raw_key="${TEMP_DIR}/nvidia-container-toolkit.key"
+    fetch_url "https://nvidia.github.io/libnvidia-container/gpgkey" "${raw_key}"
+    gpg --dearmor --yes --output "${gpg_key}" "${raw_key}"
+    fetch_url \
+      "https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list" \
+      "${source_list}"
+    sed -i \
+      's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+      "${source_list}"
+
+    sudo install -m 0644 "${gpg_key}" /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+    sudo install -m 0644 "${source_list}" /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    apt_get update
+    apt_get install -y nvidia-container-toolkit nvidia-container-toolkit-base
+  fi
+
+  sudo nvidia-ctk runtime configure --runtime=docker
+  sudo install -d -m 0755 /etc/cdi
+  sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+}
+
+install_udev_rules() {
+  local taccap_rules="${TEMP_DIR}/99-taccap-ignore-modemmanager.rules"
+  local insight_rules="${TEMP_DIR}/99-insight.rules"
+
+  printf '%s\n' \
+    '# TacCap-Gripper CH343 USB serial: keep ModemManager off the device.' \
+    'ACTION=="add|change", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1a86", ENV{ID_MM_DEVICE_IGNORE}="1"' \
+    > "${taccap_rules}"
+  printf '%s\n' \
+    'SUBSYSTEM=="hidraw", ATTRS{idVendor}=="3652", ATTRS{idProduct}=="0104", MODE="0660", GROUP="plugdev"' \
+    'SUBSYSTEM=="video4linux", ATTRS{idVendor}=="3652", ATTRS{idProduct}=="0104", MODE="0660", GROUP="video"' \
+    > "${insight_rules}"
+
+  sudo install -m 0644 "${taccap_rules}" /etc/udev/rules.d/99-taccap-ignore-modemmanager.rules
+  sudo install -m 0644 "${insight_rules}" /etc/udev/rules.d/99-insight.rules
+  sudo groupadd --force plugdev
+  sudo usermod -aG plugdev,video "${USER}"
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger
+}
+
+read_delivery_tag() {
+  if [[ -n "${IMAGE_TAG}" ]]; then
+    return
+  fi
+  if [[ -f "${ROOT_DIR}/.env" ]]; then
+    IMAGE_TAG="$(awk -F= '$1 == "LEROBOT_IMAGE_TAG" {print substr($0, index($0, "=") + 1); exit}' "${ROOT_DIR}/.env")"
+  fi
+  if [[ -z "${IMAGE_TAG}" && -f "${ROOT_DIR}/delivery.env" ]]; then
+    IMAGE_TAG="$(awk -F= '$1 == "LEROBOT_IMAGE_TAG" {print substr($0, index($0, "=") + 1); exit}' "${ROOT_DIR}/delivery.env")"
+  fi
+  IMAGE_TAG="${IMAGE_TAG:-latest}"
+}
+
+find_archive() {
+  if [[ -n "${ARCHIVE_PATH}" ]]; then
+    ARCHIVE_PATH="$(realpath "${ARCHIVE_PATH}")"
+    return
+  fi
+
+  local matches=()
+  mapfile -t matches < <(find "${ROOT_DIR}" -maxdepth 1 -type f -name 'xense-taccap-lerobot-*.tar' -print | sort)
+  [[ "${#matches[@]}" -eq 1 ]] || \
+    fail "Expected exactly one xense-taccap-lerobot-*.tar in ${ROOT_DIR}; found ${#matches[@]}. Pass the archive path as the first argument."
+  ARCHIVE_PATH="${matches[0]}"
+}
+
+derive_tag_from_archive() {
+  if [[ "${IMAGE_TAG}" != "latest" || -f "${ROOT_DIR}/.env" || -f "${ROOT_DIR}/delivery.env" ]]; then
+    return
+  fi
+
+  local archive_name
+  archive_name="$(basename "${ARCHIVE_PATH}")"
+  if [[ "${archive_name}" == xense-taccap-lerobot-*-linux-amd64.tar ]]; then
+    IMAGE_TAG="${archive_name#xense-taccap-lerobot-}"
+    IMAGE_TAG="${IMAGE_TAG%-linux-amd64.tar}"
+  fi
+}
+
+verify_archive() {
+  [[ -f "${ARCHIVE_PATH}" ]] || fail "Image archive not found: ${ARCHIVE_PATH}"
+  local checksum_file="$(dirname "${ARCHIVE_PATH}")/SHA256SUMS"
+  [[ -f "${checksum_file}" ]] || fail "Checksum file not found: ${checksum_file}"
+  log "Verifying image archive checksum..."
+  (
+    cd "$(dirname "${ARCHIVE_PATH}")"
+    sha256sum --check "$(basename "${checksum_file}")"
+  )
+}
+
+load_and_verify_image() {
+  local image_ref="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+  log "Loading Docker image from ${ARCHIVE_PATH}"
+  "${DOCKER_CMD[@]}" load --input "${ARCHIVE_PATH}"
+  "${DOCKER_CMD[@]}" image inspect "${image_ref}" >/dev/null 2>&1 || \
+    fail "Expected image was not found after docker load: ${image_ref}"
+
+  log "Running GPU and Python smoke test with ${image_ref}"
+  "${DOCKER_CMD[@]}" run --rm --gpus all \
+    --entrypoint python "${image_ref}" \
+    -c 'import torch; print("torch:", torch.__version__); print("cuda:", torch.cuda.is_available()); raise SystemExit(0 if torch.cuda.is_available() else 1)'
+}
+
+main() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    return
+  fi
+
+  require_normal_user
+  load_os_release
+  TEMP_DIR="$(mktemp -d)"
+  read_delivery_tag
+  find_archive
+  derive_tag_from_archive
+  verify_archive
+  install_docker
+  configure_docker_proxy
+  configure_docker_access
+  install_nvidia_container_toolkit
+  install_udev_rules
+  sudo systemctl restart docker
+  configure_docker_access
+  load_and_verify_image
+
+  log "Installation completed successfully."
+  log "Log out and back in once so docker/video/plugdev group membership takes effect."
+  log "Then start the container from this directory with:"
+  log "  xhost +SI:localuser:root"
+  log "  docker compose run --rm xense-taccap"
+}
+
+main "$@"

--- a/docker/package_customer_delivery.sh
+++ b/docker/package_customer_delivery.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE_REPOSITORY="${XENSE_IMAGE_REPOSITORY:-xense-taccap-lerobot}"
+IMAGE_TAG="${1:-${LEROBOT_IMAGE_TAG:-latest}}"
+IMAGE_REF="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+DIST_ROOT="${XENSE_DIST_DIR:-${ROOT_DIR}/dist/customer}"
+SAFE_TAG="${IMAGE_TAG//[^a-zA-Z0-9_.-]/-}"
+BUNDLE_DIR="${DIST_ROOT}/xense-taccap-lerobot-${SAFE_TAG}-linux-amd64"
+ARCHIVE_NAME="xense-taccap-lerobot-${SAFE_TAG}-linux-amd64.tar"
+ARCHIVE_PATH="${BUNDLE_DIR}/${ARCHIVE_NAME}"
+
+log() {
+  printf '[package_customer_delivery] %s\n' "$*"
+}
+
+fail() {
+  printf '[package_customer_delivery] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+usage() {
+  cat <<'EOF'
+Usage: ./docker/package_customer_delivery.sh [IMAGE_TAG]
+
+Packages xense-taccap-lerobot:<IMAGE_TAG> for offline customer delivery.
+IMAGE_TAG defaults to LEROBOT_IMAGE_TAG, then latest.
+
+Environment:
+  XENSE_IMAGE_REPOSITORY   Image repository name (default: xense-taccap-lerobot)
+  XENSE_DIST_DIR           Output root (default: dist/customer)
+  XENSE_FORCE_PACKAGE=1    Allow overwriting an existing image archive
+EOF
+}
+
+main() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    return
+  fi
+
+  require_command docker
+  require_command sha256sum
+
+  docker image inspect "${IMAGE_REF}" >/dev/null 2>&1 || \
+    fail "Docker image not found: ${IMAGE_REF}"
+
+  local image_arch
+  image_arch="$(docker image inspect --format '{{.Architecture}}' "${IMAGE_REF}")"
+  [[ "${image_arch}" == "amd64" ]] || \
+    fail "Expected an amd64 image, got: ${image_arch}"
+
+  mkdir -p "${BUNDLE_DIR}"
+  if [[ -e "${ARCHIVE_PATH}" && "${XENSE_FORCE_PACKAGE:-0}" != "1" ]]; then
+    fail "Archive already exists: ${ARCHIVE_PATH}. Set XENSE_FORCE_PACKAGE=1 to overwrite it."
+  fi
+
+  log "Saving ${IMAGE_REF} to ${ARCHIVE_PATH}"
+  docker save --output "${ARCHIVE_PATH}" "${IMAGE_REF}"
+
+  (
+    cd "${BUNDLE_DIR}"
+    sha256sum "${ARCHIVE_NAME}" > SHA256SUMS
+  )
+
+  install -m 0644 "${ROOT_DIR}/compose.yaml" "${BUNDLE_DIR}/compose.yaml"
+  install -m 0644 "${ROOT_DIR}/docker/README.md" "${BUNDLE_DIR}/DOCKER_README_ZH.md"
+  install -m 0755 "${ROOT_DIR}/docker/install_customer.sh" "${BUNDLE_DIR}/install_customer.sh"
+  printf 'LEROBOT_IMAGE_TAG=%s\n' "${IMAGE_TAG}" > "${BUNDLE_DIR}/.env"
+  printf 'LEROBOT_IMAGE_TAG=%s\n' "${IMAGE_TAG}" > "${BUNDLE_DIR}/delivery.env"
+
+  log "Customer delivery package is ready:"
+  log "  ${BUNDLE_DIR}"
+  log "Copy the entire directory to the customer machine, then run:"
+  log "  ./install_customer.sh"
+}
+
+main "$@"


### PR DESCRIPTION
 ## Title

  feat(docker): add GPU-ready deployment and customer delivery workflow

  ## Type / Scope

  - **Type**: Feature
  - **Scope**: Docker / deployment / customer delivery

  ## Summary / Motivation

  This PR adds a reproducible Docker deployment workflow for LeRobot-Xense and the
  TacCap-Gripper hardware stack.

  The goal is to make the project easier to deploy on customer machines without
  manually recreating the Conda, CUDA, native SDK, USB, GPU, and visualization
  environment.

  The workflow supports both source-based image builds and offline delivery of a
  prebuilt image.

  ## Related issues

  - Fixes / Closes: N/A
  - Related: N/A

  ## What changed

  - Added an Ubuntu 22.04, linux/amd64 Docker image containing:
    - Python 3.12
    - PyTorch CUDA 12.8 environment
    - XenseSDK
    - TacCap-Gripper SDK
    - XenseVR/Pico4 bindings and PC service
    - Insight camera SDK
    - Rerun X11/Vulkan runtime dependencies

  - Added a Docker Compose service named `xense-taccap` with:
    - NVIDIA GPU access
    - host networking and IPC
    - USB/V4L2/HID/serial device passthrough
    - host udev metadata passthrough
    - persistent XenseSDK, Hugging Face, Torch, and dataset caches
    - X11 display support

  - Added an entrypoint that starts the XenseVR PC Service before opening the
    requested container command.

  - Improved build reliability:
    - apt download retries and timeouts
    - curl HTTP/1.1 and retry handling
    - Conda/Mamba network timeouts and retries
    - flexible channel priority
    - CUDA 12.8 virtual package override
    - automatic retry after incomplete Conda repodata downloads

  - Added customer delivery tools:
    - `docker/package_customer_delivery.sh`
      - exports a versioned Docker image
      - generates SHA256 checksums
      - creates a self-contained customer delivery directory
    - `docker/install_customer.sh`
      - installs Docker Engine and Docker Compose when missing
      - installs and configures NVIDIA Container Toolkit
      - installs TacCap and Insight host udev rules
      - verifies and imports the offline image
      - runs a PyTorch CUDA smoke test

  - Added Docker usage and troubleshooting documentation.

  - Changed submodule URLs to HTTPS to simplify cloning on customer machines.

  ## Breaking changes

  No existing non-Docker installation workflow is changed.

  The Compose service uses privileged mode, host networking, and host IPC because
  the hardware stack requires USB hot-plugging and stable `/dev/*/by-id` discovery.
  It should only be used on trusted robot hosts.

  ## How was this tested

  ### Docker build

  Built the versioned image successfully:

  ```bash
  export LEROBOT_IMAGE_TAG=0.0.3
  docker compose --progress=plain build

  Verified the resulting image:

  xense-taccap-lerobot:0.0.3

  ### Software and GPU validation

  Verified inside the container:

  python -c 'import torch; print(torch.__version__, torch.cuda.is_available())'
  python -c 'import xensesdk'
  python -c 'import xense.taccap'
  python -c 'import xensevr_pc_service_sdk'

  Observed:

  torch 2.10.0+cu128
  CUDA available: True

  ### Real hardware validation

  Tested on real hardware with:

  - two TacCap leader grippers
  - four Xense tactile cameras
  - two wrist cameras
  - two Pico4 motion trackers
  - XenseVR PC Service
  - NVIDIA GPU
  - Rerun visualization

  The complete bi_taccap_gripper teleoperation stack connected successfully and
  streamed gripper, tactile camera, wrist camera, and Pico4 tracker observations.

  ### Delivery workflow

  Created the customer package with:

  ./docker/package_customer_delivery.sh 0.0.3

  Verified the generated image archive with SHA256 successfully.

  ### Static checks

  bash -n \
    docker/entrypoint.sh \
    docker/install_customer.sh \
    docker/package_customer_delivery.sh

  docker compose config --quiet
  docker build --check -f docker/Dockerfile.user .
  git diff --check

  ## Checklist

  - [ ] pre-commit run --all-files passes
  - [x] Docker Compose configuration validated
  - [x] Dockerfile static build check passes
  - [x] Shell scripts pass Bash syntax checks
  - [x] Docker image built successfully
  - [x] Verified on real TacCap/Pico4/Xense hardware
  - [x] Documentation updated
  - [ ] CI is green

  ## Reviewer notes

  Please pay particular attention to:

  - the use of privileged mode and host device passthrough in compose.yaml
  - the Docker and NVIDIA installation logic in docker/install_customer.sh
  - the Conda/Mamba retry strategy in docker/Dockerfile.user
  - the host udev rules installed by the customer installer

  The customer installer intentionally does not install or upgrade the host NVIDIA
  driver because driver installation may require hardware-specific choices,
  Secure Boot configuration, and a system reboot.

  The prebuilt image archive is generated locally and is not committed to Git.
