### PR TITLE
feat(docker): publish the image to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,163 @@
+# Copyright 2026 The XenseRobotics Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Builds docker/Dockerfile.user and publishes it to GHCR.
+#
+# Never on pull_request: the image is ~21 GB and takes the better part of an
+# hour to build, and publishing needs `packages: write`, which a fork PR must
+# not get. Releases go through the `v*` tag push; everything else is manual.
+name: Docker Publish
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (default: the fork version from pyproject.toml)'
+        required: false
+        type: string
+      push_latest:
+        description: 'Also move the `latest` tag to this build'
+        required: false
+        default: true
+        type: boolean
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  # Not cancel-in-progress: a cancelled build wastes up to an hour and can
+  # leave the registry cache half-written.
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  build-and-push:
+    name: Build and push to GHCR
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Free up disk space
+        # A standard hosted runner documents ~14 GB of free SSD on /, and this
+        # image is 21.4 GB unpacked. Two things buy the room: deleting the
+        # preinstalled toolchains nothing here uses, and moving the Docker /
+        # BuildKit state onto /mnt, the runner's large ephemeral disk.
+        run: |
+          set -euxo pipefail
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /opt/hostedtoolcache
+          sudo systemctl stop docker.socket docker
+          sudo mkdir -p /mnt/docker
+          printf '{\n  "data-root": "/mnt/docker"\n}\n' | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker
+          docker info --format 'Docker root dir: {{.DockerRootDir}}'
+          df -h / /mnt
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          # Unlike tests.yml, which skips them on purpose, the image build needs
+          # the vendor SDKs: Dockerfile.user bind-mounts the build context and
+          # fails immediately if third_party/taccap-gripper and
+          # third_party/XenseVR-PC-Service are absent, and setup_env.sh compiles
+          # both from source. Both submodules are public HTTPS checkouts, so
+          # they clone without credentials.
+          submodules: recursive
+
+      - name: Resolve image name and tag
+        id: resolve
+        env:
+          # Passed through env rather than interpolated into the script: a
+          # `${{ inputs.tag }}` inside run: is a shell injection site.
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${INPUT_TAG}" ]]; then
+              tag="${INPUT_TAG}"
+          elif [[ "${REF_TYPE}" == "tag" ]]; then
+              tag="${REF_NAME#v}"
+          else
+              # pyproject.toml carries `version = "0.5.1+xtac.<fork version>"`.
+              # A Docker tag cannot contain `+`, so take the fork version alone.
+              # docker/push_ghcr.sh derives it the same way — keep them in step.
+              tag="$(sed -n 's/^version *= *".*+xtac\.\([^"]*\)"/\1/p' pyproject.toml)"
+          fi
+          [[ -n "${tag}" ]] || { echo "Could not resolve an image tag" >&2; exit 1; }
+          # A registry reference has to be lowercase and the account is
+          # `Vertax42`. metadata-action lowercases its own `images` input, but
+          # the buildcache refs below are passed to buildx verbatim.
+          image="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/xense-taccap-lerobot"
+          {
+              echo "tag=${tag}"
+              echo "image=${image}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "Publishing ${image}:${tag}"
+
+      - name: Collect image metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ steps.resolve.outputs.image }}
+          tags: |
+            type=raw,value=${{ steps.resolve.outputs.tag }}
+            type=raw,value=latest,enable=${{ github.event_name != 'workflow_dispatch' || inputs.push_latest }}
+            type=sha,format=long
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: docker/Dockerfile.user
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Keep the published artifact a plain single-architecture manifest.
+          # With provenance on, buildx pushes an image index instead, and the
+          # delivery path (docker save -> docker load -> compose) has no use for
+          # the attestation while some tooling mishandles the extra layer of
+          # indirection.
+          provenance: false
+          # Registry cache, not type=gha: the GitHub Actions cache is capped at
+          # 10 GB per repository and the setup_env.sh layer alone is 9.47 GB.
+          # This mostly buys back the apt and conda layers, which only change
+          # when conda_environment.yaml does.
+          cache-from: type=registry,ref=${{ steps.resolve.outputs.image }}:buildcache
+          cache-to: type=registry,ref=${{ steps.resolve.outputs.image }}:buildcache,mode=min
+
+      - name: Summarize
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          {
+              echo "### Pushed to GHCR"
+              echo
+              echo "Digest: \`${DIGEST}\`"
+              echo
+              echo '```'
+              echo "${TAGS}"
+              echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ training scripts) refer to the
 > **Docker users:** a complete GPU + hardware-SDK image and Compose setup are
 > available in [`docker/README.md`](docker/README.md). It is the quickest way to
 > give an end user a reproducible environment; the host still needs NVIDIA
-> Container Toolkit and the udev rules documented below.
+> Container Toolkit and the udev rules documented below. The image is published
+> to `ghcr.io/vertax42/xense-taccap-lerobot` as a **private** package — see
+> [the GHCR section](docker/README.md#3-从-ghcr-拉取镜像在线交付) for how to log
+> in and pull it.
 
 Tested on Ubuntu 22.04, NVIDIA driver ≥ 570.144. Use
 [`Mamba`](https://github.com/conda-forge/miniforge?tab=readme-ov-file#install)

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,10 @@ name: xense-taccap-lerobot
 
 services:
   xense-taccap:
-    image: xense-taccap-lerobot:${LEROBOT_IMAGE_TAG:-latest}
+    # The default is the local build, so `docker compose build` and
+    # docker/package_customer_delivery.sh keep matching. Set LEROBOT_IMAGE to
+    # ghcr.io/<owner>/xense-taccap-lerobot in .env to pull from GHCR instead.
+    image: ${LEROBOT_IMAGE:-xense-taccap-lerobot}:${LEROBOT_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.user

--- a/docker/README.md
+++ b/docker/README.md
@@ -86,7 +86,64 @@ xhost +si:localuser:root
 xhost -si:localuser:root
 ```
 
-## 3. 初始化源码并构建
+## 3. 从 GHCR 拉取镜像（在线交付）
+
+镜像同时发布在 GitHub Container Registry：
+
+```text
+ghcr.io/vertax42/xense-taccap-lerobot
+```
+
+该包是 **private** 的。镜像内含 XenseSDK、XenseVR-PC-Service、TacCap-Gripper 的
+二进制产物，仓库开源不代表这些可以公开再分发，所以拉取和推送都需要凭据。
+
+第 2 节的 tar 交付方式**继续保留**：客户机完全离线时仍然只能走 tar。GHCR 的价值在
+后续升级 —— 21 GB 里绝大部分是 conda 层和 SDK 层，版本迭代时客户只需要拉变动的
+几层，而不是重新搬一遍整包。
+
+### 客户侧拉取
+
+先用一个仅有 `read:packages` 权限的 classic PAT 登录（在
+<https://github.com/settings/tokens> 创建）：
+
+```bash
+echo "$GHCR_TOKEN" | docker login ghcr.io -u <你的 GitHub 用户名> --password-stdin
+```
+
+然后在交付目录（或仓库根目录）的 `.env` 里指向 GHCR：
+
+```dotenv
+LEROBOT_IMAGE=ghcr.io/vertax42/xense-taccap-lerobot
+LEROBOT_IMAGE_TAG=0.0.3
+```
+
+`compose.yaml` 默认仍是本地构建的 `xense-taccap-lerobot`，只有设置了
+`LEROBOT_IMAGE` 才改为从 GHCR 拉取。之后照常：
+
+```bash
+docker compose pull
+docker compose run --rm xense-taccap
+```
+
+### 维护者侧推送
+
+推荐走 GitHub Actions（在托管 runner 上构建并推送，不占用本机上行带宽）：
+
+- 仓库 Actions 页面手动触发 **Docker Publish**（`workflow_dispatch`），
+  tag 留空则取 `pyproject.toml` 里 `+xtac.` 之后的版本号；
+- 或推一个 `v*` git tag 自动触发。
+
+需要推送**本机已经构建并验证过**的镜像时，用脚本：
+
+```bash
+export GHCR_TOKEN=<classic PAT，需要 write:packages>
+./docker/push_ghcr.sh 0.0.3
+```
+
+不传参数时同样从 `pyproject.toml` 推导 tag；默认连带推 `latest`，用 `--no-latest`
+关闭。镜像很大，脚本内置了推送重试 —— `docker push` 按层续传，重试不会从头再来。
+
+## 4. 初始化源码并构建
 
 镜像会编译三个硬件 SDK，因此构建前必须拉取 git submodule：
 
@@ -100,7 +157,7 @@ docker compose build
 Dockerfile 已包含 apt/curl 自动重试、CUDA 12.8 构建期覆盖和 flexible channel
 priority，不再需要使用临时 `sed` 命令修改构建过程。
 
-## 4. 启动与验证
+## 5. 启动与验证
 
 进入容器：
 
@@ -130,7 +187,7 @@ lerobot-info
 docker compose run --rm xense-taccap lerobot-info
 ```
 
-## 5. 数据、缓存与 GUI
+## 6. 数据、缓存与 GUI
 
 LeRobot 数据根目录 `HF_LEROBOT_HOME` 已设为 `/data/lerobot`，Hugging Face
 和 Torch 缓存也使用 Docker volume，删除容器不会丢失：
@@ -172,7 +229,7 @@ START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap
 
 服务日志默认位于容器内 `/tmp/xensevr-service.log`。
 
-## 6. 常见问题
+## 7. 常见问题
 
 - `Missing git submodules`：在仓库根目录执行
   `git submodule update --init --recursive` 后重新构建。
@@ -186,6 +243,8 @@ START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap
 - 找不到 GSPS，但宿主机存在：确认容器通过 Compose 启动，并检查
   `ls /dev/v4l/by-id/*GSPS*`；必要时重新插拔 USB Hub 后执行
   `sudo udevadm settle --timeout=20`。
+- `docker compose pull` 报 `denied` 或 `unauthorized`：GHCR 上的包是 private，
+  确认已 `docker login ghcr.io`，且 PAT 带 `read:packages`（推送需要 `write:packages`）。
 - 构建需要离线/定制的 vendor wheel 或 `.deb`：先按 `setup_env.sh` 支持的
   `XENSESDK_WHEEL` / `XENSEVR_DEB` 方式将安装物纳入构建上下文，再定制 Dockerfile；
   默认镜像从项目规定的公开发布地址下载。

--- a/docker/push_ghcr.sh
+++ b/docker/push_ghcr.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pushes a locally built xense-taccap-lerobot image to GHCR.
+#
+# The normal publishing path is .github/workflows/docker-publish.yml, which
+# builds on a hosted runner and uploads over GitHub's own network. This script
+# is the manual route: it pushes an image that is already on this machine,
+# which is what you want when the workflow is unavailable or when the image you
+# want published is the one you just validated against real hardware.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCAL_REPOSITORY="${XENSE_IMAGE_REPOSITORY:-xense-taccap-lerobot}"
+REGISTRY="${GHCR_REGISTRY:-ghcr.io}"
+PUSH_LATEST=1
+IMAGE_TAG=""
+
+log() {
+  printf '[push_ghcr] %s\n' "$*"
+}
+
+fail() {
+  printf '[push_ghcr] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+usage() {
+  cat <<'EOF'
+Usage: ./docker/push_ghcr.sh [IMAGE_TAG] [--no-latest]
+
+Pushes the local image xense-taccap-lerobot:<IMAGE_TAG> to GHCR as
+ghcr.io/<owner>/xense-taccap-lerobot:<IMAGE_TAG>.
+
+IMAGE_TAG defaults to LEROBOT_IMAGE_TAG, then to the fork version in
+pyproject.toml (the part after `+xtac.`).
+
+Options:
+  --no-latest              Do not also push the `latest` tag
+
+Environment:
+  GHCR_TOKEN               GitHub token used to log in (falls back to
+                           GITHUB_TOKEN; skipped entirely if already logged in)
+  GHCR_USER                Login username (default: the owner below)
+  GHCR_OWNER               GHCR namespace (default: parsed from `origin`)
+  GHCR_IMAGE               Full target repository, overriding registry/owner
+  GHCR_REGISTRY            Registry host (default: ghcr.io)
+  XENSE_IMAGE_REPOSITORY   Local image name (default: xense-taccap-lerobot)
+  GHCR_PUSH_RETRIES        Push attempts per tag (default: 3)
+EOF
+}
+
+# Mirrors the tag resolution in .github/workflows/docker-publish.yml. Keep the
+# two in step: a Docker tag cannot contain `+`, so the PEP 440 local version
+# `0.5.1+xtac.0.0.3` publishes as `0.0.3`.
+derive_tag_from_pyproject() {
+  sed -n 's/^version *= *".*+xtac\.\([^"]*\)"/\1/p' "${ROOT_DIR}/pyproject.toml"
+}
+
+# GHCR namespaces are lowercase, but the GitHub account (`Vertax42`) is not, so
+# a reference built from the remote URL verbatim is rejected at push time.
+resolve_owner() {
+  local url owner
+  url="$(git -C "${ROOT_DIR}" remote get-url origin 2>/dev/null || true)"
+  [[ -n "${url}" ]] || fail "No git remote 'origin'; set GHCR_OWNER or GHCR_IMAGE."
+  owner="${url##*github.com}"
+  owner="${owner#[:/]}"
+  owner="${owner%%/*}"
+  [[ -n "${owner}" ]] || fail "Could not parse an owner from origin: ${url}"
+  printf '%s' "${owner,,}"
+}
+
+registry_login() {
+  local token="${GHCR_TOKEN:-${GITHUB_TOKEN:-}}"
+
+  if [[ -z "${token}" ]]; then
+    # Someone who ran `docker login ghcr.io` earlier does not need a token in
+    # the environment, so check the stored credential before refusing.
+    if grep -q "\"${REGISTRY}\"" "${HOME}/.docker/config.json" 2>/dev/null; then
+      log "Using the existing ${REGISTRY} credential from docker login."
+      return
+    fi
+    fail "$(
+      cat <<EOF
+No GHCR credential. Either run \`docker login ${REGISTRY}\` first, or export a
+token:
+
+  export GHCR_TOKEN=<classic PAT with the write:packages scope>
+
+Create one at https://github.com/settings/tokens (classic). Fine-grained tokens
+need the 'Packages: write' permission on the package's owner.
+EOF
+    )"
+  fi
+
+  log "Logging in to ${REGISTRY} as ${GHCR_USER}"
+  printf '%s' "${token}" | docker login "${REGISTRY}" --username "${GHCR_USER}" --password-stdin
+}
+
+push_tag() {
+  local ref="$1"
+  local attempts="${GHCR_PUSH_RETRIES:-3}"
+  local attempt=1
+
+  # This image is over 20 GB unpacked, so a push from a slow uplink flaking
+  # part-way through is routine rather than exceptional. Docker re-pushes only
+  # the layers that did not land, so a retry resumes rather than restarts.
+  until docker push "${ref}"; do
+    if [[ "${attempt}" -ge "${attempts}" ]]; then
+      fail "docker push ${ref} failed after ${attempt} attempts"
+    fi
+    log "Push attempt ${attempt} failed; retrying ${ref}"
+    attempt=$((attempt + 1))
+    sleep 10
+  done
+}
+
+main() {
+  local arg
+  for arg in "$@"; do
+    case "${arg}" in
+      -h | --help)
+        usage
+        return
+        ;;
+      --no-latest)
+        PUSH_LATEST=0
+        ;;
+      -*)
+        fail "Unknown option: ${arg}"
+        ;;
+      *)
+        [[ -z "${IMAGE_TAG}" ]] || fail "Unexpected extra argument: ${arg}"
+        IMAGE_TAG="${arg}"
+        ;;
+    esac
+  done
+
+  require_command docker
+  require_command git
+
+  [[ -n "${IMAGE_TAG}" ]] || IMAGE_TAG="${LEROBOT_IMAGE_TAG:-}"
+  [[ -n "${IMAGE_TAG}" ]] || IMAGE_TAG="$(derive_tag_from_pyproject)"
+  [[ -n "${IMAGE_TAG}" ]] || fail "Could not resolve an image tag; pass one explicitly."
+
+  local owner target_repository local_ref
+  owner="${GHCR_OWNER:-$(resolve_owner)}"
+  target_repository="${GHCR_IMAGE:-${REGISTRY}/${owner}/${LOCAL_REPOSITORY}}"
+  GHCR_USER="${GHCR_USER:-${owner}}"
+  local_ref="${LOCAL_REPOSITORY}:${IMAGE_TAG}"
+
+  # Same two preflight checks as package_customer_delivery.sh: the image has to
+  # exist locally, and it has to be the amd64 build the Dockerfile enforces.
+  docker image inspect "${local_ref}" >/dev/null 2>&1 ||
+    fail "Docker image not found: ${local_ref}. Build it first with \`docker compose build\`."
+
+  local image_arch
+  image_arch="$(docker image inspect --format '{{.Architecture}}' "${local_ref}")"
+  [[ "${image_arch}" == "amd64" ]] || fail "Expected an amd64 image, got: ${image_arch}"
+
+  registry_login
+
+  local refs=("${target_repository}:${IMAGE_TAG}")
+  if [[ "${PUSH_LATEST}" -eq 1 && "${IMAGE_TAG}" != "latest" ]]; then
+    refs+=("${target_repository}:latest")
+  fi
+
+  local ref
+  for ref in "${refs[@]}"; do
+    log "Tagging ${local_ref} -> ${ref}"
+    docker tag "${local_ref}" "${ref}"
+    log "Pushing ${ref} (this uploads several GB on a first push)"
+    push_tag "${ref}"
+  done
+
+  local digest
+  digest="$(docker image inspect --format '{{index .RepoDigests 0}}' "${target_repository}:${IMAGE_TAG}" 2>/dev/null || true)"
+  log "Pushed:"
+  for ref in "${refs[@]}"; do
+    log "  ${ref}"
+  done
+  if [[ -n "${digest}" ]]; then
+    log "Digest: ${digest}"
+  fi
+  log "Customers pull it by putting this in the delivery directory's .env:"
+  log "  LEROBOT_IMAGE=${target_repository}"
+  log "  LEROBOT_IMAGE_TAG=${IMAGE_TAG}"
+}
+
+main "$@"


### PR DESCRIPTION
## 为什么

镜像此前没有任何 registry 分发路径：`compose.yaml` 里是个纯本地 tag，交付只能靠 `docker save` 搬 21.4 GB 的 tar 再 `docker load`。首次安装没问题，但每次升级都要重搬一遍整包 —— 而镜像的分层（`setup_env.sh` 9.47 GB + conda 3.21 GB + `COPY .` 776 MB）决定了客户其实只需要拉变动的那几层。

现有 tar 交付流程**原样保留**，完全离线的客户仍然只能走它。

## 改了什么

**两条发布路径**，因为它们的失败方式不同：

- `.github/workflows/docker-publish.yml` — 托管 runner 构建并推送。`workflow_dispatch` 手动触发或 `v*` tag 自动触发；**不挂 `pull_request`**，fork PR 不能拿到 `packages: write`。第一步删掉预装的无用工具链并把 docker `data-root` 挪到 `/mnt`（标准 runner 文档标称 `/` 只有 ~14 GB 可用，镜像 21.4 GB），然后打印 `df -h`，将来磁盘不够时是看得见的失败而不是一团迷雾。与 `tests.yml` 相反，这里必须 `submodules: recursive`：`Dockerfile.user` 会检查两个 vendor SDK，`setup_env.sh` 要从源码编。
- `docker/push_ghcr.sh` — 推送本机已构建好的镜像，用于 workflow 不可用、或想发布的正是刚在真实硬件上验证过的那个镜像。

两者都从 `pyproject.toml` 的 `+xtac.` 后缀推导 tag（Docker tag 不能含 `+`）。

**包设为 private**：镜像内含 vendor 二进制（xensesdk、XenseVR-PC-Service、`libPXREARobotSDK.so`），仓库开源不代表这些可以公开再分发。

`compose.yaml` 的 image 名加了 `LEROBOT_IMAGE` 覆盖，默认值仍是原来的本地名，`docker compose build` 和 `package_customer_delivery.sh` 继续对得上。

缓存用 registry buildcache 而非 `type=gha` —— GHA cache 每仓库上限 10 GB，装不下 9.47 GB 那层。四个 `docker/*` action 按 commit SHA 钉死（仓库启用了 zizmor）。

## 验证

- pre-commit 全绿（zizmor / check-yaml / prettier / gitleaks）。
- `docker compose config`：默认解析为 `xense-taccap-lerobot:latest`，带 `LEROBOT_IMAGE` 时为 `ghcr.io/vertax42/xense-taccap-lerobot:0.0.3`。
- 脚本三条失败路径实测：镜像不存在、无凭据、未知参数。
- workflow 的 tag 解析本地模拟：分支手动触发 → `0.0.3`，`v0.0.4` tag → `0.0.4`。
- **尚未真实推送过** —— `workflow_dispatch` 需要 workflow 文件先在默认分支上才会出现在 Actions 页面，所以合并后才能跑第一次。

## 合并后需要做的

1. 跑一次 `workflow_dispatch`，盯 `Free up disk space` 那步的 `df -h` 输出。
2. Packages → Package settings 确认 visibility 是 **Private**，Manage Actions access 里本仓库有 Write。
3. 另一台机器 `docker login ghcr.io` + `docker compose pull` 端到端验证。

## 已知风险

`setup_env.sh` 那层未压缩 9.47 GB。若 GHCR 拒收超大层，需要把该 `RUN` 拆开（conda 依赖 / 原生 SDK 分离），本次不预先拆。

🤖 Generated with [Claude Code](https://claude.com/claude-code)