### PR TITLE
fix(taccap): ask the wrist camera for MJPEG so the tactile pair can open

### DIFF
--- a/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
@@ -48,7 +48,6 @@ from __future__ import annotations
 from functools import cached_property
 from typing import Any
 
-from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
 from lerobot.cameras.utils import make_cameras_from_configs
 from lerobot.utils.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
 from lerobot.utils.robot_utils import get_logger
@@ -62,13 +61,13 @@ from ..taccap_gripper.common import (
     HeadSkewMonitor,
     build_head_camera_configs,
     build_tactile_camera_configs,
+    build_wrist_camera_config,
     connect_cameras_parallel,
     disconnect_cameras_parallel,
     open_gripper,
     prewarm_tactile_config_cache,
     read_gripper_normalized,
     read_head_pose,
-    resolve_wrist_camera_path,
     split_camera_read,
     swap_tactile_display_features,
     tactile_camera_output_types,
@@ -219,11 +218,12 @@ class BiTaccapGripper(Robot):
                     raise ValueError(
                         f"No {self._role} wrist camera found for the {side} side (rule: {side} == {parity} sequence)."
                     )
-                configs[f"{side}_wrist"] = OpenCVCameraConfig(
-                    index_or_path=resolve_wrist_camera_path(sn),
+                configs[f"{side}_wrist"] = build_wrist_camera_config(
+                    sn,
                     width=self.config.wrist_camera_width,
                     height=self.config.wrist_camera_height,
                     fps=self.config.wrist_camera_fps,
+                    fourcc=self.config.wrist_camera_fourcc,
                 )
 
         if self.config.enable_head_camera:

--- a/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
@@ -168,6 +168,14 @@ class BiTaccapGripperConfig(RobotConfig):
     wrist_camera_height: int = 480
     wrist_camera_fps: int = 30
 
+    wrist_camera_fourcc: str | None = "MJPG"
+    """Pixel format to negotiate with both wrist cameras. Defaults to MJPEG
+    because the alternative OpenCV would pick on its own (YUYV) reserves enough
+    USB isochronous bandwidth to starve the tactile sensors sharing that
+    gripper's hub — see ``build_wrist_camera_config``. Doubly so here: a bimanual
+    rig runs six UVC devices, three per gripper hub. ``None`` leaves the choice
+    to OpenCV; ``"YUYV"`` forces the uncompressed stream."""
+
     # ---- Pico head camera ---------------------------------------------------
     enable_head_camera: bool = False
     """Stream the headset's stereo camera as ``left_head`` /

--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -223,6 +223,38 @@ twice.
 > Revert by deleting the rule file and reloading. (Alternatively, on a dedicated
 > robot PC with no cellular modem: `sudo systemctl disable --now ModemManager`.)
 
+> **`Cannot open camera N` on one tactile sensor (USB bandwidth).** One gripper
+> hub carries **three** UVC devices — two tactile sensors plus the wrist camera —
+> behind a single xHCI root port, and a root port has only ~384 Mbit/s of
+> isochronous budget. An uncompressed YUYV 640x480@30 stream is ~147 Mbit/s of
+> data and reserves a top altsetting (~196 Mbit/s), so three of them overrun the
+> port: whichever camera opens last dies with
+> `ConnectionError: Failed to connect to XenseTactileCamera(GSPS…). Error: Cannot
+open camera N`, even though its `/dev/video*` node is present and
+> `find_cameras()` lists it. Which sensor loses is a race, so the failure moves
+> between runs. The tell is in `dmesg`:
+>
+> ```
+> usb 1-11.2: Not enough bandwidth for new device state.
+> usb 1-11.2: Not enough bandwidth for altsetting 6
+> ```
+>
+> This is **not** the ModemManager problem above (that one is the gripper's
+> serial port, not a camera) and not a bad cable. The wrist camera defaults to
+> `wrist_camera_fourcc="MJPG"` for exactly this reason — left to itself OpenCV's
+> V4L2 backend prefers YUYV. If a rig still overruns after that, measure before
+> changing anything else: run it and read the negotiated endpoints with
+>
+> ```bash
+> sudo grep -E "^(T:|I:.*Video|E:.*Isoc)" /sys/kernel/debug/usb/devices
+> ```
+>
+> Each video interface's `Alt=` and its `E:` line's `MxPS=` give the reservation
+> (`MxPS × 8000 × 8` bit/s); sum them per root port and compare against ~384
+> Mbit/s. The next lever is the tactile side — `raw_size` down to `(320, 240)`
+> quarters its bandwidth, but the sensor's rectify calibration is made at
+> 640x480, so verify the tactile output before recording with it.
+
 ## Calibration workflow (do once per device)
 
 ### 0. What state is a unit already in?

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -35,6 +35,7 @@ from typing import Any
 
 import numpy as np
 
+from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
 from lerobot.cameras.xense.configuration_xense import XenseTactileCameraConfig
 
 # 6D rotation convention (matches ``vive_tracker``): r1..r3 is the first column
@@ -54,6 +55,7 @@ __all__ = [
     "HeadSkewMonitor",
     "build_head_camera_configs",
     "build_tactile_camera_configs",
+    "build_wrist_camera_config",
     "connect_cameras_parallel",
     "disconnect_cameras_parallel",
     "open_gripper",
@@ -88,6 +90,36 @@ def resolve_wrist_camera_path(serial: str) -> str:
     if len(matches) > 1:
         raise RuntimeError(f"Multiple wrist cameras match serial {serial!r}: {matches}. Use a more specific serial.")
     return matches[0]
+
+
+def build_wrist_camera_config(
+    serial: str, *, width: int, height: int, fps: int, fourcc: str | None
+) -> OpenCVCameraConfig:
+    """``OpenCVCameraConfig`` for one gripper's wrist UVC camera.
+
+    Lives here for the same reason the tactile and head builders do: the single
+    and bimanual robots differ only in the observation key they file the result
+    under (``wrist_cam`` vs ``{side}_wrist``), and this was the one camera whose
+    construction they each carried a copy of.
+
+    ``fourcc`` matters more than it looks. Left at ``None``, OpenCV's V4L2
+    backend picks the format itself, and its preference order puts YUYV ahead of
+    MJPEG — so a 640x480@30 wrist camera negotiates ~147 Mbit/s of *uncompressed*
+    video and the UVC driver reserves a top isochronous altsetting (~196 Mbit/s)
+    to carry it. A gripper's hub carries three UVC devices (two tactile sensors
+    plus this camera) behind one xHCI root port, and a root port only has ~384
+    Mbit/s of isochronous budget, so three uncompressed streams overrun it: the
+    third ``open()`` fails with ``Not enough bandwidth for altsetting N`` in dmesg,
+    surfacing as a camera that "cannot be opened" even though its ``/dev/video*``
+    node is right there. MJPEG is what buys the headroom back.
+    """
+    return OpenCVCameraConfig(
+        index_or_path=resolve_wrist_camera_path(serial),
+        width=width,
+        height=height,
+        fps=fps,
+        fourcc=fourcc,
+    )
 
 
 # ------------------------------------------------------------ tactile pre-warm

--- a/src/lerobot/robots/taccap_gripper/config_taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/config_taccap_gripper.py
@@ -167,6 +167,14 @@ class TaccapGripperConfig(RobotConfig):
     wrist_camera_height: int = 480
     wrist_camera_fps: int = 30
 
+    wrist_camera_fourcc: str | None = "MJPG"
+    """Pixel format to negotiate with the wrist camera. Defaults to MJPEG
+    because the alternative OpenCV would pick on its own (YUYV) reserves enough
+    USB isochronous bandwidth to starve the tactile sensors sharing this
+    gripper's hub — see ``build_wrist_camera_config``. ``None`` leaves the choice
+    to OpenCV; ``"YUYV"`` forces the uncompressed stream, which is lossless but
+    only fits when few enough cameras share the USB root port."""
+
     # ---- Pico head camera ---------------------------------------------------
     enable_head_camera: bool = False
     """Stream the headset's stereo camera as ``left_head`` /

--- a/src/lerobot/robots/taccap_gripper/taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/taccap_gripper.py
@@ -49,7 +49,6 @@ from __future__ import annotations
 from functools import cached_property
 from typing import Any
 
-from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
 from lerobot.cameras.utils import make_cameras_from_configs
 from lerobot.utils.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
 from lerobot.utils.robot_utils import get_logger
@@ -63,13 +62,13 @@ from .common import (
     HeadSkewMonitor,
     build_head_camera_configs,
     build_tactile_camera_configs,
+    build_wrist_camera_config,
     connect_cameras_parallel,
     disconnect_cameras_parallel,
     open_gripper,
     prewarm_tactile_config_cache,
     read_gripper_normalized,
     read_head_pose,
-    resolve_wrist_camera_path,
     split_camera_read,
     swap_tactile_display_features,
     tactile_camera_output_types,
@@ -233,11 +232,12 @@ class TaccapGripper(Robot):
                 raise ValueError(
                     f"No {self._role} wrist camera found for the {side} side (rule: {side} == {parity} sequence)."
                 )
-            configs["wrist_cam"] = OpenCVCameraConfig(
-                index_or_path=resolve_wrist_camera_path(sn),
+            configs["wrist_cam"] = build_wrist_camera_config(
+                sn,
                 width=self.config.wrist_camera_width,
                 height=self.config.wrist_camera_height,
                 fps=self.config.wrist_camera_fps,
+                fourcc=self.config.wrist_camera_fourcc,
             )
 
         if self.config.enable_head_camera:


### PR DESCRIPTION
## The failure

A bimanual rig died at `connect()` with one tactile sensor unopenable:

```
[BiTaccapGripper-default] [error]   Camera 'left_tactile_right' connect failed:
  Failed to connect to XenseTactileCamera(GSPS01A29Z0054).
  Error: Cannot open camera 0. Make sure the sensor is plugged in and the serial number is correct.
```

Everything about it pointed away from the real cause: the node was in `/dev/v4l/by-id`,
discovery had already paired it to the right gripper by USB hub, and
`find_cameras()` listed it with the correct `cam_id`. `dmesg` had the answer:

```
usb 1-11.2: Not enough bandwidth for new device state.
usb 1-11.2: Not enough bandwidth for altsetting 6
```

## Why

One gripper hub carries **three** UVC devices — two tactile sensors plus the wrist
camera — behind a single xHCI root port, and a root port has only ~384 Mbit/s of
isochronous budget. The wrist camera's `OpenCVCameraConfig` never set `fourcc`, so
OpenCV's V4L2 backend picked the format itself, and its preference order puts YUYV
ahead of MJPEG: ~147 Mbit/s of uncompressed video, reserving a top altsetting worth
~196. Three of those overrun the port, and whichever camera opens last loses — so
the failure moves between runs.

## The change

- Default `wrist_camera_fourcc` to `"MJPG"` on both robots. The wrist stream is
  JPEG-encoded on its way to disk anyway, so this moves the encode into the camera
  rather than adding a loss the dataset did not already have. `None` restores
  OpenCV's choice; `"YUYV"` forces uncompressed on a rig with bandwidth to spare.
- Both robots built their wrist `OpenCVCameraConfig` inline, so the parameter would
  have had to be threaded through twice — fold that construction into
  `build_wrist_camera_config` in `common.py`, next to the tactile and head builders
  that were already shared.
- README troubleshooting entry with the bandwidth arithmetic and the
  `/sys/kernel/debug/usb/devices` command for measuring per-port reservations.

## Not covered

The tactile sensors negotiate YUYV too, through the Xense SDK rather than OpenCV,
and are untouched here. If a rig still overruns after this, the next lever is
`raw_size` → `(320, 240)`, which quarters tactile bandwidth — but the rectify
calibration is made at 640x480, so that one needs verification against real tactile
output first.

## Testing

Lint, format, mypy and the rest of pre-commit pass. **Not yet run against hardware** —
the rig that produced the traceback is the place to confirm all six cameras now open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)