### PR TITLE
fix: point the encoder-max fallback at calibrate.py, not fisheye_cal.py

### DIFF
--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -511,8 +511,7 @@ def open_gripper(
     * **Uncalibrated or pre-V2.1 leaders** — the constructor raises. Rather
       than fail the session we re-open with ``encoder_max_rad`` supplied from
       the host, which is the same arithmetic as before, and say so once. Run
-      ``fisheye_cal.py measure-encoder-max`` to move a unit onto the firmware
-      value.
+      ``calibrate.py <side>`` to move a unit onto the firmware value.
 
     Returns ``(gripper, norm_source)`` where ``norm_source`` is ``"firmware"``
     or ``"config"`` — which of the two paths above the unit ended up on.
@@ -528,7 +527,7 @@ def open_gripper(
             f"  {label}Firmware encoder-max calibration unavailable ({e}); falling back to "
             f"gripper_open_rad={open_rad}. gripper.pos will not reach 1.0 if this unit's "
             "real travel differs. Fix with: python "
-            "third_party/taccap-gripper/python/examples/fisheye_cal.py measure-encoder-max"
+            "third_party/taccap-gripper/python/examples/calibrate.py <left|right>"
         )
         return gripper_cls(mcu_device, normalize_position=True, encoder_max_rad=open_rad), "config"
 


### PR DESCRIPTION
Found while auditing the XTac-UMI-G1 customer manual against this repo.

## The problem

When a leader's firmware encoder-max calibration is unavailable, `open_gripper` falls back to `gripper_open_rad` and warns the operator how to fix it:

```
[left] Firmware encoder-max calibration unavailable (...); falling back to
gripper_open_rad=1.7. gripper.pos will not reach 1.0 if this unit's real travel
differs. Fix with: python third_party/taccap-gripper/python/examples/fisheye_cal.py measure-encoder-max
```

`fisheye_cal.py` appears nowhere in the customer manual — the whole calibration chapter is written around `calibrate.py`. So a customer who follows the manual hits a script they have never seen, at the one moment they are already stuck.

## Why calibrate.py is the right target

Not a behaviour difference: `fisheye_cal.py measure-encoder-max` calls `_calib_flow.guided_calibration`, and `calibrate.py` builds the same flow out of `require_support` / `store_max` — both do zero + travel span.

The difference is the entry point. `calibrate.py` resolves the unit by side (`left`/`right`) or by firmware SN and prints every gripper the scan saw, so with both sides plugged in you cannot zero the wrong one. `fisheye_cal.py` is a read/write tool for the calibration records (`show` / `set-fisheye` / `set-encoder-max`) that happens to re-expose the flow.

## Change

Two lines in `src/lerobot/robots/taccap_gripper/common.py` — the runtime warning and the `open_gripper` docstring above it. No logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)