### PR TITLE
fix(video): probe hardware encoders by opening one, not by looking them up

### DIFF
--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
+import functools
 import glob
 import importlib
+import io
 import logging
 import queue
 import shutil
@@ -87,16 +89,91 @@ def _get_codec_options(
     return options
 
 
-def detect_available_hw_encoders() -> list[str]:
-    """Probe PyAV/FFmpeg for available hardware video encoders."""
+# Probe frames must clear nvenc's minimum dimensions or a working encoder is
+# reported as broken: on an RTX PRO 6000, 128x96 is rejected while 160x120
+# encodes fine (NVIDIA documents 145x49 for H.264). 320x240 sits above every
+# generation's floor, is even in both axes for yuv420p, and encodes in
+# microseconds.
+_ENCODER_PROBE_SIZE = (320, 240)
+
+
+def _encoder_session_opens(codec_name: str) -> bool:
+    """Whether an encode session can actually be created for ``codec_name``.
+
+    ``av.codec.Codec(name, "w")`` cannot answer this. It is
+    ``avcodec_find_encoder_by_name`` — a static lookup in the codec table FFmpeg
+    was *built* with, which never touches a driver and never allocates a session.
+    PyAV ships with nvenc compiled in, so on a host with no NVIDIA driver that
+    lookup still succeeds; ``auto`` then picks ``h264_nvenc`` and recording dies
+    at ``avcodec_open2`` on the first frame instead of falling back to software.
+
+    Opening one is the only question worth asking, and it is cheap: one frame
+    into an in-memory container, thrown away.
+    """
+    width, height = _ENCODER_PROBE_SIZE
+    try:
+        container = av.open(io.BytesIO(), "w", format="mp4")
+    except Exception:
+        return False
+
+    opened = False
+    try:
+        stream = container.add_stream(codec_name, rate=30)
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = "yuv420p"
+        # Contents are irrelevant — avcodec_open2 has already happened or failed
+        # by the time the first packet comes back.
+        for _ in stream.encode(av.VideoFrame(width, height, "yuv420p")):
+            pass
+        opened = True
+    except Exception:  # nosec B110
+        pass  # nosec B110
+    finally:
+        # Muxing a trailer for a stream that never opened raises; that says
+        # nothing more than the encode already did.
+        with contextlib.suppress(Exception):
+            container.close()
+
+    return opened
+
+
+@functools.lru_cache(maxsize=1)
+def detect_available_hw_encoders() -> tuple[str, ...]:
+    """Probe PyAV/FFmpeg for hardware video encoders that actually work here.
+
+    Two stages: the cheap static lookup rules out encoders FFmpeg was not built
+    with, then :func:`_encoder_session_opens` rules out the ones whose driver or
+    device is missing. Both are needed — see that function for why the static
+    lookup alone silently selects nvenc on machines that have no GPU.
+
+    Cached for the process, and worth caching: opening an nvenc session costs
+    ~450 ms, so probing both nvenc entries takes ~900 ms on a GPU host.
+    ``resolve_vcodec`` is called per dataset and per streaming encoder, and the
+    answer cannot change under a running process. Call ``cache_clear()`` if a
+    test needs to re-probe.
+    """
     available = []
-    for codec_name in HW_ENCODERS:
-        try:
-            av.codec.Codec(codec_name, "w")
-            available.append(codec_name)
-        except Exception:  # nosec B110
-            pass  # nosec B110
-    return available
+    # A failing hardware encoder logs at ERROR through libav ("Cannot load
+    # libnvidia-encode.so.1"), which is noise when we are only asking whether it
+    # works and are about to fall back on purpose.
+    previous_level = av.logging.get_level()
+    av.logging.set_level(av.logging.CRITICAL)
+    try:
+        for codec_name in HW_ENCODERS:
+            try:
+                av.codec.Codec(codec_name, "w")
+            except Exception:  # nosec B110
+                continue  # not in this FFmpeg build
+            if _encoder_session_opens(codec_name):
+                available.append(codec_name)
+            else:
+                logging.debug(f"Hardware encoder '{codec_name}' is present in FFmpeg but will not open here")
+    finally:
+        av.logging.set_level(previous_level)
+    # A tuple because lru_cache hands the same object to every caller, and a
+    # list would let one of them mutate what the next one sees.
+    return tuple(available)
 
 
 def resolve_vcodec(vcodec: str) -> str:

--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -163,7 +163,7 @@ def detect_available_hw_encoders() -> tuple[str, ...]:
         for codec_name in HW_ENCODERS:
             try:
                 av.codec.Codec(codec_name, "w")
-            except Exception:  # nosec B110
+            except Exception:  # nosec B112
                 continue  # not in this FFmpeg build
             if _encoder_session_opens(codec_name):
                 available.append(codec_name)

--- a/src/lerobot/scripts/client_commands.md
+++ b/src/lerobot/scripts/client_commands.md
@@ -201,32 +201,31 @@ a different problem from the viewer being expensive.
 
 ### Recording on a machine with no GPU
 
-The defaults assume an NVIDIA card. On a GPU-less host — a CPU-only server, a VM,
-a laptop with no discrete GPU — say so explicitly:
+On a GPU-less host — a CPU-only server, a VM, a laptop with no discrete GPU —
+turn streaming encoding off:
 
 ```bash
 lerobot-record \
     ... \
-    --dataset.vcodec=libsvtav1 \
     --dataset.streaming_encoding=false
 ```
 
-**`--dataset.vcodec=libsvtav1`.** The default is `auto`, and **`auto` does not
-detect this case.** It probes with `av.codec.Codec(name, "w")`, which is
-`avcodec_find_encoder_by_name` — a static lookup in the FFmpeg build's codec
-table. PyAV ships with `h264_nvenc` compiled in, so that lookup succeeds on a
-machine with no NVIDIA driver at all, `auto` selects it, and the failure surfaces
-later, at the first frame, as something like:
+**The codec you can leave alone.** `--dataset.vcodec=auto` (the default) probes
+by opening a real encode session, so on a host with no NVIDIA driver it reports
+no hardware encoder and falls back to `libsvtav1` — AV1 on the CPU, which is what
+the offline dataset tools already default to. Measured with
+`libnvidia-encode.so.1` masked out: `auto` resolves to `libsvtav1` in 2 ms.
 
-```
-UnknownError: [Errno 1313558101] Unknown error occurred: 'avcodec_open2(h264_nvenc)'
-```
+Passing `--dataset.vcodec=libsvtav1` explicitly is still fine, and worth doing if
+you want the recording command to be self-documenting about where it can run.
 
-Measured with the GPU masked off (`CUDA_VISIBLE_DEVICES=-1`): the probe still
-returns `h264_nvenc` and only `avcodec_open2` fails. The `libsvtav1` fallback in
-`resolve_vcodec()` is therefore only reached on a host whose FFmpeg was built
-without nvenc, which is not the build we install. `libsvtav1` is AV1 on the CPU
-and is what the offline dataset tools already default to.
+> This did not use to work. The probe was `av.codec.Codec(name, "w")` —
+> `avcodec_find_encoder_by_name`, a static lookup in the codec table FFmpeg was
+> _built_ with, which never touches a driver. PyAV ships with nvenc compiled in,
+> so the lookup succeeded on machines with no GPU at all, `auto` selected
+> `h264_nvenc`, and recording died at the first frame with
+> `avcodec_open2(h264_nvenc)`. If you are on a build from before that fix, pass
+> `--dataset.vcodec=libsvtav1` by hand.
 
 **`--dataset.streaming_encoding=false`.** Streaming encoding runs the encoder
 inline with capture, which is a win when the encoder is a dedicated ASIC on the
@@ -270,10 +269,9 @@ lerobot-record \
 ```
 
 > `--dataset.streaming_encoding=true` is the default and assumes an NVIDIA card.
-> On a GPU-less host, use `--dataset.vcodec=libsvtav1` with
-> `--dataset.streaming_encoding=false` instead — see
-> [Recording on a machine with no GPU](#recording-on-a-machine-with-no-gpu),
-> which also explains why `--dataset.vcodec=auto` does not work that out for you.
+> On a GPU-less host, pass `--dataset.streaming_encoding=false` instead — the
+> codec picks itself. See
+> [Recording on a machine with no GPU](#recording-on-a-machine-with-no-gpu).
 
 ### Single (`taccap_gripper`)
 

--- a/tests/datasets/test_streaming_video_encoder.py
+++ b/tests/datasets/test_streaming_video_encoder.py
@@ -87,9 +87,11 @@ class TestGetCodecOptions:
 
 
 class TestHWEncoderDetection:
-    def test_detect_available_hw_encoders_returns_list(self):
+    def test_detect_available_hw_encoders_returns_tuple(self):
+        """A tuple, not a list: the result is lru_cached and handed to every
+        caller, so it must not be mutable."""
         result = detect_available_hw_encoders()
-        assert isinstance(result, list)
+        assert isinstance(result, tuple)
 
     def test_detect_available_hw_encoders_only_valid(self):
         from lerobot.datasets.video_utils import HW_ENCODERS
@@ -97,6 +99,25 @@ class TestHWEncoderDetection:
         result = detect_available_hw_encoders()
         for encoder in result:
             assert encoder in HW_ENCODERS
+
+    def test_detected_encoders_actually_open(self):
+        """The point of the probe: anything it reports must survive
+        avcodec_open2, not merely exist in the FFmpeg build. A static lookup
+        passes for nvenc on a host with no NVIDIA driver, which is how 'auto'
+        used to select it and then die on the first frame."""
+        from lerobot.datasets.video_utils import _encoder_session_opens
+
+        for encoder in detect_available_hw_encoders():
+            assert _encoder_session_opens(encoder)
+
+    def test_probe_size_clears_nvenc_minimum(self):
+        """Too small a probe frame reports a working encoder as broken: 128x96
+        is rejected on an RTX PRO 6000 that encodes 160x120 fine."""
+        from lerobot.datasets.video_utils import _ENCODER_PROBE_SIZE
+
+        width, height = _ENCODER_PROBE_SIZE
+        assert width >= 160 and height >= 120
+        assert width % 2 == 0 and height % 2 == 0  # yuv420p
 
     def test_resolve_vcodec_passthrough(self):
         assert resolve_vcodec("libsvtav1") == "libsvtav1"


### PR DESCRIPTION
`--dataset.vcodec=auto` selected `h264_nvenc` on hosts with **no NVIDIA driver** and then died at the first frame, instead of falling back to `libsvtav1`.

## The check could not fail on the machines it protected

`detect_available_hw_encoders()` asked `av.codec.Codec(name, "w")` — that is `avcodec_find_encoder_by_name`, a static lookup in the codec table FFmpeg was *built* with. It never touches a driver and never allocates a session.

PyAV ships with nvenc compiled in, so the lookup succeeds everywhere, and the `libsvtav1` fallback in `resolve_vcodec()` was only reachable on a build *without* nvenc — not the build we install.

## Fix

Two stages: keep the cheap lookup to rule out encoders that were never built in, then **actually open an encode session and push one frame**. That is the question `avcodec_open2` answers, and the only one worth asking.

## Measured, both directions

In the project conda env:

| Host | probe | `auto` | encode |
| --- | --- | --- | --- |
| real GPU + driver | `('h264_nvenc', 'hevc_nvenc')` | `h264_nvenc` | ✅ |
| `libnvidia-encode.so.1` masked | `()` | **`libsvtav1`** | ✅ |

The second case is a mount namespace with an empty file bind-mounted over `/lib/x86_64-linux-gnu/libnvidia-encode.so.1` — closer to a driverless host than `CUDA_VISIBLE_DEVICES=-1`, and it makes libav log `Cannot load libnvidia-encode.so.1` exactly as a real one would.

## Two details that are easy to get wrong

**Probe frames are 320×240.** Too small and the probe reports a *working* encoder as broken: `128x96` is rejected on an RTX PRO 6000 that encodes `160x120` fine (NVIDIA documents 145×49 for H.264). I hit this myself while investigating — a 64×64 test frame made nvenc look broken on a machine whose nvenc is fine. A false negative here is worse than the false positive being fixed: it would push GPU rigs onto the CPU encoder silently. A test pins the size.

**Cached, and returns a tuple.** Opening an nvenc session costs ~450 ms, so probing both nvenc entries is ~900 ms — and `resolve_vcodec()` is called per dataset and per streaming encoder. `lru_cache` makes that once per process (0.001 ms after). The result is a tuple because `lru_cache` hands the same object to every caller, and a list would let one of them mutate what the next one sees.

libav's ERROR output is suppressed for the duration of the probe — `Cannot load libnvidia-encode.so.1` is noise when we are asking whether it works and are about to fall back on purpose.

## Tests

- `test_detected_encoders_actually_open` — anything the probe reports must survive `avcodec_open2`, which is the whole point
- `test_probe_size_clears_nvenc_minimum` — locks 320×240 in (≥160×120, even in both axes for yuv420p) so nobody "optimises" it back into false negatives
- `test_detect_available_hw_encoders_returns_tuple` — updated from `list`, with the reason

## Docs

The GPU-less recording section merged in #25 said `auto` cannot work this out. It can now, so that section drops the manual `--dataset.vcodec` and keeps only `--dataset.streaming_encoding=false`, which is off for its own unrelated reason (the CPU encoder competes with the capture loop). The old behaviour stays as a note for anyone on an older build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)