### PR TITLE
Slim the Docker image from 30.5 GB to 21.4 GB

### DIFF
--- a/conda_environment.yaml
+++ b/conda_environment.yaml
@@ -1,7 +1,8 @@
 name: xense-taccap
 channels:
   - conda-forge
-  - nvidia
+  # The `nvidia` channel went with the cuda-toolkit/cudnn entries below; nothing
+  # in this file resolves from it any more, and dropping it shortens the solve.
   - nodefaults
 dependencies:
   - python=3.12
@@ -23,9 +24,25 @@ dependencies:
   - spdlog=1.14.1
   - pkg-config
   - make
-  # ── CUDA (xensesdk 2.1.1 / onnxruntime-gpu) ────────────────────────────────
-  - nvidia::cuda-toolkit=12.8
-  - nvidia::cudnn
+  # ── CUDA ───────────────────────────────────────────────────────────────────
+  # Deliberately absent. `nvidia::cuda-toolkit=12.8` + `nvidia::cudnn` used to
+  # live here for onnxruntime-gpu, which xensesdk declares only as an optional
+  # extra (`xensesdk[onnx]`) — and setup_env.sh installs xensesdk with
+  # --no-deps, so onnxruntime was never in the environment. Nothing else used
+  # them: torch/torchvision/torchcodec come from pip and bundle their own CUDA
+  # runtime under site-packages/nvidia (torch reports cuDNN 9.10.2, not the
+  # 9.14.0 conda installed), none of the three C++ SDK builds reference CUDA,
+  # and nvcc is never invoked. Together they cost 4.7 GB — 2.7 GB of that being
+  # headers and static libs nothing links against.
+  #
+  # None of this affects recording. NVENC video encoding uses
+  # libnvidia-encode from the host driver (injected by nvidia-container-toolkit
+  # in Docker), and torch's CUDA comes from its own wheels.
+  #
+  # If you ever want GPU tactile inference (the FORCE / DEPTH output types),
+  # install `xensesdk[onnx]` and add `nvidia::cuda-runtime=12.8` +
+  # `nvidia::cudnn` back — cuda-runtime, not cuda-toolkit: the compiler and
+  # headers in the full toolkit are not needed to *run* anything.
   # ── Video (torchcodec / av) ────────────────────────────────────────────────
   # PyAV/torchcodec are installed from wheels later in setup_env.sh; ffmpeg is
   # kept out of the conda solve to avoid ICU/libxml2 conflicts.

--- a/docker/Dockerfile.user
+++ b/docker/Dockerfile.user
@@ -109,9 +109,17 @@ COPY . /opt/lerobot
 
 # Reuse the canonical installer so Docker and bare-metal environments receive
 # exactly the same version checks, native bindings and vendor runtime fixes.
+# The XenseVR-PC-Service checkout is build-time only, and it is 756 MB of Qt
+# service sources, a Unity demo and duplicate SDK binaries. What survives the
+# build lives elsewhere: the daemon is installed by the .deb under
+# /opt/apps/roboticsservice, and the C SDK the Python bindings load is copied
+# into xensevr-pc-service-pybind/lib, which the extension records as its RPATH.
+# taccap-gripper stays: it is an editable install, so its sources are its
+# package.
 RUN bash ./setup_env.sh --install \
     && mamba clean -afy \
-    && rm -rf /root/.cache/pip /root/.cache/uv
+    && rm -rf /root/.cache/pip /root/.cache/uv \
+    && rm -rf third_party/XenseVR-PC-Service
 
 RUN install -m 0755 docker/entrypoint.sh /usr/local/bin/lerobot-entrypoint \
     && mkdir -p /data /root/.xensesdk "${HF_HOME}" "${TORCH_HOME}" "${TRITON_CACHE_DIR}" "${XDG_RUNTIME_DIR}" \


### PR DESCRIPTION
Groundwork for publishing the image to a registry — pulling 30.5 GB is not something to ask a customer to do. Two thirds of the waste turned out to be a second, unused copy of CUDA.

## What was in there twice

`conda_environment.yaml` pulled `nvidia::cuda-toolkit=12.8` and `nvidia::cudnn`:

| | |
|---|---|
| CUDA headers + static libs (`targets/`) | 2.7 GB |
| conda cuDNN 9.14 | 926 MB |
| other `libcu*` / `libnv*` | 928 MB |
| nvcc toolchain | 191 MB |
| **total** | **4.7 GB** |

The comment above them said "xensesdk 2.1.1 / onnxruntime-gpu". But xensesdk declares `onnxruntime-gpu<=1.20` only as an **optional extra** (`extra == "onnx"`), and `setup_env.sh` installs xensesdk with `--no-deps` — so onnxruntime was never in the environment. Checked directly: no `onnxruntime`, no `tensorrt`, no `openvino`.

Nothing else wanted it either:

- torch / torchvision / torchcodec are all `pypi_0` and bundle their own CUDA under `site-packages/nvidia` (4.3 GB, kept)
- none of the three C++ SDK builds reference CUDA; no `.so` links a conda CUDA library
- `nvcc` is never invoked — all 15 mentions in the build log are package names being installed

The tell is cuDNN: **torch reports 9.10.2**, its own bundled copy, while conda had installed **9.14.0** next to it.

## Recording is not affected

This was the thing worth checking, since the capture host does use the GPU. Three different things get called "CUDA" here and only one of them is going away:

| | comes from | changed |
|---|---|---|
| NVENC video encoding (`auto` → `h264_nvenc`) | host driver, `libnvidia-encode.so.595.71.05`, injected by nvidia-container-toolkit | no |
| torch's CUDA (`version.cuda=12.8`, cuDNN 9.10.2) | pip's bundled `site-packages/nvidia` | no |
| conda `cuda-toolkit` + `cudnn` 9.14 | `conda_environment.yaml` | **removed** |

## Also removed: build-only sources

`third_party/XenseVR-PC-Service` (**756 MB**) is deleted after the build — Qt service sources, a Unity demo and duplicate SDK binaries, none of which survive into runtime. The daemon is installed by the `.deb` under `/opt/apps/roboticsservice`, and the C SDK the Python bindings load is copied into `xensevr-pc-service-pybind/lib`, which the extension records as its `RPATH`. `taccap-gripper` stays: it is an editable install, so its sources *are* its package.

## Result

**30.5 GB → 21.4 GB.** More than the ~5.6 GB the removed packages account for — dropping the `nvidia` channel presumably stopped the solver preferring CUDA-enabled variants elsewhere. Not chased further, since every function below still checks out.

## Verification

Built and exercised on this host (Ubuntu 24.04, RTX 5060, driver 595.71.05).

| | |
|---|---|
| `docker compose build` | exit 0 |
| post-install verification | every package `[OK]`, including `xensevr_pc_service_sdk` — the one whose sources were deleted |
| torch | `2.10.0+cu128`, `cuda_available=True`, RTX 5060 visible, **a real GPU matmul runs** |
| video encoding | `h264_nvenc` still selected |
| SDK imports | lerobot, xensesdk, xense.taccap, xensevr_pc_service_sdk |
| removals | `third_party/XenseVR-PC-Service` gone, RPATH target `libPXREARobotSDK.so` present, taccap-gripper sources present |
| conda CUDA | cuDNN, headers/static libs and nvcc all gone; pip's 4.3 GB intact |

Hardware discovery, run **inside the container** against the grippers attached to this host, still resolves everything:

```
scan_grippers():  Left  Leader TCGU01A24Z0021m
                  Right Leader TCGU01A24Z0024m
tactiles: left {GSPS01A28Z0005, GSPS01A28Z0006}  right {GSPS01A28Z0011, GSPS01A28Z0012}
wrist:    left XCA24Z0021m   right XCA24Z0024m
```

**Not verified:** `conda_environment.yaml` is shared with the native install, so an environment built by `setup_env.sh --mamba` also loses conda's CUDA. The reasoning applies there too — torch brings its own, NVENC comes from the driver — but only the Docker path was actually tested. Anyone who needs `nvcc` or GPU tactile inference should add `nvidia::cuda-runtime=12.8` + `nvidia::cudnn` back; `cuda-runtime`, not `cuda-toolkit`, since the compiler and headers are not needed to run anything. The file carries that note.

Pre-existing and untouched: the XenseVR `.deb` postinst exits 127 because it calls `gtk-update-icon-cache` / `update-desktop-database`, which a headless image does not have. Identical in the previous build; the service starts regardless.

## Next

21.4 GB is better but still large for a `docker pull`. The floor now is torch + its CUDA (~6.6 GB) plus the conda environment itself. Publishing to a registry is the follow-up — and for domestic customers a China-based registry will matter far more than another few GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)