### PR TITLE
feat(taccap): expand a bare --robot.id number against the robot type

### DIFF
--- a/src/lerobot/robots/bi_taccap_gripper/README.md
+++ b/src/lerobot/robots/bi_taccap_gripper/README.md
@@ -156,7 +156,7 @@ Self-driven — **no `--teleop`**. Prerequisite: `xense.taccap` importable in th
 ```bash
 lerobot-teleoperate \
     --robot.type=bi_taccap_gripper \
-    --robot.id=taccap_0 \
+    --robot.id=0 \
     --fps=30 \
     --display_data=true
 ```
@@ -168,7 +168,7 @@ add `--robot.enable_tracker=false` to record tactile + gripper only:
 ```bash
 lerobot-record \
     --robot.type=bi_taccap_gripper \
-    --robot.id=taccap_0 \
+    --robot.id=0 \
     --robot.enable_head_camera=true \
     --dataset.repo_id=Xense/<dataset_name> \
     --dataset.single_task="Pick up the cube" \
@@ -183,9 +183,12 @@ The head camera shares the XenseVR SDK connection with the Pico4 trackers, so th
 headset app must be running and streaming before enabling it. Turning the camera off
 does not drop the trackers' connection, and vice versa.
 
-`--robot.id` is a **required station label** (`taccap_0`, `taccap_1`, … — one per rig,
-and this bimanual rig is one rig): the config rejects a missing or blank one at
-CLI-parse time, before any device is touched. It is not a dataset column. What is
+`--robot.id` is a **required station label** — one per rig, and this bimanual rig
+is one rig: the config rejects a missing or blank one at CLI-parse time, before
+any device is touched. Pass a number: `--robot.id=0` is stored as `bi_taccap_0`
+here, expanded against `--robot.type` minus its `_gripper` suffix, so the label
+cannot disagree with the rig it names. Anything not all digits is taken verbatim,
+so an existing `bi_taccap_0` keeps working. It is not a dataset column. What is
 recorded instead is `meta/hardware.json`, written at connect: each unit's gripper
 firmware SN plus the two tactile serials on that gripper, keyed by `side` (which
 gripper) and `finger` (which sensor on it) and carrying the observation key each sensor

--- a/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
@@ -231,9 +231,9 @@ class BiTaccapGripperConfig(RobotConfig):
 
     def __post_init__(self):
         super().__post_init__()
-        # Required here, not left optional as upstream has it — see
-        # ``validate_robot_id``.
-        self.id = validate_robot_id(self.id)
+        # Required here, not left optional as upstream has it, and a bare
+        # number is expanded to ``bi_taccap_<n>`` — see ``validate_robot_id``.
+        self.id = validate_robot_id(self.id, self.type)
         if self.role.strip().lower() not in (
             "leader",
             "master",

--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -577,7 +577,7 @@ are connected, set `--robot.side=left|right`:
 ```bash
 lerobot-record \
     --robot.type=taccap_gripper \
-    --robot.id=taccap_0 \
+    --robot.id=0 \
     --robot.side=right \
     --dataset.repo_id=<your_org>/<your_dataset> \
     --dataset.num_episodes=1 \
@@ -657,20 +657,31 @@ defensive fallback for callers that don't pre-warm.
 
 Two different things, and they answer two different questions.
 
-**`--robot.id` is the station label**, `taccap_0` / `taccap_1` / …, one per rig (a
-bimanual rig is one rig, one id). It names the _seat_, not the hardware in it, so
-it stays put when a gripper is swapped. It reaches the log prefix, the
-calibration filename, `str(robot)` and the manifest below, but **not a dataset
-column** — `LeRobotDataset.create()` is handed `robot_type` and nothing else.
+**`--robot.id` is the station label**, one per rig (a bimanual rig is one rig,
+one id). It names the _seat_, not the hardware in it, so it stays put when a
+gripper is swapped. It reaches the log prefix, the calibration filename,
+`str(robot)` and the manifest below, but **not a dataset column** —
+`LeRobotDataset.create()` is handed `robot_type` and nothing else.
+
+**Pass a number.** `--robot.id=0` is stored as `taccap_0` here and as
+`bi_taccap_0` on a bimanual rig: a bare number is expanded against
+`--robot.type`, minus its `_gripper` suffix, because the label names a station
+and a station is not a gripper. Typing the prefix by hand only repeated what
+`--robot.type` already said, and got it wrong often enough to matter —
+`--robot.type=bi_taccap_gripper --robot.id=taccap_0` parses fine and then
+labels a bimanual rig as a single one.
+
+Anything that is not all digits is taken verbatim, so an existing
+`--robot.id=taccap_0` keeps working — along with the calibration file named
+after it — and a rig can still be named after a room.
 
 **It is required**, unlike upstream's optional `RobotConfig.id`. Both TacCap
 configs put it through `validate_robot_id()` in `__post_init__`, so a missing or
 blank id fails at CLI-parse time — before any device is touched — instead of a
 rig spinning up and recording anonymously. That `None` default is also why
-terminal output used to read `None TaccapGripper`. The format itself is not
-policed: the convention is `taccap_<n>`, but identity lives in the serials below,
-so a rig named after a room is allowed. The smoke test takes `--id` and defaults
-it to `taccap_0`.
+terminal output used to read `None TaccapGripper`. Identity itself still lives
+in the serials below, not in this string. The smoke test takes `--id` and
+defaults it to `taccap_0`.
 
 **The hardware manifest is the identity.** `lerobot-record` writes
 `meta/hardware.json` into the dataset right after `robot.connect()`:

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -732,8 +732,8 @@ def read_gripper_normalized(gripper: Any, open_rad: float) -> float:
 # -------------------------------------------------------------------- robot id
 
 
-def validate_robot_id(robot_id: str | None) -> str:
-    """Require ``--robot.id`` and return it stripped.
+def validate_robot_id(robot_id: str | None, robot_type: str) -> str:
+    """Require ``--robot.id``, expand a bare number, and return it stripped.
 
     Upstream leaves ``RobotConfig.id`` optional, defaulting to ``None`` — which
     is how terminal output came to read ``None BiTaccapGripper`` and how a run
@@ -742,19 +742,36 @@ def validate_robot_id(robot_id: str | None) -> str:
     configured. Enforced in each config's ``__post_init__`` rather than by
     changing the base dataclass, which belongs to upstream.
 
-    Free-form on purpose: the convention is ``taccap_0`` / ``taccap_1`` / …, but
-    the *identity* of the hardware is the serials in ``meta/hardware.json``, so
-    pinning a format here would buy nothing and would break the first rig named
-    after a room.
+    **A bare number is expanded against the robot type**, so ``--robot.id=0``
+    stores ``taccap_0`` on a single rig and ``bi_taccap_0`` on a bimanual one.
+    Typing the prefix was pure ceremony — it repeats what ``--robot.type``
+    already said, and getting it wrong (``--robot.type=bi_taccap_gripper
+    --robot.id=taccap_0``) produced a label that quietly disagreed with the
+    rig. The ``_gripper`` suffix is dropped: the label names a station, and a
+    station is not a gripper — the gripper is one of the parts you swap out of
+    it.
+
+    Anything that is not all digits is taken verbatim, which keeps every
+    existing ``--robot.id=taccap_0`` working — and its calibration file, which
+    is named after this value — and leaves room for a rig named after a room.
+    The *identity* of the hardware is still the serials in
+    ``meta/hardware.json``, not this string.
     """
     if robot_id is None or not robot_id.strip():
         raise ValueError(
             "--robot.id is required: the station label for this rig, e.g. "
-            "--robot.id=taccap_0 (taccap_0 / taccap_1 / …, one per rig — a bimanual rig is one rig). "
-            "It names the seat, not the hardware in it, so it stays put when a gripper is swapped; "
-            "the device serials go into the recorded dataset's meta/hardware.json instead."
+            "--robot.id=0 (0 / 1 / …, one per rig — a bimanual rig is one rig). "
+            "A bare number is expanded against --robot.type, so 0 becomes "
+            f"{robot_type.removesuffix('_gripper')}_0; pass a full string to name a rig "
+            "something else. It names the seat, not the hardware in it, so it stays put "
+            "when a gripper is swapped; the device serials go into the recorded dataset's "
+            "meta/hardware.json instead."
         )
-    return robot_id.strip()
+
+    stripped = robot_id.strip()
+    if stripped.isdigit():
+        return f"{robot_type.removesuffix('_gripper')}_{stripped}"
+    return stripped
 
 
 # ------------------------------------------------------------ hardware manifest

--- a/src/lerobot/robots/taccap_gripper/config_taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/config_taccap_gripper.py
@@ -234,9 +234,9 @@ class TaccapGripperConfig(RobotConfig):
     def __post_init__(self):
         super().__post_init__()
 
-        # Required here, not left optional as upstream has it — see
-        # ``validate_robot_id``.
-        self.id = validate_robot_id(self.id)
+        # Required here, not left optional as upstream has it, and a bare
+        # number is expanded to ``taccap_<n>`` — see ``validate_robot_id``.
+        self.id = validate_robot_id(self.id, self.type)
 
         if self.enable_head_camera:
             # Delegate to the camera config so there is one definition of what

--- a/src/lerobot/robots/taccap_gripper/taccap_gripper_example.py
+++ b/src/lerobot/robots/taccap_gripper/taccap_gripper_example.py
@@ -14,7 +14,8 @@ Standalone smoke test for TaccapGripper.
 The gripper, its tactile sensors and its wrist camera are auto-discovered by
 serial rule — no serials are supplied. Pass ``--side`` only when both grippers
 are connected. ``--robot.id`` is required by the config; here it is ``--id``,
-defaulted to ``taccap_0`` so the smoke test stays a one-liner.
+defaulted to ``0`` — which the config expands to ``taccap_0`` — so the smoke
+test stays a one-liner.
 
 Usage:
     # Gripper + tactile + wrist (auto-discovered); pick a side if both present.
@@ -57,8 +58,9 @@ def main() -> None:
     )
     parser.add_argument(
         "--id",
-        default="taccap_0",
-        help="Station label for this rig (required by the config; the smoke test defaults it).",
+        default="0",
+        help="Station label for this rig. A bare number is expanded to taccap_<n> by the config; "
+        "pass a full string to name a rig something else.",
     )
     parser.add_argument(
         "--role", default="leader", choices=["leader", "follower"], help="Device role to bind (default leader)."

--- a/src/lerobot/scripts/client_commands.md
+++ b/src/lerobot/scripts/client_commands.md
@@ -56,7 +56,7 @@ drops that view only, leaving the rest of the layout in place, and it auto-skips
 ```bash
 lerobot-teleoperate \
     --robot.type=bi_taccap_gripper \
-    --robot.id=taccap_0 \
+    --robot.id=0 \
     --fps=30 \
     --display_data=true \
     --robot.enable_tracker=false \
@@ -112,7 +112,7 @@ stored. `--robot.head_camera_eyes=left` (or `right`) records a single eye.
 ```bash
 lerobot-teleoperate \
     --robot.type=taccap_gripper \
-    --robot.id=taccap_0 \
+    --robot.id=0 \
     --robot.side=left \
     --fps=30 \
     --display_data=true
@@ -127,14 +127,21 @@ Recording is self-driven (`self_driven_record_loop`, shifted-frame: `action[t]` 
 
 ### `--robot.id` (required) and the hardware manifest
 
-`--robot.id` is a **required station label** — `taccap_0`, `taccap_1`, … one per rig,
-and a bimanual rig is one rig. It names the seat, not the hardware in it, so it
-survives a gripper swap. Upstream leaves it optional; both TacCap configs reject a
+`--robot.id` is a **required station label** — one per rig, and a bimanual rig is
+one rig. It names the seat, not the hardware in it, so it survives a gripper swap.
+
+**Pass a number.** `--robot.id=0` is stored as `taccap_0` on a single rig and
+`bi_taccap_0` on a bimanual one: a bare number is expanded against `--robot.type`
+minus its `_gripper` suffix, so the label cannot disagree with the rig it names.
+Anything not all digits is taken verbatim, so an existing `--robot.id=taccap_0`
+keeps working.
+
+Upstream leaves it optional; both TacCap configs reject a
 missing or blank one in `__post_init__`, so the run stops at CLI-parse time rather
 than a rig spinning up and recording anonymously:
 
 ```
-ValueError: --robot.id is required: the station label for this rig, e.g. --robot.id=taccap_0 …
+ValueError: --robot.id is required: the station label for this rig, e.g. --robot.id=0 …
 ```
 
 It reaches the log prefix, the calibration filename and `str(robot)`, and it is copied
@@ -197,7 +204,7 @@ a different problem from the viewer being expensive.
 ```bash
 lerobot-record \
     --robot.type=bi_taccap_gripper \
-    --robot.id=taccap_0 \
+    --robot.id=0 \
     --robot.enable_head_camera=true \
     --dataset.repo_id=Xense/taccap-g1-test-0722 \
     --dataset.single_task="Pick up the cube" \
@@ -227,7 +234,7 @@ digit). Add `--robot.enable_tracker=false` to record tactile + gripper only — 
 ```bash
 lerobot-record \
     --robot.type=taccap_gripper \
-    --robot.id=taccap_0 \
+    --robot.id=0 \
     --robot.side=left \
     --dataset.repo_id=Xense/<dataset_name> \
     --dataset.single_task="Pick up the cube" \

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -562,28 +562,59 @@ class TestValidateRobotId:
     rig it came from."""
 
     def test_a_station_label_passes_through(self):
-        assert validate_robot_id("taccap_0") == "taccap_0"
+        assert validate_robot_id("taccap_0", "taccap_gripper") == "taccap_0"
 
     def test_missing_id_names_the_flag_and_the_convention(self):
         with pytest.raises(ValueError, match="--robot.id is required"):
-            validate_robot_id(None)
+            validate_robot_id(None, "taccap_gripper")
 
     @pytest.mark.parametrize("blank", ["", "   ", "\t"])
     def test_blank_is_as_absent_as_none(self, blank):
         """``--robot.id=""`` would otherwise satisfy a bare None check and then
         name a rig nothing at all."""
         with pytest.raises(ValueError, match="--robot.id is required"):
-            validate_robot_id(blank)
+            validate_robot_id(blank, "taccap_gripper")
 
     def test_surrounding_whitespace_is_stripped(self):
         """It reaches a calibration filename and the manifest; ``taccap_0 `` and
         ``taccap_0`` must not be two stations."""
-        assert validate_robot_id("  taccap_0  ") == "taccap_0"
+        assert validate_robot_id("  taccap_0  ", "taccap_gripper") == "taccap_0"
 
     def test_the_format_itself_is_not_policed(self):
         """The convention is taccap_<n>, but identity lives in the serials, so a
         rig named after a room is allowed."""
-        assert validate_robot_id("lab-b-bench-3") == "lab-b-bench-3"
+        assert validate_robot_id("lab-b-bench-3", "taccap_gripper") == "lab-b-bench-3"
+
+    @pytest.mark.parametrize(
+        ("raw", "robot_type", "expected"),
+        [
+            ("0", "taccap_gripper", "taccap_0"),
+            ("1", "taccap_gripper", "taccap_1"),
+            ("12", "taccap_gripper", "taccap_12"),
+            ("0", "bi_taccap_gripper", "bi_taccap_0"),
+            ("3", "bi_taccap_gripper", "bi_taccap_3"),
+        ],
+    )
+    def test_a_bare_number_is_expanded_against_the_type(self, raw, robot_type, expected):
+        """``--robot.id=0`` is the whole point: the prefix repeats what
+        ``--robot.type`` already said, and typing it by hand is how you end up
+        with ``--robot.type=bi_taccap_gripper --robot.id=taccap_0``."""
+        assert validate_robot_id(raw, robot_type) == expected
+
+    def test_the_expansion_drops_gripper(self):
+        """The label names a station, and a station is not a gripper — the
+        gripper is one of the parts you swap out of it."""
+        assert "gripper" not in validate_robot_id("0", "taccap_gripper")
+        assert "gripper" not in validate_robot_id("0", "bi_taccap_gripper")
+
+    def test_a_number_is_stripped_before_it_is_expanded(self):
+        assert validate_robot_id("  2  ", "taccap_gripper") == "taccap_2"
+
+    @pytest.mark.parametrize("raw", ["taccap_0", "bi_taccap_7", "lab-b-bench-3", "0a", "rig-0"])
+    def test_anything_not_all_digits_is_taken_verbatim(self, raw):
+        """Existing rigs pass the full label, and it reaches a calibration
+        filename — expanding those would orphan every calibration on disk."""
+        assert validate_robot_id(raw, "bi_taccap_gripper") == raw
 
 
 class FakeEndpoints:


### PR DESCRIPTION
`--robot.id=0` now stores **`taccap_0`** on a single rig and **`bi_taccap_0`** on a bimanual one.

## Why

Typing the prefix was ceremony — it repeats what `--robot.type` already said, and repeating it is how you get:

```
--robot.type=bi_taccap_gripper --robot.id=taccap_0
```

which parses fine and then labels a bimanual rig as a single one, in the log prefix, the calibration filename, `str(robot)` and `meta/hardware.json`. The bimanual README's own examples had exactly that, which is what prompted this.

The `_gripper` suffix is dropped: the label names a **station**, and a station is not a gripper — the gripper is one of the parts you swap out of it, which is the whole reason the label is a seat rather than a device.

## Behaviour

| `--robot.id` | `--robot.type` | stored |
| --- | --- | --- |
| `0` | `taccap_gripper` | `taccap_0` |
| `1` | `taccap_gripper` | `taccap_1` |
| `0` | `bi_taccap_gripper` | `bi_taccap_0` |
| `  2  ` | `taccap_gripper` | `taccap_2` |
| `taccap_0` | `taccap_gripper` | `taccap_0` (verbatim) |
| `lab-b-bench-3` | either | `lab-b-bench-3` (verbatim) |
| `0a`, `rig-0` | either | verbatim |
| blank / `None` | either | still `ValueError` |

**Only an all-digits value is expanded.** That is deliberate: this string is the calibration filename (`Robot.calibration_fpath` = `<dir>/<id>.json`), so expanding an existing `taccap_0` would orphan every calibration on disk.

The type comes from `RobotConfig.type` — draccus's registered choice name — so neither config hardcodes its own name.

## Verified

This environment cannot run pytest (half-installed: no `draccus`, no `serial`), so beyond adding the tests I ran all 17 cases they assert directly against the function: expansion for both types, the `_gripper` drop, strip-before-expand, verbatim for `taccap_0` / `bi_taccap_7` / `lab-b-bench-3` / `0a` / `rig-0`, and blank-or-`None` still raising. Also confirmed `RobotConfig.get_choice_name` returns `taccap_gripper` / `bi_taccap_gripper` and that `.removesuffix("_gripper")` yields the intended prefixes. CI runs the real suite.

## Docs

Seven command examples move to `--robot.id=0`. Three prose spots deliberately keep the old form — the wrong-prefix example and the two "keeps working" notes — and the error message the docs quote was re-checked against what the code now emits. The smoke test's `--id` defaults to `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)