### PR TITLE
feat(taccap): tie a recording to the rig that produced it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,24 @@ the **second-to-last digit**: odd → left, even → right (`pico_tracker_side`)
 e.g. `…496G` → `6` → right. Trackers enumerate from the XenseVR PC service at
 connect (pin with `--robot.{left_,right_,}tracker_serial=<SN>` to bypass).
 
+### Dataset provenance — `meta/hardware.json`, not `robot.id`
+
+`--robot.id` is the station label (`taccap_0`, `taccap_1`; one per rig) — it
+reaches the logger prefix, the calibration filename and `str(robot)`, and is
+**not a dataset column** (`LeRobotDataset.create` takes only `robot_type`).
+Unlike upstream's optional `RobotConfig.id` it is **required**: both TacCap
+configs run `validate_robot_id()` in `__post_init__`, so a missing/blank id
+fails at CLI-parse time instead of a rig recording anonymously. Enforced there
+rather than by changing the base dataclass, which is upstream's.
+Identity travels in `meta/hardware.json`, written by `lerobot-record` right
+after `connect()` from `robot.hardware_manifest`: per unit, the gripper's
+**firmware** SN (`Cmd::GetSn`, not `mcu_serial`) plus its tactile serials, each
+tagged with `side` (which gripper), `finger` (which sensor on it) and the
+`observation_key` it feeds. Keep it a separate file — `meta/info.json` is
+upstream's schema and a fork-local key there collides on the next v5.x sync.
+Helpers live in `taccap_gripper/common.py`; a resume against different hardware
+warns and keeps the original file rather than misattributing recorded episodes.
+
 ### On mis-burned / mis-installed hardware
 
 Every discovery helper raises `ValueError` naming the offending hub/serial

--- a/src/lerobot/robots/bi_taccap_gripper/README.md
+++ b/src/lerobot/robots/bi_taccap_gripper/README.md
@@ -156,6 +156,7 @@ Self-driven — **no `--teleop`**. Prerequisite: `xense.taccap` importable in th
 ```bash
 lerobot-teleoperate \
     --robot.type=bi_taccap_gripper \
+    --robot.id=taccap_0 \
     --fps=30 \
     --display_data=true
 ```
@@ -167,6 +168,7 @@ add `--robot.enable_tracker=false` to record tactile + gripper only:
 ```bash
 lerobot-record \
     --robot.type=bi_taccap_gripper \
+    --robot.id=taccap_0 \
     --robot.enable_head_camera=true \
     --dataset.repo_id=Xense/<dataset_name> \
     --dataset.single_task="Pick up the cube" \
@@ -180,6 +182,15 @@ lerobot-record \
 The head camera shares the XenseVR SDK connection with the Pico4 trackers, so the
 headset app must be running and streaming before enabling it. Turning the camera off
 does not drop the trackers' connection, and vice versa.
+
+`--robot.id` is a **required station label** (`taccap_0`, `taccap_1`, … — one per rig,
+and this bimanual rig is one rig): the config rejects a missing or blank one at
+CLI-parse time, before any device is touched. It is not a dataset column. What is
+recorded instead is `meta/hardware.json`, written at connect: each unit's gripper
+firmware SN plus the two tactile serials on that gripper, keyed by `side` (which
+gripper) and `finger` (which sensor on it) and carrying the observation key each sensor
+feeds. See
+[`../taccap_gripper/README.md`](../taccap_gripper/README.md#--robotid-required-and-the-hardware-manifest).
 
 ## 3D trajectory visualization
 

--- a/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
@@ -60,11 +60,13 @@ from ..taccap_gripper.common import (
     POSE_KEYS,
     GripperReadGuard,
     HeadSkewMonitor,
+    build_hardware_manifest,
     build_head_camera_configs,
     build_tactile_camera_configs,
     build_wrist_camera_config,
     connect_cameras_parallel,
     disconnect_cameras_parallel,
+    hardware_manifest_unit,
     open_gripper,
     prewarm_tactile_config_cache,
     read_head_pose,
@@ -116,7 +118,7 @@ class BiTaccapGripper(Robot):
     def __init__(self, config: BiTaccapGripperConfig):
         super().__init__(config)
         self.config = config
-        self.logger = get_logger(f"BiTaccapGripper-{config.id or 'default'}")
+        self.logger = get_logger(f"BiTaccapGripper-{config.id}")
         self._role = disco.normalize_role(config.role)
 
         any_gripper = any(getattr(config, f"{s}_enable_gripper") for s in _SIDES)
@@ -160,7 +162,7 @@ class BiTaccapGripper(Robot):
                 {s: getattr(config, f"{s}_tracker_serial") for s in _SIDES},
                 lambda: Pico4TrackerReader.list_serial_numbers(
                     device_wait_timeout=config.tracker_wait_timeout,
-                    logger_name=config.id or "bi",
+                    logger_name=config.id,
                 ),
             )
             self.logger.info(f"Pico4 trackers: {self._tracker_sn_by_side}")
@@ -190,6 +192,9 @@ class BiTaccapGripper(Robot):
         """
         n_exp = self.config.tactiles_per_side
         tactiles = disco.discover_tactiles_by_hub(self._role) if n_exp else {"left": {}, "right": {}}
+        # Kept for ``hardware_manifest``: the camera configs downstream carry the
+        # serials too, but only as an opaque field of each backend's config.
+        self._disc_tactiles = tactiles
         want_wrist = any(getattr(self.config, f"{s}_enable_wrist_camera") for s in _SIDES)
         cameras = disco.discover_wrist_cameras(self._role) if want_wrist else {}
 
@@ -230,6 +235,32 @@ class BiTaccapGripper(Robot):
         if self.config.enable_head_camera:
             configs.update(build_head_camera_configs(self.config))
         return configs
+
+    @property
+    def hardware_manifest(self) -> dict[str, Any]:
+        """Which physical devices this rig is, for the recording to carry along.
+
+        Read it **while connected**: the gripper serials are the firmware SNs
+        read over the wire at ``connect()``, and ``_release()`` drops the
+        endpoints again, so before/after they come out ``None``. Tactile serials
+        come from construction-time discovery and are always there.
+
+        ``--robot.id`` is only a station label; this is the identity.
+        """
+        return build_hardware_manifest(
+            robot_type=self.name,
+            robot_id=self.id,
+            role=self._role,
+            units=[
+                hardware_manifest_unit(
+                    side,
+                    endpoints=self._endpoints[side],
+                    tactile_serials=self._disc_tactiles.get(side, {}),
+                    key_prefix=f"{side}_",
+                )
+                for side in _SIDES
+            ],
+        )
 
     # ------------------------------------------------------------------ schema
 
@@ -408,7 +439,7 @@ class BiTaccapGripper(Robot):
                     tracker_to_ee_pos=ee_pos,
                     tracker_to_ee_quat=ee_quat,
                     device_wait_timeout=self.config.tracker_wait_timeout,
-                    logger_name=f"{self.config.id or 'bi'}-{side}",
+                    logger_name=f"{self.config.id}-{side}",
                 )
                 # No init-pose alignment — see the note in the config module.
                 tracker.connect()

--- a/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
@@ -38,7 +38,7 @@ auto-discover by rule.
 from dataclasses import dataclass, field
 
 from ..config import RobotConfig
-from ..taccap_gripper.common import build_head_camera_configs
+from ..taccap_gripper.common import build_head_camera_configs, validate_robot_id
 
 _SIDES = ("left", "right")
 
@@ -231,6 +231,9 @@ class BiTaccapGripperConfig(RobotConfig):
 
     def __post_init__(self):
         super().__post_init__()
+        # Required here, not left optional as upstream has it — see
+        # ``validate_robot_id``.
+        self.id = validate_robot_id(self.id)
         if self.role.strip().lower() not in (
             "leader",
             "master",

--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -204,7 +204,8 @@ lsusb -t
 
 Each `480M` `root_hub` line is one budget. A bimanual rig puts **six** cameras
 (four tactile + two wrist) on it, plus the laptop's built-in webcam if it has
-one. Two `480M` root_hubs, three cameras each, is comfortable.
+one, and six is more than one bus can carry (measured below). Two `480M`
+root_hubs, three cameras each, is comfortable.
 
 Watch the kernel while you start, in a second terminal:
 
@@ -329,10 +330,11 @@ open camera N`, even though its `/dev/video*` node is present and
 >   compressed format has no meaningful bpp — so it has nothing to work with for
 >   the MJPEG wrist cameras, which are the biggest over-requesters.
 >
-> Until a second controller is fitted, record with the wrist cameras off:
-> tactile, pose and jaw are all still there, but the dataset then has no
-> `{side}_wrist` key, so decide before recording rather than mixing two
-> incompatible observation schemas.
+> The fix is a second USB host controller — see
+> [Step 2](#step-2--check-the-usb-bandwidth-budget). Until one is fitted, record
+> with the wrist cameras off: tactile, pose and jaw are all still there, but the
+> dataset then has no `{side}_wrist` key, so decide before recording rather than
+> mixing two incompatible observation schemas.
 
 ## Calibration workflow (do once per device)
 
@@ -535,7 +537,8 @@ record — same flags on `lerobot-record`.
 ## Standalone smoke test
 
 Verifies the robot stack independently of `lerobot-record`. Devices are
-auto-discovered; pass `--side` only when both grippers are connected:
+auto-discovered; pass `--side` only when both grippers are connected. The station
+label the config requires is `--id` here, defaulted to `taccap_0`:
 
 ```bash
 # Gripper + tactile + wrist, all auto-discovered (pick a side if both present):
@@ -574,7 +577,7 @@ are connected, set `--robot.side=left|right`:
 ```bash
 lerobot-record \
     --robot.type=taccap_gripper \
-    --robot.id=right \
+    --robot.id=taccap_0 \
     --robot.side=right \
     --dataset.repo_id=<your_org>/<your_dataset> \
     --dataset.num_episodes=1 \
@@ -650,6 +653,78 @@ reports ready. By the time the first frame is recorded the encoders are hot, so 
 `add_frame()` no longer pays the init cost. The lazy first-frame start remains as a
 defensive fallback for callers that don't pre-warm.
 
+### `--robot.id` (required) and the hardware manifest
+
+Two different things, and they answer two different questions.
+
+**`--robot.id` is the station label**, `taccap_0` / `taccap_1` / …, one per rig (a
+bimanual rig is one rig, one id). It names the _seat_, not the hardware in it, so
+it stays put when a gripper is swapped. It reaches the log prefix, the
+calibration filename, `str(robot)` and the manifest below, but **not a dataset
+column** — `LeRobotDataset.create()` is handed `robot_type` and nothing else.
+
+**It is required**, unlike upstream's optional `RobotConfig.id`. Both TacCap
+configs put it through `validate_robot_id()` in `__post_init__`, so a missing or
+blank id fails at CLI-parse time — before any device is touched — instead of a
+rig spinning up and recording anonymously. That `None` default is also why
+terminal output used to read `None TaccapGripper`. The format itself is not
+policed: the convention is `taccap_<n>`, but identity lives in the serials below,
+so a rig named after a room is allowed. The smoke test takes `--id` and defaults
+it to `taccap_0`.
+
+**The hardware manifest is the identity.** `lerobot-record` writes
+`meta/hardware.json` into the dataset right after `robot.connect()`:
+
+```json
+{
+  "robot_type": "bi_taccap_gripper",
+  "robot_id": "taccap_0",
+  "role": "leader",
+  "units": [
+    {
+      "side": "left",
+      "gripper_sn": "TCGU01A24Z0001m",
+      "tactile_sensors": [
+        {
+          "finger": "left",
+          "observation_key": "left_tactile_left",
+          "serial": "GSPS01A25Z0011"
+        },
+        {
+          "finger": "right",
+          "observation_key": "left_tactile_right",
+          "serial": "GSPS01A25Z0012"
+        }
+      ]
+    }
+  ]
+}
+```
+
+- `side` is which gripper; `finger` is which sensor on it. Both are called
+  left/right and they are **independent** — 单左双右 is applied once to the
+  gripper's own serial and again to each tactile's. Each sensor therefore also
+  carries the `observation_key` it feeds, so a dataset column traces back to a
+  physical sensor without re-deriving the naming rule.
+- `gripper_sn` is the **firmware** SN (`Cmd::GetSn`, read over the wire at
+  connect), never the CH343 `mcu_serial` — that one identifies the USB-serial
+  adapter and changes when the adapter does.
+- The single-arm robot writes the same shape with one entry in `units`, so
+  anything reading these datasets needs one code path, not two.
+- A side whose gripper is off records `"gripper_sn": null` rather than being
+  omitted; `enable_tactile=false` gives it an empty `tactile_sensors`.
+- It is a file of its own, **not** a key in `meta/info.json`: that schema is
+  upstream's and a fork-local key in it would collide on the next v5.x sync.
+- Resuming a dataset on _different_ hardware keeps the original file and warns.
+  The episodes already recorded came from the devices named there, and
+  overwriting would misattribute every one of them — the warning is the signal
+  that the dataset now spans two rigs.
+
+Trackers and wrist cameras are deliberately not in the manifest: they are
+mounted accessories, while the gripper + its two tactiles are the unit whose
+serials the data is about. `hardware_manifest_unit()` in `common.py` is where
+that would change.
+
 ## What gets recorded per frame
 
 Keys are **unprefixed** — unlike [`bi_taccap_gripper`](../bi_taccap_gripper/README.md),
@@ -690,6 +765,9 @@ second column.
 - `taccap_gripper.py` — the `Robot` subclass. `get_observation()` and
   `get_action()` both surface pose + gripper + optional IMU + cameras.
 - `config_taccap_gripper.py` — `RobotConfig` dataclass.
+- `common.py` — everything the single and bimanual robots share, including the
+  hardware-manifest helpers (`hardware_manifest_unit` / `build_hardware_manifest`
+  / `write_hardware_manifest`).
 - `taccap_gripper_example.py` — standalone smoke test (above).
 - `check_tracker.py` — sanity-check the Pico4 tracker (read-only; it calibrates nothing).
 

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -28,9 +28,11 @@ single gripper, ``"[left] "`` for one arm of the bimanual rig.
 from __future__ import annotations
 
 import glob
+import json
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -52,13 +54,16 @@ __all__ = [
     "POSE_KEYS",
     "HEAD_POSE_KEYS",
     "HEAD_CAMERA_KEYS",
+    "HARDWARE_MANIFEST_PATH",
     "GripperReadGuard",
     "HeadSkewMonitor",
+    "build_hardware_manifest",
     "build_head_camera_configs",
     "build_tactile_camera_configs",
     "build_wrist_camera_config",
     "connect_cameras_parallel",
     "disconnect_cameras_parallel",
+    "hardware_manifest_unit",
     "open_gripper",
     "prewarm_tactile_config_cache",
     "read_gripper_normalized",
@@ -69,6 +74,8 @@ __all__ = [
     "swap_tactile_display_features",
     "tactile_camera_output_types",
     "tactile_display_key",
+    "validate_robot_id",
+    "write_hardware_manifest",
 ]
 
 
@@ -720,3 +727,132 @@ def read_gripper_normalized(gripper: Any, open_rad: float) -> float:
     if open_rad <= 0.0:  # guarded in config.__post_init__ but be defensive
         return 0.0
     return float(np.clip(float(sample.position_rad) / open_rad, 0.0, 1.0))
+
+
+# -------------------------------------------------------------------- robot id
+
+
+def validate_robot_id(robot_id: str | None) -> str:
+    """Require ``--robot.id`` and return it stripped.
+
+    Upstream leaves ``RobotConfig.id`` optional, defaulting to ``None`` — which
+    is how terminal output came to read ``None BiTaccapGripper`` and how a run
+    could be recorded with nothing naming the rig it came from. Here it is the
+    station label, and a capture rig that cannot say which station it is is not
+    configured. Enforced in each config's ``__post_init__`` rather than by
+    changing the base dataclass, which belongs to upstream.
+
+    Free-form on purpose: the convention is ``taccap_0`` / ``taccap_1`` / …, but
+    the *identity* of the hardware is the serials in ``meta/hardware.json``, so
+    pinning a format here would buy nothing and would break the first rig named
+    after a room.
+    """
+    if robot_id is None or not robot_id.strip():
+        raise ValueError(
+            "--robot.id is required: the station label for this rig, e.g. "
+            "--robot.id=taccap_0 (taccap_0 / taccap_1 / …, one per rig — a bimanual rig is one rig). "
+            "It names the seat, not the hardware in it, so it stays put when a gripper is swapped; "
+            "the device serials go into the recorded dataset's meta/hardware.json instead."
+        )
+    return robot_id.strip()
+
+
+# ------------------------------------------------------------ hardware manifest
+
+HARDWARE_MANIFEST_PATH = "meta/hardware.json"
+"""Where a recorded dataset keeps its TacCap hardware manifest, relative to the
+dataset root.
+
+Deliberately a file of its own rather than a key in ``meta/info.json``: that
+file's schema belongs to upstream lerobot, and a fork-local key in it would
+collide on the next v5.x sync. ``robot.id`` does not reach the dataset at all
+(``LeRobotDataset.create`` takes only ``robot_type``), so this manifest is the
+only thing tying recorded episodes to the physical devices that produced them.
+"""
+
+
+def hardware_manifest_unit(
+    side: str,
+    *,
+    endpoints: Any,
+    tactile_serials: dict[str, str],
+    key_prefix: str,
+) -> dict[str, Any]:
+    """One TacCap unit's identity: its gripper, and the tactiles on that gripper.
+
+    ``endpoints`` is the unit's ``GripperEndpoints`` (``None`` when the gripper is
+    off, or when the robot is not connected — the SN is read over the wire). The
+    serial recorded is the **firmware** SN (``Cmd::GetSn``), never the CH343
+    ``mcu_serial``: the latter identifies the USB-serial adapter and changes when
+    the adapter does, so it is not the device's identity.
+
+    ``side`` is which gripper the unit is; ``finger`` is which sensor on it. Both
+    are called left/right and they are independent — 单左双右 is applied once to
+    the gripper's own serial and again to each tactile's — so each entry also
+    carries the ``observation_key`` it feeds (``{key_prefix}tactile_{finger}``),
+    letting a dataset column trace back to a physical sensor without re-deriving
+    the naming rule.
+    """
+    return {
+        "side": side,
+        "gripper_sn": getattr(endpoints, "firmware_sn", None) or None,
+        "tactile_sensors": [
+            {
+                "finger": finger,
+                "observation_key": f"{key_prefix}tactile_{finger}",
+                "serial": sn,
+            }
+            for finger, sn in sorted(tactile_serials.items())
+        ],
+    }
+
+
+def build_hardware_manifest(
+    *,
+    robot_type: str,
+    robot_id: str | None,
+    role: str,
+    units: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Wrap per-unit entries into the manifest both TacCap robots emit.
+
+    ``robot_id`` is the station label (``--robot.id``, e.g. ``taccap_0``) and is
+    free to be ``None``; the serials below are the actual identity, and they are
+    what a dataset should be trusted to be traced by.
+    """
+    return {
+        "robot_type": robot_type,
+        "robot_id": robot_id,
+        "role": role,
+        "units": units,
+    }
+
+
+def write_hardware_manifest(root: str | Path, manifest: dict[str, Any], logger: Any) -> Path:
+    """Write ``manifest`` to ``root/meta/hardware.json`` and return the path.
+
+    Written once, when the file is absent. Resuming a dataset with *different*
+    hardware keeps the original file and warns instead of overwriting: the
+    episodes already in the dataset came from the devices named there, and
+    silently replacing them would misattribute every one of them. The warning is
+    the signal that the dataset now spans two rigs.
+    """
+    path = Path(root) / HARDWARE_MANIFEST_PATH
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text())
+        except (OSError, ValueError) as e:
+            logger.warn(f"Could not read the existing hardware manifest {path} ({e}); leaving it alone.")
+            return path
+        if existing != manifest:
+            logger.warn(
+                f"Hardware manifest {path} does not match the devices connected now — this dataset "
+                f"already holds episodes recorded on other hardware. Keeping the original; "
+                f"current: {json.dumps(manifest, sort_keys=True)}"
+            )
+        return path
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2) + "\n")
+    logger.info(f"Hardware manifest written to {path}")
+    return path

--- a/src/lerobot/robots/taccap_gripper/config_taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/config_taccap_gripper.py
@@ -34,7 +34,7 @@ Unity-app launch time.
 from dataclasses import dataclass, field
 
 from ..config import RobotConfig
-from .common import build_head_camera_configs
+from .common import build_head_camera_configs, validate_robot_id
 
 
 @RobotConfig.register_subclass("taccap_gripper")
@@ -233,6 +233,10 @@ class TaccapGripperConfig(RobotConfig):
 
     def __post_init__(self):
         super().__post_init__()
+
+        # Required here, not left optional as upstream has it — see
+        # ``validate_robot_id``.
+        self.id = validate_robot_id(self.id)
 
         if self.enable_head_camera:
             # Delegate to the camera config so there is one definition of what

--- a/src/lerobot/robots/taccap_gripper/taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/taccap_gripper.py
@@ -61,11 +61,13 @@ from .common import (
     POSE_KEYS,
     GripperReadGuard,
     HeadSkewMonitor,
+    build_hardware_manifest,
     build_head_camera_configs,
     build_tactile_camera_configs,
     build_wrist_camera_config,
     connect_cameras_parallel,
     disconnect_cameras_parallel,
+    hardware_manifest_unit,
     open_gripper,
     prewarm_tactile_config_cache,
     read_head_pose,
@@ -116,7 +118,7 @@ class TaccapGripper(Robot):
     def __init__(self, config: TaccapGripperConfig):
         super().__init__(config)
         self.config = config
-        self.logger = get_logger(f"TaccapGripper-{config.id or 'default'}")
+        self.logger = get_logger(f"TaccapGripper-{config.id}")
         self._role = disco.normalize_role(config.role)
 
         # Tactile discovery now pairs sensors to a gripper by USB hub, so it also
@@ -161,7 +163,7 @@ class TaccapGripper(Robot):
                 {self._side: config.tracker_serial},
                 lambda: Pico4TrackerReader.list_serial_numbers(
                     device_wait_timeout=config.tracker_wait_timeout,
-                    logger_name=config.id or "robot",
+                    logger_name=config.id,
                 ),
             )[self._side]
             source = "manual" if (config.tracker_serial or "").strip() else "rule"
@@ -242,6 +244,33 @@ class TaccapGripper(Robot):
         if self.config.enable_head_camera:
             configs.update(build_head_camera_configs(self.config))
         return configs
+
+    @property
+    def hardware_manifest(self) -> dict[str, Any]:
+        """Which physical device this unit is, for the recording to carry along.
+
+        Read it **while connected**: the gripper serial is the firmware SN read
+        over the wire at ``connect()``, and ``_release()`` drops the endpoints
+        again, so before/after it comes out ``None``. Tactile serials come from
+        construction-time discovery and are always there.
+
+        ``--robot.id`` is only a station label; this is the identity. One unit,
+        so one entry in ``units`` — same shape as the bimanual manifest, which
+        keeps anything reading these datasets from needing two code paths.
+        """
+        return build_hardware_manifest(
+            robot_type=self.name,
+            robot_id=self.id,
+            role=self._role,
+            units=[
+                hardware_manifest_unit(
+                    self._side,
+                    endpoints=self._endpoints,
+                    tactile_serials=self._disc_tactiles.get(self._side, {}),
+                    key_prefix="",
+                )
+            ],
+        )
 
     # ------------------------------------------------------------------ schema
 
@@ -413,7 +442,7 @@ class TaccapGripper(Robot):
                 tracker_to_ee_pos=ee_pos,
                 tracker_to_ee_quat=ee_quat,
                 device_wait_timeout=self.config.tracker_wait_timeout,
-                logger_name=self.config.id or "robot",
+                logger_name=self.config.id,
             )
             # No init-pose alignment: poses stay in the world frame and the
             # deployment robot's base is cancelled downstream by the

--- a/src/lerobot/robots/taccap_gripper/taccap_gripper_example.py
+++ b/src/lerobot/robots/taccap_gripper/taccap_gripper_example.py
@@ -13,7 +13,8 @@ Standalone smoke test for TaccapGripper.
 
 The gripper, its tactile sensors and its wrist camera are auto-discovered by
 serial rule — no serials are supplied. Pass ``--side`` only when both grippers
-are connected.
+are connected. ``--robot.id`` is required by the config; here it is ``--id``,
+defaulted to ``taccap_0`` so the smoke test stays a one-liner.
 
 Usage:
     # Gripper + tactile + wrist (auto-discovered); pick a side if both present.
@@ -55,6 +56,11 @@ def main() -> None:
         "--side", default=None, choices=["left", "right"], help="Which gripper (only needed when both are connected)."
     )
     parser.add_argument(
+        "--id",
+        default="taccap_0",
+        help="Station label for this rig (required by the config; the smoke test defaults it).",
+    )
+    parser.add_argument(
         "--role", default="leader", choices=["leader", "follower"], help="Device role to bind (default leader)."
     )
     parser.add_argument("--tracker", action="store_true", help="Enable the Pico4 motion tracker.")
@@ -70,6 +76,7 @@ def main() -> None:
     args = parser.parse_args()
 
     cfg = TaccapGripperConfig(
+        id=args.id,
         side=args.side,
         role=args.role,
         enable_gripper=True,

--- a/src/lerobot/scripts/client_commands.md
+++ b/src/lerobot/scripts/client_commands.md
@@ -6,6 +6,10 @@ and Pico4 motion trackers — are **auto-discovered by serial rule**, so no devi
 are passed on the CLI. The one optional override is the Pico4 tracker serial
 (`--robot.tracker_serial` / `--robot.{left,right}_tracker_serial`); see Teleoperate below.
 
+`--robot.id` **is required** on every command below — the station label for the rig
+(`taccap_0`, `taccap_1`, … one per rig). See
+[`--robot.id` and the hardware manifest](#--robotid-required-and-the-hardware-manifest).
+
 ## Prerequisites
 
 ### Hugging Face CLI login
@@ -52,9 +56,10 @@ drops that view only, leaving the rest of the layout in place, and it auto-skips
 ```bash
 lerobot-teleoperate \
     --robot.type=bi_taccap_gripper \
+    --robot.id=taccap_0 \
     --fps=30 \
     --display_data=true \
-    --robot.enable_tracker=true \
+    --robot.enable_tracker=false \
     --robot.enable_head_camera=false
 ```
 
@@ -107,6 +112,7 @@ stored. `--robot.head_camera_eyes=left` (or `right`) records a single eye.
 ```bash
 lerobot-teleoperate \
     --robot.type=taccap_gripper \
+    --robot.id=taccap_0 \
     --robot.side=left \
     --fps=30 \
     --display_data=true
@@ -118,6 +124,58 @@ lerobot-teleoperate \
 
 Recording is self-driven (`self_driven_record_loop`, shifted-frame: `action[t]` paired with
 `obs[t-1]`) — **no `--teleop`**. Same robot flags as teleop, plus `--dataset.*`.
+
+### `--robot.id` (required) and the hardware manifest
+
+`--robot.id` is a **required station label** — `taccap_0`, `taccap_1`, … one per rig,
+and a bimanual rig is one rig. It names the seat, not the hardware in it, so it
+survives a gripper swap. Upstream leaves it optional; both TacCap configs reject a
+missing or blank one in `__post_init__`, so the run stops at CLI-parse time rather
+than a rig spinning up and recording anonymously:
+
+```
+ValueError: --robot.id is required: the station label for this rig, e.g. --robot.id=taccap_0 …
+```
+
+It reaches the log prefix, the calibration filename and `str(robot)`, and it is copied
+into the manifest below — but it is **not** a dataset column, and `meta/info.json`
+never sees it.
+
+Device identity is carried instead by `meta/hardware.json`, written into the dataset
+right after connect — gripper firmware SN plus the tactile sensors on that gripper,
+each tied to the observation key it feeds:
+
+```json
+{
+  "robot_type": "bi_taccap_gripper",
+  "robot_id": "taccap_0",
+  "role": "leader",
+  "units": [
+    {
+      "side": "left",
+      "gripper_sn": "TCGU01A24Z0001m",
+      "tactile_sensors": [
+        {
+          "finger": "left",
+          "observation_key": "left_tactile_left",
+          "serial": "GSPS01A25Z0011"
+        },
+        {
+          "finger": "right",
+          "observation_key": "left_tactile_right",
+          "serial": "GSPS01A25Z0012"
+        }
+      ]
+    }
+  ]
+}
+```
+
+`side` is which gripper, `finger` is which sensor on it — independent left/rights, hence
+the explicit `observation_key`. `gripper_sn` is the firmware SN read over the wire, not
+the CH343 `mcu_serial`. Single-arm writes the same shape with one entry. Resuming a
+dataset on different hardware keeps the original file and warns rather than overwriting
+it. Details: [`robots/taccap_gripper/README.md`](../robots/taccap_gripper/README.md).
 
 ### Recording with the viewer on — `[slow_frame]`
 
@@ -139,6 +197,7 @@ a different problem from the viewer being expensive.
 ```bash
 lerobot-record \
     --robot.type=bi_taccap_gripper \
+    --robot.id=taccap_0 \
     --robot.enable_head_camera=true \
     --dataset.repo_id=Xense/taccap-g1-test-0722 \
     --dataset.single_task="Pick up the cube" \
@@ -168,6 +227,7 @@ digit). Add `--robot.enable_tracker=false` to record tactile + gripper only — 
 ```bash
 lerobot-record \
     --robot.type=taccap_gripper \
+    --robot.id=taccap_0 \
     --robot.side=left \
     --dataset.repo_id=Xense/<dataset_name> \
     --dataset.single_task="Pick up the cube" \

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -25,6 +25,7 @@ Example (bimanual TacCap-Gripper):
 ```shell
 lerobot-record \
     --robot.type=bi_taccap_gripper \
+    --robot.id=taccap_0 \
     --dataset.repo_id=<my_username>/<my_dataset_name> \
     --dataset.num_episodes=50 \
     --dataset.single_task="Pick up the cube" \
@@ -71,6 +72,7 @@ from lerobot.robots import (  # noqa: F401
     make_robot_from_config,
     taccap_gripper,
 )
+from lerobot.robots.taccap_gripper.common import write_hardware_manifest
 from lerobot.robots.taccap_gripper.visualization import TaccapTrajectoryViz
 from lerobot.teleoperators import (  # noqa: F401
     Teleoperator,
@@ -472,6 +474,18 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
         robot.connect()
         if teleop is not None:
             teleop.connect()
+
+        # Which physical devices produced this dataset. It has to happen here:
+        # the gripper firmware SNs are read over the wire at connect(), and the
+        # dataset itself only stores ``robot_type`` — neither ``robot.id`` nor a
+        # serial reaches meta/info.json, so without this the episodes are not
+        # traceable to a rig at all. Robots that expose no manifest (anything but
+        # TacCap) are skipped.
+        # (asked of the class, not the instance: ``getattr(robot, ...)`` with a
+        # default would also swallow an AttributeError raised *inside* the
+        # property, turning a bug into a silently missing manifest.)
+        if hasattr(type(robot), "hardware_manifest"):
+            write_hardware_manifest(dataset.root, robot.hardware_manifest, logger)
 
         # 3D pose + trajectory overlay (no-op if the device emits no tcp.* poses).
         # The viewer is laid out from display_features when the robot has one —

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -24,6 +24,7 @@ Example (bimanual TacCap-Gripper):
 ```shell
 lerobot-teleoperate \
     --robot.type=bi_taccap_gripper \
+    --robot.id=taccap_0 \
     --fps=30 \
     --display_data=true
 ```

--- a/tests/robots/test_action_features.py
+++ b/tests/robots/test_action_features.py
@@ -77,7 +77,7 @@ def head_keys(features):
 
 class TestSingleArmActionFeatures:
     def _robot(self, **kwargs):
-        return build(TaccapGripper, TaccapGripperConfig(side="left", **kwargs), {"left": "PC1"})
+        return build(TaccapGripper, TaccapGripperConfig(id="taccap_0", side="left", **kwargs), {"left": "PC1"})
 
     def test_head_pose_is_absent_without_the_head_camera(self):
         assert head_keys(self._robot(enable_head_camera=False).action_features) == set()
@@ -110,10 +110,10 @@ class TestEnableTactile:
     """
 
     def _single(self, **kwargs):
-        return build(TaccapGripper, TaccapGripperConfig(side="left", **kwargs), {"left": "PC1"})
+        return build(TaccapGripper, TaccapGripperConfig(id="taccap_0", side="left", **kwargs), {"left": "PC1"})
 
     def _bimanual(self, **kwargs):
-        return build(BiTaccapGripper, BiTaccapGripperConfig(**kwargs), {"left": "PC1", "right": "PC2"})
+        return build(BiTaccapGripper, BiTaccapGripperConfig(id="taccap_0", **kwargs), {"left": "PC1", "right": "PC2"})
 
     @staticmethod
     def _tactile_keys(features):
@@ -137,14 +137,17 @@ class TestEnableTactile:
     def test_the_count_still_applies_when_enabled(self):
         """enable_tactile gates; expected_tactiles_per_side still says how many
         a gripper carries, and discovery still validates against it."""
-        cfg = BiTaccapGripperConfig(expected_tactiles_per_side=2)
+        cfg = BiTaccapGripperConfig(id="taccap_0", expected_tactiles_per_side=2)
         assert cfg.tactiles_per_side == 2
-        assert BiTaccapGripperConfig(enable_tactile=False, expected_tactiles_per_side=2).tactiles_per_side == 0
+        assert (
+            BiTaccapGripperConfig(id="taccap_0", enable_tactile=False, expected_tactiles_per_side=2).tactiles_per_side
+            == 0
+        )
 
 
 class TestBimanualActionFeatures:
     def _robot(self, **kwargs):
-        return build(BiTaccapGripper, BiTaccapGripperConfig(**kwargs), {"left": "PC1", "right": "PC2"})
+        return build(BiTaccapGripper, BiTaccapGripperConfig(id="taccap_0", **kwargs), {"left": "PC1", "right": "PC2"})
 
     def test_head_pose_is_absent_without_the_head_camera(self):
         assert head_keys(self._robot(enable_head_camera=False).action_features) == set()
@@ -168,6 +171,37 @@ class TestBimanualActionFeatures:
         assert sided == set(without)
 
 
+class TestRobotIdIsRequired:
+    """Both configs refuse to build without ``--robot.id``. It reaches the log
+    prefix, the calibration filename and the recorded hardware manifest, so an
+    unnamed rig means a run nothing identifies the station of."""
+
+    @pytest.mark.parametrize(
+        "make",
+        [
+            lambda **kw: TaccapGripperConfig(side="left", **kw),
+            lambda **kw: BiTaccapGripperConfig(**kw),
+        ],
+        ids=["single", "bimanual"],
+    )
+    def test_omitting_it_fails_at_config_time(self, make):
+        """At config time, i.e. before any device is touched — the CLI parse
+        raises rather than a rig spinning up and recording anonymously."""
+        with pytest.raises(ValueError, match="--robot.id is required"):
+            make()
+
+    @pytest.mark.parametrize(
+        "make",
+        [
+            lambda **kw: TaccapGripperConfig(side="left", **kw),
+            lambda **kw: BiTaccapGripperConfig(**kw),
+        ],
+        ids=["single", "bimanual"],
+    )
+    def test_it_is_stored_stripped(self, make):
+        assert make(id="  taccap_1 ").id == "taccap_1"
+
+
 @pytest.mark.parametrize("enable_head_camera", [False, True])
 def test_action_features_is_a_subset_of_observation_features(enable_head_camera):
     """The record loop builds the action by selecting action_features out of the
@@ -175,7 +209,7 @@ def test_action_features_is_a_subset_of_observation_features(enable_head_camera)
     carry would silently drop out of the dataset."""
     robot = build(
         BiTaccapGripper,
-        BiTaccapGripperConfig(enable_head_camera=enable_head_camera),
+        BiTaccapGripperConfig(id="taccap_0", enable_head_camera=enable_head_camera),
         {"left": "PC1", "right": "PC2"},
     )
     assert set(robot.action_features) <= set(robot.observation_features)

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -17,26 +17,32 @@ pinning. Nothing below touches hardware or either vendor SDK.
 """
 
 import functools
+import json
 import time
 
 import numpy as np
 import pytest
 
 from lerobot.robots.taccap_gripper.common import (
+    HARDWARE_MANIFEST_PATH,
     HEAD_CAMERA_KEYS,
     HEAD_POSE_KEYS,
     POSE_KEYS,
     GripperReadGuard,
     HeadSkewMonitor,
+    build_hardware_manifest,
     build_head_camera_configs,
     build_tactile_camera_configs,
     connect_cameras_parallel,
+    hardware_manifest_unit,
     open_gripper,
     read_head_camera_skew,
     split_camera_read,
     swap_tactile_display_features,
     tactile_camera_output_types,
     tactile_display_key,
+    validate_robot_id,
+    write_hardware_manifest,
 )
 from lerobot.robots.taccap_gripper.ee_transform import resolve_tracker_to_ee, tracker_to_tcp
 
@@ -547,6 +553,165 @@ class TestBuildTactileCameraConfigs:
                 output_types=["rectify"],
                 diff_gain=1.0,
             )
+
+
+class TestValidateRobotId:
+    """``--robot.id`` is required on both TacCap configs. Upstream leaves it
+    optional, which is how terminal output came to read ``None
+    BiTaccapGripper`` and how a run could be recorded with nothing naming the
+    rig it came from."""
+
+    def test_a_station_label_passes_through(self):
+        assert validate_robot_id("taccap_0") == "taccap_0"
+
+    def test_missing_id_names_the_flag_and_the_convention(self):
+        with pytest.raises(ValueError, match="--robot.id is required"):
+            validate_robot_id(None)
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t"])
+    def test_blank_is_as_absent_as_none(self, blank):
+        """``--robot.id=""`` would otherwise satisfy a bare None check and then
+        name a rig nothing at all."""
+        with pytest.raises(ValueError, match="--robot.id is required"):
+            validate_robot_id(blank)
+
+    def test_surrounding_whitespace_is_stripped(self):
+        """It reaches a calibration filename and the manifest; ``taccap_0 `` and
+        ``taccap_0`` must not be two stations."""
+        assert validate_robot_id("  taccap_0  ") == "taccap_0"
+
+    def test_the_format_itself_is_not_policed(self):
+        """The convention is taccap_<n>, but identity lives in the serials, so a
+        rig named after a room is allowed."""
+        assert validate_robot_id("lab-b-bench-3") == "lab-b-bench-3"
+
+
+class FakeEndpoints:
+    """Stand-in for the SDK's ``GripperEndpoints``, which only connected
+    hardware produces."""
+
+    def __init__(self, firmware_sn):
+        self.firmware_sn = firmware_sn
+        self.mcu_serial = "0001"  # the CH343 adapter's — must never be recorded
+
+
+class TestHardwareManifestUnit:
+    """The dataset's only link back to the physical devices, so what goes in it
+    and what each field means are both worth pinning."""
+
+    TACTILES = {"left": "GSPS01A25Z0011", "right": "GSPS01A25Z0012"}
+
+    def test_gripper_serial_is_the_firmware_one(self):
+        """Not ``mcu_serial``: that identifies the USB-serial adapter and changes
+        when the adapter does, so it is not the device's identity."""
+        unit = hardware_manifest_unit(
+            "left",
+            endpoints=FakeEndpoints("TCGU01A24Z0001m"),
+            tactile_serials=self.TACTILES,
+            key_prefix="left_",
+        )
+        assert unit["gripper_sn"] == "TCGU01A24Z0001m"
+        assert "0001" not in str(unit).replace("TCGU01A24Z0001m", "")
+
+    def test_side_and_finger_are_recorded_separately(self):
+        """They are independent left/rights — 单左双右 applied to the gripper's
+        own serial and again to each tactile's — so a right-hand gripper carries
+        a left finger like any other."""
+        unit = hardware_manifest_unit(
+            "right",
+            endpoints=FakeEndpoints("TCGU01A24Z0002m"),
+            tactile_serials=self.TACTILES,
+            key_prefix="right_",
+        )
+        assert unit["side"] == "right"
+        assert [s["finger"] for s in unit["tactile_sensors"]] == ["left", "right"]
+
+    def test_each_tactile_carries_the_observation_key_it_feeds(self):
+        """So a dataset column traces back to a sensor without re-deriving the
+        naming rule."""
+        unit = hardware_manifest_unit(
+            "right",
+            endpoints=FakeEndpoints("TCGU01A24Z0002m"),
+            tactile_serials=self.TACTILES,
+            key_prefix="right_",
+        )
+        assert [(s["observation_key"], s["serial"]) for s in unit["tactile_sensors"]] == [
+            ("right_tactile_left", "GSPS01A25Z0011"),
+            ("right_tactile_right", "GSPS01A25Z0012"),
+        ]
+
+    def test_single_gripper_keys_are_unprefixed(self):
+        unit = hardware_manifest_unit(
+            "left",
+            endpoints=FakeEndpoints("TCGU01A24Z0001m"),
+            tactile_serials=self.TACTILES,
+            key_prefix="",
+        )
+        assert [s["observation_key"] for s in unit["tactile_sensors"]] == ["tactile_left", "tactile_right"]
+
+    def test_disabled_or_disconnected_gripper_records_null_not_a_guess(self):
+        """``_release()`` drops the endpoints, and ``enable_gripper=false`` never
+        creates them; either way the honest answer is "no serial"."""
+        unit = hardware_manifest_unit("left", endpoints=None, tactile_serials={}, key_prefix="left_")
+        assert unit == {"side": "left", "gripper_sn": None, "tactile_sensors": []}
+
+
+class TestWriteHardwareManifest:
+    MANIFEST = build_hardware_manifest(
+        robot_type="taccap_gripper",
+        robot_id="taccap_0",
+        role="leader",
+        units=[
+            hardware_manifest_unit(
+                "left",
+                endpoints=FakeEndpoints("TCGU01A24Z0001m"),
+                tactile_serials={"left": "GSPS01A25Z0011", "right": "GSPS01A25Z0012"},
+                key_prefix="",
+            )
+        ],
+    )
+
+    def test_written_under_meta_not_into_info_json(self, tmp_path):
+        """``meta/info.json`` is upstream's schema; a fork-local key there would
+        collide on the next v5.x sync."""
+        path = write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        assert path == tmp_path / HARDWARE_MANIFEST_PATH
+        assert json.loads(path.read_text()) == self.MANIFEST
+        assert not (tmp_path / "meta" / "info.json").exists()
+
+    def test_rewriting_the_same_hardware_is_a_silent_no_op(self, tmp_path):
+        write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        logger = FakeLogger()
+        write_hardware_manifest(tmp_path, self.MANIFEST, logger)
+        assert logger.warnings == []
+
+    def test_resuming_on_other_hardware_warns_and_keeps_the_original(self, tmp_path):
+        """The episodes already in the dataset came from the devices named in
+        the file; overwriting would misattribute every one of them."""
+        write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        swapped = json.loads(json.dumps(self.MANIFEST))
+        swapped["units"][0]["gripper_sn"] = "TCGU01A24Z0003m"
+
+        logger = FakeLogger()
+        write_hardware_manifest(tmp_path, swapped, logger)
+
+        on_disk = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
+        assert on_disk == self.MANIFEST
+        assert len(logger.warnings) == 1
+        assert "TCGU01A24Z0003m" in logger.warnings[0]  # names what is connected now
+
+    def test_an_unreadable_manifest_is_left_alone(self, tmp_path):
+        """A truncated file is someone else's problem to fix; clobbering it would
+        destroy the provenance of whatever episodes are already there."""
+        path = tmp_path / HARDWARE_MANIFEST_PATH
+        path.parent.mkdir(parents=True)
+        path.write_text("{ truncated")
+
+        logger = FakeLogger()
+        write_hardware_manifest(tmp_path, self.MANIFEST, logger)
+
+        assert path.read_text() == "{ truncated"
+        assert len(logger.warnings) == 1
 
 
 class TestSwapTactileDisplayFeatures:


### PR DESCRIPTION
A recorded dataset could not say which hardware it came from. `LeRobotDataset.create` is handed `robot_type` and nothing else, and `--robot.id` — the only human-readable handle on a rig — defaulted to `None`, which is why terminal output read `None BiTaccapGripper`.

Two halves, deliberately separate.

## `--robot.id` is now required — the station label

`taccap_0`, `taccap_1`, … one per rig, and a bimanual rig is one rig. It names the *seat*, not the hardware in it, so it survives a gripper swap.

Enforced by `validate_robot_id()` in each TacCap config's `__post_init__`, **not** by changing upstream's `RobotConfig.id` (that schema is upstream's and a fork-local change would collide on the next v5.x sync). A missing or blank id fails at CLI-parse time, before any device is touched:

```
ValueError: --robot.id is required: the station label for this rig, e.g. --robot.id=taccap_0 …
```

The format itself is not policed — identity lives in the serials below, so a rig named after a room is allowed.

## Identity travels in `meta/hardware.json`

Written by `lerobot-record` right after `connect()`, from the new `robot.hardware_manifest`:

```json
{
  "robot_type": "bi_taccap_gripper", "robot_id": "taccap_0", "role": "leader",
  "units": [
    { "side": "left", "gripper_sn": "TCGU01A24Z0001m",
      "tactile_sensors": [
        { "finger": "left",  "observation_key": "left_tactile_left",  "serial": "GSPS01A25Z0011" },
        { "finger": "right", "observation_key": "left_tactile_right", "serial": "GSPS01A25Z0012" }
      ] }
  ]
}
```

- `gripper_sn` is the **firmware** SN (`Cmd::GetSn`), never the CH343 `mcu_serial` — that identifies the USB adapter and changes when the adapter does.
- `side` (which gripper) and `finger` (which sensor on it) are recorded separately: independent left/rights, since 单左双右 applies to each. Each sensor carries the `observation_key` it feeds, so a dataset column traces back to a physical sensor without re-deriving the naming rule.
- Single-arm writes the same shape with one entry in `units`, so readers need one code path.
- A file of its own, not a key in `meta/info.json` — upstream's schema.
- Resuming against different hardware **keeps the original file and warns**: the episodes already recorded came from the devices named there, and overwriting would misattribute every one of them.

Trackers and wrist cameras are deliberately out: they are mounted accessories, while the gripper and its two tactiles are the unit the data is about. `hardware_manifest_unit()` is where that would change.

## Also

- Dropped the now-unreachable `config.id or 'default'` / `or 'bi'` / `or 'robot'` fallbacks (6 sites).
- `--robot.id=taccap_0` added to every CLI example (both READMEs, `client_commands.md`, both script docstrings); the smoke test takes `--id`, defaulted.

## Test plan

- 14 new cases: `TestValidateRobotId`, `TestHardwareManifestUnit`, `TestWriteHardwareManifest` (helpers), `TestRobotIdIsRequired` (config wiring, both robots).
- Full suite: **555 passed, 7 skipped**. Three modules excluded — `tests/datasets/test_datasets.py`, `test_image_transforms.py`, `tests/utils/test_random_utils.py` fail to import for want of `safetensors` in this env, unrelated to this change.
- ruff check + format clean (the 7 pre-existing `UP042` errors are unchanged; verified by stashing).
- Hardware-free: the manifest's `firmware_sn` read has **not** been exercised on a real rig yet — the pure helpers are covered, the wire read is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)