### PR TITLE
Bump the TacCap SDK to leader firmware 1.2.1 (no protocol change)

### DIFF
--- a/docker/BUILD_TROUBLESHOOTING_ZH.md
+++ b/docker/BUILD_TROUBLESHOOTING_ZH.md
@@ -157,5 +157,8 @@ lerobot-teleoperate \
 
 最终验证通过：两个夹爪、两个 Pico4 tracker、四个触觉传感器、两个腕部相机、CUDA 和 Rerun 均可正常工作。
 
-> 当前夹爪固件为 `1.1.0.0`，不支持 encoder-max 校准，程序会临时使用
-> `gripper_open_rad=1.7`。这不阻止运行，但后续建议升级固件并重新校准。
+> 该记录写于夹爪固件还是 `1.1.0` 的时候：当时不支持 encoder-max 校准，程序
+> 临时回退到 `gripper_open_rad=1.7`。两台 leader 现已升级到 `1.2.1` 并完成
+> encoder-max 校准，`gripper.pos` 走的是固件里的实测行程，不再走那个回退。
+> 如果连接日志里仍出现 `Firmware encoder-max calibration unavailable …`，
+> 说明该台没校准过，按 `taccap_gripper/README.md` 的"硬件启动流程"补一次。

--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -272,9 +272,10 @@ pre-V2.1 units, and for followers (`Cmd::EncoderMaxCal` is leader-only).
 
 #### If the gripper reports pre-V2.1 firmware
 
-`calibrate.py` exits without changing anything when the unit is older than V2.1
-(leader 1.2.0) — the encoder-max command does not exist there. Since 0.1.7 the
-SDK ships the released images, so flashing no longer needs the firmware source:
+`calibrate.py` exits without changing anything when the unit's command set is
+older than V2.1 (i.e. leader < 1.2.0) — the encoder-max command does not exist
+there. Since 0.1.7 the SDK ships the released images, so flashing no longer
+needs the firmware source:
 
 ```bash
 # Which role is this unit?  The LAST character of the firmware SN decides —
@@ -285,7 +286,7 @@ python -c "from xense.taccap import scan_grippers
 for g in scan_grippers(): print(g.firmware_sn, '->', 'leader' if g.firmware_sn.endswith('m') else 'follower')"
 
 python third_party/taccap-gripper/python/examples/ota_update.py \
-    tc-gu-01-master.bin --side left --target-version 1.2.0.0
+    tc-gu-01-master.bin --side left --target-version 1.2.1
 ```
 
 Naming the image is enough — `ota_update.py` finds it in the SDK's own

--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -225,6 +225,55 @@ twice.
 
 ## Calibration workflow (do once per device)
 
+### 0. What state is a unit already in?
+
+Both questions below — what firmware is on it, and is it calibrated — are
+answered by one command. The name is about fisheye, but `show` prints the
+firmware version and **both** stored calibrations:
+
+```bash
+python third_party/taccap-gripper/python/examples/fisheye_cal.py show --sn TCGU01A28Z0023m
+```
+
+```
+Firmware 1.2.1  (fisheye needs cmd set >= V2.0, encoder-max >= V2.1: leader >= 1.2.0 / follower >= 1.1.0)
+
+Fisheye camera calibration (Cmd 0x2B)
+  not calibrated — firmware returned CalNotSet
+
+Encoder max travel angle (Cmd 0x2C, leader only)
+  max_rad = 1.1582 rad (66.4°)
+```
+
+`max_rad` present means step 1 is done and `gripper.pos` is normalised against
+this unit's real travel; `CalNotSet` there means it still falls back to
+`gripper_open_rad`.
+
+If you only want the version, ask the MCU directly — `scan_grippers()` cannot
+tell you, since `GripperEndpoints` carries `firmware_sn` / `side` / `role` but
+no version, and the C++ `fw_version_str` is not exposed through pybind:
+
+```bash
+python -c "
+from xense.taccap import scan_grippers, LeaderGripper, Cmd
+for ep in scan_grippers():
+    g = LeaderGripper(mcu_device=ep.mcu_device)
+    ack = g.transport.send_cmd(Cmd.GetVersion, b'', 500)
+    print(f'{ep.firmware_sn}  {ep.side.name:5}  fw={ack.data[0]}.{ack.data[1]}.{ack.data[2]}')
+"
+```
+
+Opening by `mcu_device` leaves the cameras off and `normalize_position` at its
+default `False`, so this works on an uncalibrated unit — the normalising
+constructor would throw instead.
+
+`Cmd::GetVersion` returns the constant compiled into the running image, not OTA
+bank metadata, so it is proof of what actually landed. Two things it is not:
+`xense.taccap.__version__` is the **SDK** version (`0.1.7`), unrelated to
+firmware; and `ack.data[3]`, the fourth "build" byte, is pinned to 0 and
+meaningless — versions are `MAJOR.MINOR.PATCH` everywhere, so do not write the
+trailing zero into a version comparison.
+
 ### 1. Encoder zero + travel span
 
 The SDK ships the calibration CLI. Select the gripper by side — it resolves the


### PR DESCRIPTION
Tracks the TacCap-Gripper SDK from `16412dc` (`v0.1.0-45`) to `76efa81`
(`v0.1.0-49`), after both bench leaders were flashed to 1.2.1 over OTA.

## No protocol change

Worth stating up front, because a firmware bump usually implies one here:
`protocol_cmd.h`, `protocol_data.h` and `protocol_frame.h` are byte-identical
to 1.2.0. The command set stays **V2.1** and no SDK API moves, so
`serial_discovery.py`, `common.py` and `taccap_gripper.py` are untouched —
`Cmd::GetSn` (which side discovery depends on) and the encoder-max travel
readout both behave exactly as before.

Leader 1.2.1 / follower 1.1.1 only retune the status LED:

- normal state: solid **white** at brightness 20 (was solid green at 10)
- fault state: blinks at 500 ms (was 1000 ms)
- the key-press LED reactions are disabled

Upgrading is therefore optional as far as the SDK is concerned.

## What this PR actually changes

**Submodule pointer.** `firmware/manifest.json` is regenerated alongside the
images; the OTA role guard identifies them by CRC32, so a stale manifest
silently stops protecting against flashing the wrong role's image. Verified
the shipped leader image hashes to the new `0xEC491CBD`.

**Version formatting propagated into our docs.** The SDK now presents versions
as `MAJOR.MINOR.PATCH` everywhere. The fourth "build" byte is pinned to 0 and
carries no meaning, so printing `1.2.1.0` only invited people to type the
trailing zero into version comparisons. It is still on the wire and readable
as `FirmwareVersion::build`. Accordingly:

- `taccap_gripper/README.md` — the OTA example now says `--target-version
  1.2.1`. (`--target-version` still accepts the legacy four-part form, so
  nobody's existing scripts break.)
- Same file — "older than V2.1 (leader 1.2.0)" read as if 1.2.0 were an exact
  requirement; now "command set older than V2.1 (i.e. leader < 1.2.0)".

**A stale bench note.** `docker/BUILD_TROUBLESHOOTING_ZH.md` claimed the
firmware was `1.1.0.0` with no encoder-max support, so `gripper.pos` fell back
to `gripper_open_rad=1.7`. Both leaders are now on 1.2.1 **and** calibrated
(travel 1.1582 / 1.1486 rad; the flash-persisted encoder zero and IMU survived
the bank swap), so that fallback no longer applies. The note is dated rather
than deleted, and now names the log line that means a unit still needs
calibrating.

## Verification

- Native extension rebuilt — `cpp/src/protocol/codec.cpp` gained
  `version_string()`, so the previously built `.so` was stale.
- `pytest tests/` → **573 passed, 13 skipped**.

## Note for anyone pulling this locally

Run `git submodule update --init --recursive` and **rebuild the extension**
(`uv pip install -e third_party/taccap-gripper --no-deps
--no-build-isolation`) — the C++ side changed, so an unrebuilt `.so` will keep
printing four-part versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)