### PR TITLE
docs(docker): say what is in the image and what changed since 0.0.3

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -4,6 +4,39 @@
 LeRobot-Xense、XenseSDK、TacCap-Gripper SDK、Pico4 Python 绑定，
 并在容器启动时默认启动 XenseVR PC Service。
 
+## 0. 镜像里有什么
+
+当前发布版本 **0.0.4**（`ghcr.io/vertax42/xense-taccap-lerobot:0.0.4`，`latest` 指向同一镜像）。
+
+| 组成                      | 版本 / 来源                                                        |
+| ------------------------- | ------------------------------------------------------------------ |
+| Conda 环境                | `xense-taccap`，Python 3.12                                        |
+| CUDA 用户态               | 12.8（`CONDA_OVERRIDE_CUDA=12.8`）                                 |
+| XenseVR PC Service daemon | `.deb` **v0.2.1**，装在 `/opt/apps/roboticsservice`                |
+| `xensevr_pc_service_sdk`  | 仓库内 pybind 编译；链接的 C SDK 取自上面那个 `.deb`，版本号也随它 |
+| `xense.taccap`            | 由 `third_party/taccap-gripper` submodule 在镜像内从源码编译       |
+| `xensesdk`                | PyPI 预编译 wheel                                                  |
+
+镜像的 tag 由 `pyproject.toml` 的 `version = "0.5.1+xtac.<版本>"` 推导（Docker tag 不能含
+`+`，故只取 `+xtac.` 之后的部分）。每次发布同时打一个 `sha-<commit>` tag，可以精确追溯
+镜像是从哪个源码提交构建的。
+
+### 0.0.3 → 0.0.4 的变化
+
+对**已有使用方式**有影响的只有一条：
+
+- **`--robot.id` 现在接受纯数字**，并按 `--robot.type` 展开：`--robot.id=0` 在单臂上存为
+  `taccap_0`、在双臂上存为 `bi_taccap_0`。**旧写法不受影响** —— 非纯数字一律原样保留，
+  所以 `--robot.id=taccap_0` 和按它命名的标定文件都照常工作。
+
+其余是内部变化，不改变命令行：
+
+- daemon 升到 v0.2.1（修掉了 Pico 相机每帧刷屏、把调用方控制台冲垮的问题）
+- 镜像不再需要 `XenseVR-PC-Service` submodule：pico4 的 C SDK 直接取自 `.deb`，
+  构建时少一次 cmake + 静态 gRPC 链接
+- `--dataset.vcodec=auto` 现在会真正打开一次编码器再判定，无 GPU 的机器上会正确
+  回退到 `libsvtav1`，而不是选中 nvenc 后在第一帧崩掉
+
 ## 1. 宿主机要求
 
 - Ubuntu 22.04/24.04，`linux/amd64`
@@ -119,6 +152,16 @@ docker compose pull
 docker compose run --rm xense-taccap
 ```
 
+`latest` 是浮动的，出问题时先确认手上这个到底是哪一个镜像：
+
+```bash
+docker image inspect --format '{{index .RepoDigests 0}}' \
+    ghcr.io/vertax42/xense-taccap-lerobot:0.0.4
+```
+
+发布时 `0.0.4` 和 `latest` 指向同一镜像，两者 digest 应当一致。想在**拉之前**看远端的，
+用 `docker manifest inspect <image>:<tag>`，不必先下载 21 GB。
+
 ### 维护者侧推送
 
 推荐走 GitHub Actions（在托管 runner 上构建并推送，不占用本机上行带宽）：
@@ -169,8 +212,13 @@ docker compose run --rm xense-taccap
 python -c 'import torch; print(torch.__version__, torch.cuda.is_available())'
 python -c 'import xensesdk; print("xensesdk ->", xensesdk.__file__)'
 python -c 'import xense.taccap; print("taccap ->", xense.taccap.__file__)'
-python -c 'import xensevr_pc_service_sdk; print("pico4 ->", xensevr_pc_service_sdk.__file__)'
+python -c 'import importlib.metadata as M; print("pico4 ->", M.version("xensevr_pc_service_sdk"))'
+dpkg-query -W -f='daemon -> ${Version}\n' xensevr-pc-service
 ```
+
+后两行应当**打印同一个版本号**（0.0.4 镜像里是 `0.2.1`）。这不是巧合：pico4 绑定链接的
+C SDK 就是从那个 `.deb` 里取的，它的包版本也由 `dpkg-query` 推导。两者不一致，说明镜像
+是半新不旧的构建，不要拿它录数据。
 
 发现相机和串口：
 


### PR DESCRIPTION
Three gaps, all of them things someone has to answer while holding a 21 GB tarball. The README was already thorough on *how* to run the image — this is about *which* image and *what is in it*.

## 1. What is in it

The intro listed components without versions. The one that matters now is the daemon: the Pico4 bindings link a C SDK taken out of the `xensevr-pc-service` `.deb`, so **"which .deb" is "which SDK"**.

New table: Python 3.12, CUDA 12.8, `.deb` v0.2.1, and where each piece comes from.

Verified rather than recalled — pulled the published image's **config blob** from GHCR (8 KB, no need to fetch 21 GB) to confirm the conda env name, `CONDA_OVERRIDE_CUDA=12.8` and that `setup_env.sh --install` is in the layer history, and read `DEB_VER` out of `setup_env.sh` at commit `21147758`, which is the `sha-` tag the image carries.

## 2. What changed since 0.0.3

Exactly one thing touches existing usage:

> `--robot.id` now accepts a bare number and expands it against `--robot.type`.

Said together with the part that keeps people calm: a non-numeric id is still taken verbatim, so `--robot.id=taccap_0` — **and the calibration file named after it** — keeps working.

The rest (daemon 0.2.1, submodule removed, the `vcodec=auto` fix) changes nothing on the command line and is listed separately as such.

## 3. Whether the image you have is the one you think

The verification block printed module **paths**, which cannot tell a fresh image from a stale one. It now prints the pico4 package version next to `dpkg-query` on the daemon:

```bash
python -c 'import importlib.metadata as M; print("pico4 ->", M.version("xensevr_pc_service_sdk"))'
dpkg-query -W -f='daemon -> ${Version}\n' xensevr-pc-service
```

Those two **must** agree — one is derived from the other — so a mismatch means a half-updated build, which is worth catching before recording data with it.

The GHCR section also gains the digest check, since `latest` floats. It sits in section 3 with the rest of the pull instructions rather than mid-verification: "which image did I get" is a question about pulling, and putting it in section 5 split "check the software" from "find the cameras".

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)