### PR TITLE
docs(record): how to record on a machine with no GPU, and why auto misses it

### DIFF
--- a/src/lerobot/scripts/client_commands.md
+++ b/src/lerobot/scripts/client_commands.md
@@ -199,6 +199,58 @@ The `[slow_frame]` line carries a `top_obs=` suffix naming the slowest cameras o
 that frame, so check it before reaching for either flag — a single slow sensor is
 a different problem from the viewer being expensive.
 
+### Recording on a machine with no GPU
+
+The defaults assume an NVIDIA card. On a GPU-less host — a CPU-only server, a VM,
+a laptop with no discrete GPU — say so explicitly:
+
+```bash
+lerobot-record \
+    ... \
+    --dataset.vcodec=libsvtav1 \
+    --dataset.streaming_encoding=false
+```
+
+**`--dataset.vcodec=libsvtav1`.** The default is `auto`, and **`auto` does not
+detect this case.** It probes with `av.codec.Codec(name, "w")`, which is
+`avcodec_find_encoder_by_name` — a static lookup in the FFmpeg build's codec
+table. PyAV ships with `h264_nvenc` compiled in, so that lookup succeeds on a
+machine with no NVIDIA driver at all, `auto` selects it, and the failure surfaces
+later, at the first frame, as something like:
+
+```
+UnknownError: [Errno 1313558101] Unknown error occurred: 'avcodec_open2(h264_nvenc)'
+```
+
+Measured with the GPU masked off (`CUDA_VISIBLE_DEVICES=-1`): the probe still
+returns `h264_nvenc` and only `avcodec_open2` fails. The `libsvtav1` fallback in
+`resolve_vcodec()` is therefore only reached on a host whose FFmpeg was built
+without nvenc, which is not the build we install. `libsvtav1` is AV1 on the CPU
+and is what the offline dataset tools already default to.
+
+**`--dataset.streaming_encoding=false`.** Streaming encoding runs the encoder
+inline with capture, which is a win when the encoder is a dedicated ASIC on the
+GPU and the CPU only hands it frames. With `libsvtav1` the encoder _is_ the CPU,
+and it competes with the capture loop for the same cores — on a bimanual rig
+that is six to eight images per frame inside a 33.3 ms budget at 30 fps, so the
+first thing you see is `[slow_frame] ... overrun=`. With it off, frames are
+written out during capture and encoded in a batch at `save_episode()` instead:
+episode saves become slow and visible, capture stays on time. That is the right
+trade — a late save costs you patience, a starved capture loop costs you data
+you cannot re-record.
+
+Two knobs worth knowing if you keep streaming encoding on anyway, e.g. on a
+many-core server:
+
+| Flag                              | Default | Why you would touch it                                                                                                                            |
+| --------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--dataset.encoder_threads`       | `None`  | `None` lets the codec pick, which on a big machine means libsvtav1 helping itself to cores the capture loop needs. `2` per encoder is a sane cap. |
+| `--dataset.encoder_queue_maxsize` | `30`    | ~1 s of buffer at 30 fps. It is the backpressure valve: when the encoder falls behind, capture blocks here rather than growing memory forever.    |
+
+`lerobot-record` prints a reminder when `streaming_encoding=false`, suggesting you
+turn it back on if the hardware is capable. On a GPU-less host it is not, so the
+suggestion does not apply — leaving it off is deliberate.
+
 ### Bimanual (`bi_taccap_gripper`)
 
 ```bash
@@ -216,6 +268,12 @@ lerobot-record \
     --dataset.push_to_hub=false \
     --display_data=false
 ```
+
+> `--dataset.streaming_encoding=true` is the default and assumes an NVIDIA card.
+> On a GPU-less host, use `--dataset.vcodec=libsvtav1` with
+> `--dataset.streaming_encoding=false` instead — see
+> [Recording on a machine with no GPU](#recording-on-a-machine-with-no-gpu),
+> which also explains why `--dataset.vcodec=auto` does not work that out for you.
 
 ### Single (`taccap_gripper`)
 


### PR DESCRIPTION
The recording defaults assume an NVIDIA card: `--dataset.vcodec=auto` and `--dataset.streaming_encoding=true`. Neither is right on a CPU-only host, and — the part worth writing down — **`auto` does not work that out for you.**

## `auto` does not detect a missing GPU

`detect_available_hw_encoders()` probes with `av.codec.Codec(name, "w")`, which is `avcodec_find_encoder_by_name`: a static lookup in the FFmpeg build's codec table. It never touches the driver and never opens an encode session.

PyAV ships with `h264_nvenc` compiled in, so that probe succeeds on a host with **no NVIDIA driver at all**, `auto` returns `h264_nvenc`, and the failure lands later, at `avcodec_open2` on the first frame. The `libsvtav1` fallback in `resolve_vcodec()` is only reached when FFmpeg was built *without* nvenc — not the build we install.

Measured rather than reasoned. With the GPU masked off:

```
$ CUDA_VISIBLE_DEVICES=-1 python -c "..."
  probe h264_nvenc: passes
  actual open:      UnknownError: [Errno 1313558101] ... 'avcodec_open2(h264_nvenc)'
```

(An earlier run of mine appeared to show nvenc failing even *with* a GPU — that was a 64×64 test frame, below nvenc's minimum dimensions. At 320×240 / 640×480 / 1280×960 nvenc works fine here. The probe/reality gap is real; the "broken on GPU machines too" reading was not.)

## What to pass

```bash
lerobot-record \
    ... \
    --dataset.vcodec=libsvtav1 \
    --dataset.streaming_encoding=false
```

`libsvtav1` is AV1 on the CPU, and is already what the offline dataset tools default to (`dataset_tools.py`, three call sites).

## Why streaming encoding goes off too

A separate reason, not a consequence. Streaming encoding pays off when the encoder is a dedicated ASIC and the CPU only feeds it frames. With `libsvtav1` the encoder **is** the CPU, and it competes with the capture loop for the same cores — six to eight images per frame inside a 33.3 ms budget on a bimanual rig at 30 fps — so it surfaces as `[slow_frame] ... overrun=`.

With it off, frames are written during capture and encoded in a batch at `save_episode()`: slow, visible saves; on-time capture. That is the right trade — a late save costs patience, a starved capture loop costs data you cannot re-record.

Also documents `--dataset.encoder_threads` and `--dataset.encoder_queue_maxsize` for anyone keeping streaming encoding on a many-core server, and notes that the "consider enabling it" reminder `lerobot-record` prints when it is off does not apply on a GPU-less host.

## Not fixed here

`auto`'s probe is still a build check rather than a capability check, so it will keep mis-selecting nvenc on GPU-less hosts. Making `detect_available_hw_encoders()` actually open a small test encoder would close that, at the cost of a little startup time — worth doing, but a behaviour change rather than a doc, so it is not in this PR.

Docs-only otherwise. Formatting verified idempotent under the repo's prettier hook, which had to be run out of the pre-commit cache since this host's env currently has no `pre-commit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)