### PR TITLE
fix(setup): drop the libudev-dev / libusb-1.0-0-dev requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ main `lerobot` package.
 Step 3, so a bare Ubuntu install is missing pieces the build needs:
 
 ```bash
-sudo apt install -y build-essential cmake pkg-config git curl libudev-dev libusb-1.0-0-dev
+sudo apt install -y build-essential cmake pkg-config git curl
 sudo apt install -y v4l-utils usbutils   # not needed to run, but this is how you debug a camera
 ```
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -74,12 +74,14 @@ check_system_packages() {
         command -v "$cmd" &>/dev/null || missing_recommended+=("$pkg")
     done
 
-    # Header-only packages expose no command; ask pkg-config, which is itself in
-    # the required list above so this is meaningful by the time we get here.
-    if command -v pkg-config &>/dev/null; then
-        pkg-config --exists libudev || missing_required+=("libudev-dev")
-        pkg-config --exists libusb-1.0 || missing_required+=("libusb-1.0-0-dev")
-    fi
+    # No libudev-dev / libusb-1.0-0-dev check. Nothing here compiles against
+    # either header: taccap-gripper's only find_package is Threads, the pico4
+    # bindings link the SDK from the .deb, and both libraries are reached at
+    # *runtime* through prebuilt wheels — pyrealsense2 NEEDs libudev.so.1 and
+    # libusb-1.0.so.0, and pyudev (under xensesdk) dlopens libudev by name,
+    # which cameras/xense/camera_xense.py already resolves via ldconfig.
+    # Those come from libudev1 and libusb-1.0-0, which are base packages, not
+    # the -dev ones this used to demand.
 
     # De-duplicate (build-essential is named twice above).
     local -a uniq_required=() uniq_recommended=()


### PR DESCRIPTION
`./setup_env.sh --install` stops on every correctly set up host:

```
ERROR: the hardware SDK build needs system packages that are not installed:
    sudo apt install -y libudev-dev
```

…on a machine where `libudev-dev 249.11` is installed and `libudev.pc` is exactly where Debian puts it. Two separate faults, and the second is why this is a removal rather than a repair.

## 1. The check could not succeed

It asked pkg-config. `--install` runs inside the mamba env, `conda_environment.yaml` puts `pkg-config` **in** that env, and conda's copy searches only `$CONDA_PREFIX/{lib,share}/pkgconfig` — never `/usr/lib/<triplet>/pkgconfig`, where the system `.pc` files live.

| | `pkg-config --exists libudev` |
| --- | --- |
| `/usr/bin/pkg-config` | ✅ found |
| `$CONDA_PREFIX/bin/pkg-config` | ❌ not found |

`libusb-1.0` slipped through only because conda ships its own `libusb-1.0.pc` — it succeeded for the wrong reason.

## 2. Neither package is needed

Nothing here compiles against either header:

- **taccap-gripper** — its only `find_package` is `Threads`, and its sources never mention udev or libusb
- **pico4 bindings** — link the SDK out of the `.deb`

Both libraries are reached at **runtime**, through prebuilt wheels:

- `pyrealsense2` NEEDs `libudev.so.1` and `libusb-1.0.so.0`
- `pyudev` (under `xensesdk`) dlopens libudev by name, which `cameras/xense/camera_xense.py` already resolves via `ldconfig`, with `/lib/x86_64-linux-gnu/libudev.so.1` as its fallback

Those ship in `libudev1` and `libusb-1.0-0` — base packages on any Ubuntu — not the `-dev` packages this demanded. Most likely left over from SDKs the fork has since dropped.

So the check was blocking installs to enforce a dependency that no longer exists.

## Result

Both entries removed; README Step 1.5 drops them from the apt line. What remains is all commands found with `command -v`, which is indifferent to which copy is first on `PATH`:

```
cmake  g++  make  pkg-config  git  curl
```

Verified inside the mamba env, where `which pkg-config` resolves to the conda copy: `System package check passed.`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)