### PR TITLE
feat(docker): make GHCR the install path, demote tar delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ training scripts) refer to the
 
 > **Docker users:** a complete GPU + hardware-SDK image and Compose setup are
 > available in [`docker/README.md`](docker/README.md). It is the quickest way to
-> give an end user a reproducible environment; the host still needs NVIDIA
-> Container Toolkit and the udev rules documented below. Prebuilt images are on
-> `ghcr.io/vertax42/xense-taccap-lerobot` and need no login to pull — see
-> [the GHCR section](docker/README.md#3-从-ghcr-拉取镜像在线交付).
+> give an end user a reproducible environment. Images are published on
+> `ghcr.io/vertax42/xense-taccap-lerobot` and need no login to pull;
+> `docker/install_customer.sh` prepares the host (Docker, NVIDIA Container
+> Toolkit, the udev rules documented below) and pulls one — see
+> [the install section](docker/README.md#2-客户安装在线拉取). Building the image
+> yourself is a maintainer path, not an installation step.
 
 Tested on Ubuntu 22.04, NVIDIA driver ≥ 570.144. Use
 [`Mamba`](https://github.com/conda-forge/miniforge?tab=readme-ov-file#install)
@@ -63,11 +65,10 @@ cd xense-taccap-lerobot
 > git submodule update --init --recursive --progress
 > ```
 >
-> Check what yours are on with
-> `git submodule foreach 'git remote get-url origin'`. Both submodule
-> repositories are public, so HTTPS needs no credentials at all — which is the
-> point: a customer machine and a Docker build can fetch them without being
-> given a key.
+> Check what yours is on with
+> `git submodule foreach 'git remote get-url origin'`. The submodule repository
+> is public, so HTTPS needs no credentials at all — which is the point: a
+> Docker build can fetch it without being given a key.
 
 This repository uses one `third_party/` git submodule for a hardware SDK:
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,10 +2,18 @@ name: xense-taccap-lerobot
 
 services:
   xense-taccap:
-    # The default is the local build, so `docker compose build` and
-    # docker/package_customer_delivery.sh keep matching. Set LEROBOT_IMAGE to
-    # ghcr.io/<owner>/xense-taccap-lerobot in .env to pull from GHCR instead.
-    image: ${LEROBOT_IMAGE:-xense-taccap-lerobot}:${LEROBOT_IMAGE_TAG:-latest}
+    # The default is the published GHCR image, so a fresh checkout can
+    # `docker compose pull` with no .env at all. The package is public: pulling
+    # needs no login, only pushing does.
+    #
+    # `latest` floats. Pin a rig to a release before recording anything:
+    #
+    #     LEROBOT_IMAGE_TAG=0.0.4        # in .env
+    #
+    # `docker compose build` tags its output with this same name, which keeps it
+    # matching docker/push_ghcr.sh and docker/package_customer_delivery.sh. Set
+    # LEROBOT_IMAGE to build or run under a different name.
+    image: ${LEROBOT_IMAGE:-ghcr.io/vertax42/xense-taccap-lerobot}:${LEROBOT_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.user

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,6 +4,9 @@
 LeRobot-Xense、XenseSDK、TacCap-Gripper SDK、Pico4 Python 绑定，
 并在容器启动时默认启动 XenseVR PC Service。
 
+**安装方式只有一种：从 GHCR 在线拉取。** 镜像是公开的，拉取不需要登录。离线 tar
+交付是内部应急手段，见第 6 节，不作为常规交付路径。
+
 ## 0. 镜像里有什么
 
 当前发布版本 **0.0.4**（`ghcr.io/vertax42/xense-taccap-lerobot:0.0.4`，`latest` 指向同一镜像）。
@@ -44,52 +47,61 @@ LeRobot-Xense、XenseSDK、TacCap-Gripper SDK、Pico4 Python 绑定，
 - Docker Engine + Docker Compose 插件
 - NVIDIA Container Toolkit；`docker run --rm --gpus all ubuntu:22.04 nvidia-smi`
   应能看到显卡
-- USB/串口/HID/CAN 设备仍需在**宿主机**完成 README 中的 udev 规则，容器不能替宿主机管理热插拔规则
+- USB/串口/HID/CAN 设备仍需在**宿主机**完成 udev 规则，容器不能替宿主机管理热插拔规则
+
+其中 Docker、NVIDIA Container Toolkit 和 udev 规则都由第 2 节的 `install_customer.sh`
+自动装好，这里列出只是为了说明这台机器最终需要具备什么。
 
 Compose 使用 `privileged: true`、host 网络和 host IPC，以支持运行中热插拔的
 Xense 触觉/手腕相机、TacCap 串口、Pico4 和 CAN。请只在可信的机器人主机上运行。
 
-## 2. 客户交付与新机器一键安装
-
-开发机在镜像构建、验证完成后执行：
+## 2. 客户安装（在线拉取）
 
 ```bash
-export LEROBOT_IMAGE_TAG=0.0.4
-./docker/package_customer_delivery.sh
+git clone https://github.com/Vertax42/xense-taccap-lerobot.git
+cd xense-taccap-lerobot
+./docker/install_customer.sh
 ```
 
-脚本会在 `dist/customer/` 下生成一个完整交付目录，包含：
+**不需要 `git submodule update`** —— submodule 只在自己构建镜像时才用得上（第 5 节），
+拉现成镜像用不到。
 
-- `xense-taccap-lerobot-<版本>-linux-amd64.tar`
-- `SHA256SUMS`
-- `compose.yaml` 和 `.env`
-- 客户侧 `install_customer.sh`
-- Docker 中文说明
-
-将整个目录复制到客户的新机器，然后使用普通用户执行：
-
-```bash
-cd xense-taccap-lerobot-0.0.4-linux-amd64
-./install_customer.sh
-```
-
-客户脚本会自动完成：
+脚本会自动完成：
 
 1. 检查 Ubuntu/Debian amd64 和宿主机 NVIDIA 驱动。
 2. 缺少时安装 Docker Engine、Buildx 和 Compose 插件。
 3. 缺少时安装 NVIDIA Container Toolkit，并配置 Docker GPU runtime/CDI。
 4. 安装 TacCap 宿主机 udev 规则（CH343 的 ModemManager 屏蔽规则）。
-5. 校验 SHA256、导入镜像并运行 PyTorch CUDA 冒烟测试。
+5. 从 GHCR 拉取镜像并运行 PyTorch CUDA 冒烟测试。
 
 需要本机 HTTP 代理时：
 
 ```bash
-XENSE_PROXY_URL=http://127.0.0.1:7897 ./install_customer.sh
+XENSE_PROXY_URL=http://127.0.0.1:7897 ./docker/install_customer.sh
 ```
 
 脚本不会自动安装或升级宿主机 NVIDIA 驱动，因为驱动安装涉及显卡型号、
 Secure Boot 和系统重启。若 `nvidia-smi` 不可用或驱动低于 `570.144`，脚本会停止并
 提示先处理驱动。
+
+### 录数据前请 pin 版本
+
+默认拉的是 `latest`，它是**浮动**的：下一次发布会把同一个 tag 指到新镜像上。正式采集
+之前，在仓库根目录的 `.env` 里钉死版本：
+
+```dotenv
+LEROBOT_IMAGE_TAG=0.0.4
+```
+
+`.env` 已在 `.gitignore` 里，不会被提交。想确认手上跑的到底是哪一个镜像：
+
+```bash
+docker image inspect --format '{{index .RepoDigests 0}}' \
+    ghcr.io/vertax42/xense-taccap-lerobot:0.0.4
+```
+
+发布时 `0.0.4` 和 `latest` 指向同一镜像，两者 digest 应当一致。想在**拉之前**看远端的，
+用 `docker manifest inspect <image>:<tag>`，不必先下载 21 GB。
 
 ### 安装完成后的宿主机设置
 
@@ -119,86 +131,18 @@ xhost +si:localuser:root
 xhost -si:localuser:root
 ```
 
-## 3. 从 GHCR 拉取镜像（在线交付）
+### 后续升级
 
-镜像同时发布在 GitHub Container Registry：
-
-```text
-ghcr.io/vertax42/xense-taccap-lerobot
-```
-
-该包是 **public** 的，拉取不需要登录 —— 与仓库本身一致：镜像里的 XenseSDK 来自公开
-PyPI，XenseVR-PC-Service 的 `.deb` 来自公开 GitHub release，taccap-gripper submodule
-也是公开仓库，没有一样是靠镜像才拿得到的。只有**推送**需要凭据。
-
-第 2 节的 tar 交付方式**继续保留**：客户机完全离线时仍然只能走 tar。GHCR 的价值在
-后续升级 —— 21 GB 里绝大部分是 conda 层和 SDK 层，版本迭代时客户只需要拉变动的
-几层，而不是重新搬一遍整包。
-
-### 客户侧拉取
-
-在交付目录（或仓库根目录）的 `.env` 里指向 GHCR：
-
-```dotenv
-LEROBOT_IMAGE=ghcr.io/vertax42/xense-taccap-lerobot
-LEROBOT_IMAGE_TAG=0.0.4
-```
-
-`compose.yaml` 默认仍是本地构建的 `xense-taccap-lerobot`，只有设置了
-`LEROBOT_IMAGE` 才改为从 GHCR 拉取。之后照常：
+改 `.env` 里的 `LEROBOT_IMAGE_TAG`，然后：
 
 ```bash
 docker compose pull
-docker compose run --rm xense-taccap
 ```
 
-`latest` 是浮动的，出问题时先确认手上这个到底是哪一个镜像：
+21 GB 里绝大部分是 conda 层和 SDK 层，版本迭代时只会拉变动的那几层，不是重新
+搬一遍整包。
 
-```bash
-docker image inspect --format '{{index .RepoDigests 0}}' \
-    ghcr.io/vertax42/xense-taccap-lerobot:0.0.4
-```
-
-发布时 `0.0.4` 和 `latest` 指向同一镜像，两者 digest 应当一致。想在**拉之前**看远端的，
-用 `docker manifest inspect <image>:<tag>`，不必先下载 21 GB。
-
-### 维护者侧推送
-
-推荐走 GitHub Actions（在托管 runner 上构建并推送，不占用本机上行带宽）：
-
-- 仓库 Actions 页面手动触发 **Docker Publish**（`workflow_dispatch`），
-  tag 留空则取 `pyproject.toml` 里 `+xtac.` 之后的版本号；
-- 或推一个 `v*` git tag 自动触发。
-
-需要推送**本机已经构建并验证过**的镜像时，用脚本：
-
-```bash
-export GHCR_TOKEN=<classic PAT，需要 write:packages>
-./docker/push_ghcr.sh 0.0.4
-```
-
-不传参数时同样从 `pyproject.toml` 推导 tag；默认连带推 `latest`，用 `--no-latest`
-关闭。镜像很大，脚本内置了推送重试 —— `docker push` 按层续传，重试不会从头再来。
-
-## 4. 初始化源码并构建
-
-构建前必须拉取 git submodule —— `third_party/taccap-gripper` 会在镜像里从源码编译：
-
-```bash
-git submodule update --init --recursive --progress
-docker compose build
-```
-
-> 只剩这一个 submodule。Pico4 的 `xensevr_pc_service_sdk` 仍然会编译（那是仓库内的
-> pybind），但它链接的 C SDK 直接取自安装好的 `xensevr-pc-service` `.deb`，不再需要
-> 克隆 `XenseVR-PC-Service`；`xensesdk` 则是 PyPI 上的预编译 wheel。
-
-首次构建需要下载 Conda/CUDA/Python 依赖并编译原生模块，耗时较长，镜像也会比较大。
-后续未修改 `conda_environment.yaml` 时会复用最耗时的依赖层。
-Dockerfile 已包含 apt/curl 自动重试、CUDA 12.8 构建期覆盖和 flexible channel
-priority，不再需要使用临时 `sed` 命令修改构建过程。
-
-## 5. 启动与验证
+## 3. 启动与验证
 
 进入容器：
 
@@ -233,7 +177,7 @@ lerobot-info
 docker compose run --rm xense-taccap lerobot-info
 ```
 
-## 6. 数据、缓存与 GUI
+## 4. 数据、缓存与 GUI
 
 LeRobot 数据根目录 `HF_LEROBOT_HOME` 已设为 `/data/lerobot`，Hugging Face
 和 Torch 缓存也使用 Docker volume，删除容器不会丢失：
@@ -275,9 +219,105 @@ START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap
 
 服务日志默认位于容器内 `/tmp/xensevr-service.log`。
 
+## 5. 维护者：构建与发布
+
+### 本地构建
+
+构建前必须拉取 git submodule —— `third_party/taccap-gripper` 会在镜像里从源码编译：
+
+```bash
+git submodule update --init --recursive --progress
+docker compose build
+```
+
+> 只剩这一个 submodule。Pico4 的 `xensevr_pc_service_sdk` 仍然会编译（那是仓库内的
+> pybind），但它链接的 C SDK 直接取自安装好的 `xensevr-pc-service` `.deb`，不再需要
+> 克隆 `XenseVR-PC-Service`；`xensesdk` 则是 PyPI 上的预编译 wheel。
+
+首次构建需要下载 Conda/CUDA/Python 依赖并编译原生模块，耗时较长，镜像也会比较大。
+后续未修改 `conda_environment.yaml` 时会复用最耗时的依赖层。
+Dockerfile 已包含 apt/curl 自动重试、CUDA 12.8 构建期覆盖和 flexible channel
+priority，不再需要使用临时 `sed` 命令修改构建过程。
+
+`docker compose build` 打出来的镜像名和 compose 的默认值一致，也就是
+`ghcr.io/vertax42/xense-taccap-lerobot:latest` —— 和拉下来的镜像同名。想构建成别的
+名字或版本，用 `LEROBOT_IMAGE` / `LEROBOT_IMAGE_TAG` 覆盖。
+
+### 发布
+
+**正常发布路径是推一个 `v*` git tag**，由 `.github/workflows/docker-publish.yml`
+在托管 runner 上构建并推送，不占用本机上行带宽：
+
+```bash
+# 先把 pyproject.toml 的 version 改成 0.5.1+xtac.0.0.5 并提交
+git tag -a v0.0.5 -m 'release 0.0.5'
+git push origin v0.0.5
+```
+
+tag 名去掉前导 `v` 就是镜像 tag。workflow 同时打 `latest` 和 `sha-<commit>`。
+也可以在仓库 Actions 页面手动触发 **Docker Publish**（`workflow_dispatch`），
+tag 留空则取 `pyproject.toml` 里 `+xtac.` 之后的版本号。
+
+发布后确认远端：
+
+```bash
+docker manifest inspect ghcr.io/vertax42/xense-taccap-lerobot:0.0.5
+```
+
+镜像包是 **public** 的，拉取不需要登录 —— 与仓库本身一致：镜像里的 XenseSDK 来自公开
+PyPI，XenseVR-PC-Service 的 `.deb` 来自公开 GitHub release，taccap-gripper submodule
+也是公开仓库，没有一样是靠镜像才拿得到的。只有**推送**需要凭据。
+
+## 6. 内部应急手段
+
+这一节的两个脚本**不进客户文档**，只在常规路径不可用时使用。
+
+### 6.1 手动推送本机镜像
+
+workflow 挂了，或者要发布的就是刚在本机实机验证过的那个镜像时：
+
+```bash
+export GHCR_TOKEN=<classic PAT，需要 write:packages>
+./docker/push_ghcr.sh 0.0.4
+```
+
+不传参数时同样从 `pyproject.toml` 推导 tag；默认连带推 `latest`，用 `--no-latest`
+关闭。镜像很大，脚本内置了推送重试 —— `docker push` 按层续传，重试不会从头再来。
+
+### 6.2 离线 tar 交付
+
+只在客户机**完全无法访问 ghcr.io** 时使用。开发机上：
+
+```bash
+LEROBOT_IMAGE_TAG=0.0.4 docker compose build
+LEROBOT_IMAGE_TAG=0.0.4 ./docker/package_customer_delivery.sh
+```
+
+两条命令的 `LEROBOT_IMAGE_TAG` 必须一致：`docker compose build` 默认打的是
+`latest`，打包脚本按 tag 找镜像，找不到就会报 `Docker image not found`。
+
+脚本会在 `dist/customer/` 下生成一个交付目录，包含 tar、`SHA256SUMS`、
+`compose.yaml`、`.env` 和 `install_customer.sh`。把整个目录复制到客户机后：
+
+```bash
+cd xense-taccap-lerobot-0.0.4-linux-amd64
+./install_customer.sh
+```
+
+`install_customer.sh` 看到同目录下有 tar 就自动走离线装载（校验 SHA256 后
+`docker load`），宿主机准备步骤与在线路径完全相同。目录里有多个 tar 时它会拒绝猜测，
+要求把目标 tar 作为参数传入。
+
 ## 7. 常见问题
 
-- `Missing git submodules`：在仓库根目录执行
+- `pull access denied ... may require 'docker login'`：**不是权限问题**。GHCR 上的包是
+  公开的，拉取从不需要登录。这条报错说明镜像名被解析成了 registry 上不存在的名字 ——
+  检查 `.env` 里的 `LEROBOT_IMAGE` 是否被改成了本地构建名，或用
+  `docker compose config --images` 看看实际解析出来的是什么。
+- 打包/推送脚本报 `Docker image not found: ...:0.0.4`：`docker compose build` 打的 tag 是
+  `latest`。用 `LEROBOT_IMAGE_TAG=0.0.4 docker compose build` 重新构建，或先
+  `docker tag` 到目标 tag。
+- `Missing git submodules`：只有自己构建镜像时才需要 submodule。在仓库根目录执行
   `git submodule update --init --recursive` 后重新构建。
 - `could not select device driver ... gpu`：安装/配置 NVIDIA Container Toolkit，
   然后重启 Docker daemon。

--- a/docker/install_customer.sh
+++ b/docker/install_customer.sh
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Installs a customer machine. The normal path is online: prepare the host,
+# then pull the published image from GHCR. The package is public, so the pull
+# needs no credentials.
+#
+# An image archive is the offline fallback, for a machine that cannot reach
+# ghcr.io at all. It is used when one is passed explicitly, or when exactly one
+# sits next to this script — which is the layout docker/package_customer_delivery.sh
+# produces. Neither is required any more: with no archive in sight the script
+# pulls instead of failing.
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ARCHIVE_PATH="${1:-${XENSE_IMAGE_ARCHIVE:-}}"
 PROXY_URL="${XENSE_PROXY_URL:-}"
-IMAGE_REPOSITORY="${XENSE_IMAGE_REPOSITORY:-xense-taccap-lerobot}"
+IMAGE_REPOSITORY="${XENSE_IMAGE_REPOSITORY:-}"
 IMAGE_TAG="${LEROBOT_IMAGE_TAG:-}"
+DEFAULT_IMAGE_REPOSITORY="ghcr.io/vertax42/xense-taccap-lerobot"
 TEMP_DIR=""
 DOCKER_CMD=(docker)
 
@@ -19,17 +29,22 @@ fail() {
 }
 
 usage() {
-  cat <<'EOF'
+  cat <<EOF
 Usage: ./install_customer.sh [IMAGE_ARCHIVE]
 
-Installs/checks Docker and NVIDIA Container Toolkit, verifies and loads the
-delivery image, installs host udev rules, and runs a CUDA smoke test.
+Installs/checks Docker and NVIDIA Container Toolkit, installs host udev rules,
+obtains the container image, and runs a CUDA smoke test.
+
+The image is pulled from ${DEFAULT_IMAGE_REPOSITORY} unless an
+archive is given or found next to this script, in which case it is verified
+against SHA256SUMS and loaded from disk instead.
 
 Environment:
   XENSE_PROXY_URL          Optional HTTP/HTTPS proxy, e.g. http://127.0.0.1:7897
   XENSE_IMAGE_ARCHIVE      Image archive path when not passed as an argument
-  LEROBOT_IMAGE_TAG        Override the expected image tag
-  XENSE_IMAGE_REPOSITORY   Image repository name (default: xense-taccap-lerobot)
+  LEROBOT_IMAGE            Override the image repository
+  LEROBOT_IMAGE_TAG        Override the image tag (default: latest)
+  XENSE_IMAGE_REPOSITORY   Same as LEROBOT_IMAGE, kept for older delivery dirs
 EOF
 }
 
@@ -210,34 +225,68 @@ install_udev_rules() {
   sudo udevadm trigger
 }
 
-read_delivery_tag() {
-  if [[ -n "${IMAGE_TAG}" ]]; then
-    return
-  fi
-  if [[ -f "${ROOT_DIR}/.env" ]]; then
-    IMAGE_TAG="$(awk -F= '$1 == "LEROBOT_IMAGE_TAG" {print substr($0, index($0, "=") + 1); exit}' "${ROOT_DIR}/.env")"
-  fi
-  if [[ -z "${IMAGE_TAG}" && -f "${ROOT_DIR}/delivery.env" ]]; then
-    IMAGE_TAG="$(awk -F= '$1 == "LEROBOT_IMAGE_TAG" {print substr($0, index($0, "=") + 1); exit}' "${ROOT_DIR}/delivery.env")"
-  fi
-  IMAGE_TAG="${IMAGE_TAG:-latest}"
+# The script sits at docker/ in a repository checkout but at the top of a
+# delivery directory, so compose's .env is one level up in the first layout and
+# alongside in the second. Look in both rather than guessing which one this is.
+ENV_LOOKUP_RESULT=""
+TAG_EXPLICIT=0
+
+# Returns through a global on purpose: a $(...) capture would run this in a
+# subshell, so anything it recorded would be discarded with that subshell.
+env_lookup() {
+  local key="$1" candidate value
+  ENV_LOOKUP_RESULT=""
+  for candidate in "${ROOT_DIR}/.env" "${ROOT_DIR}/delivery.env" "${ROOT_DIR}/../.env"; do
+    [[ -f "${candidate}" ]] || continue
+    value="$(awk -F= -v k="${key}" '$1 == k {print substr($0, index($0, "=") + 1); exit}' "${candidate}")"
+    if [[ -n "${value}" ]]; then
+      ENV_LOOKUP_RESULT="${value}"
+      return
+    fi
+  done
 }
 
-find_archive() {
+resolve_image_ref() {
+  if [[ -z "${IMAGE_REPOSITORY}" ]]; then
+    env_lookup LEROBOT_IMAGE
+    IMAGE_REPOSITORY="${ENV_LOOKUP_RESULT:-${DEFAULT_IMAGE_REPOSITORY}}"
+  fi
+
+  if [[ -n "${IMAGE_TAG}" ]]; then
+    TAG_EXPLICIT=1
+  else
+    env_lookup LEROBOT_IMAGE_TAG
+    if [[ -n "${ENV_LOOKUP_RESULT}" ]]; then
+      IMAGE_TAG="${ENV_LOOKUP_RESULT}"
+      TAG_EXPLICIT=1
+    else
+      IMAGE_TAG="latest"
+    fi
+  fi
+}
+
+# Auto-detection, not a requirement: zero archives is the normal online case and
+# must stay silent. Two or more is genuinely ambiguous — picking one at random
+# would install an image the operator did not choose, so that still fails.
+detect_archive() {
   if [[ -n "${ARCHIVE_PATH}" ]]; then
     ARCHIVE_PATH="$(realpath "${ARCHIVE_PATH}")"
-    return
+    return 0
   fi
 
   local matches=()
   mapfile -t matches < <(find "${ROOT_DIR}" -maxdepth 1 -type f -name 'xense-taccap-lerobot-*.tar' -print | sort)
-  [[ "${#matches[@]}" -eq 1 ]] || \
-    fail "Expected exactly one xense-taccap-lerobot-*.tar in ${ROOT_DIR}; found ${#matches[@]}. Pass the archive path as the first argument."
-  ARCHIVE_PATH="${matches[0]}"
+  case "${#matches[@]}" in
+    0) return 1 ;;
+    1) ARCHIVE_PATH="${matches[0]}" ;;
+    *) fail "Found ${#matches[@]} xense-taccap-lerobot-*.tar files in ${ROOT_DIR}. Pass the one to install as the first argument." ;;
+  esac
 }
 
 derive_tag_from_archive() {
-  if [[ "${IMAGE_TAG}" != "latest" || -f "${ROOT_DIR}/.env" || -f "${ROOT_DIR}/delivery.env" ]]; then
+  # The archive name is the weakest source of a tag: it loses to an explicit
+  # LEROBOT_IMAGE_TAG and to one pinned in an env file.
+  if [[ "${TAG_EXPLICIT}" -eq 1 ]]; then
     return
   fi
 
@@ -260,13 +309,48 @@ verify_archive() {
   )
 }
 
-load_and_verify_image() {
+load_image_from_archive() {
   local image_ref="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
   log "Loading Docker image from ${ARCHIVE_PATH}"
   "${DOCKER_CMD[@]}" load --input "${ARCHIVE_PATH}"
+  # A bundle built before the image was renamed to its GHCR reference carries
+  # the bare `xense-taccap-lerobot` name, which no longer matches the default.
   "${DOCKER_CMD[@]}" image inspect "${image_ref}" >/dev/null 2>&1 || \
-    fail "Expected image was not found after docker load: ${image_ref}"
+    fail "$(
+      cat <<EOF
+Expected image was not found after docker load: ${image_ref}
 
+The archive loaded, but under a different name. \`docker images\` will show it;
+if this is an older delivery directory, rerun with:
+
+  XENSE_IMAGE_REPOSITORY=xense-taccap-lerobot ./install_customer.sh
+EOF
+    )"
+}
+
+pull_image() {
+  local image_ref="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+  log "Pulling ${image_ref} (this downloads about 21 GB on a first install)"
+  # Deliberately `docker pull` rather than `docker compose pull`: this script
+  # runs both from a repository checkout and from a delivery directory, and only
+  # the image reference is common to both. The package is public, so no login.
+  "${DOCKER_CMD[@]}" pull "${image_ref}" || \
+    fail "Could not pull ${image_ref}. Check network/proxy, or install offline by passing an image archive."
+}
+
+# Published images carry the release here: docker/metadata-action sets
+# org.opencontainers.image.version from the tag it pushed. Used only to make the
+# "pin your tag" hint name a real version instead of a placeholder.
+docker_image_version() {
+  local version=""
+  version="$("${DOCKER_CMD[@]}" image inspect \
+    --format '{{index .Config.Labels "org.opencontainers.image.version"}}' \
+    "${IMAGE_REPOSITORY}:${IMAGE_TAG}" 2>/dev/null || true)"
+  printf '%s' "${version:-<release>}"
+}
+
+verify_image() {
+  local image_ref="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
   log "Running GPU and Python smoke test with ${image_ref}"
   "${DOCKER_CMD[@]}" run --rm --gpus all \
     --entrypoint python "${image_ref}" \
@@ -282,10 +366,20 @@ main() {
   require_normal_user
   load_os_release
   TEMP_DIR="$(mktemp -d)"
-  read_delivery_tag
-  find_archive
-  derive_tag_from_archive
-  verify_archive
+  resolve_image_ref
+
+  # Decide the image source before touching the host, so an ambiguous archive
+  # or a bad checksum stops the run before it starts installing packages.
+  local offline=0
+  if detect_archive; then
+    offline=1
+    derive_tag_from_archive
+    verify_archive
+    log "Installing offline from ${ARCHIVE_PATH}"
+  else
+    log "Installing online from ${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+  fi
+
   install_docker
   configure_docker_proxy
   configure_docker_access
@@ -293,13 +387,25 @@ main() {
   install_udev_rules
   sudo systemctl restart docker
   configure_docker_access
-  load_and_verify_image
+
+  if [[ "${offline}" -eq 1 ]]; then
+    load_image_from_archive
+  else
+    pull_image
+  fi
+  verify_image
 
   log "Installation completed successfully."
   log "Log out and back in once so docker/video/plugdev group membership takes effect."
   log "Then start the container from this directory with:"
   log "  xhost +SI:localuser:root"
   log "  docker compose run --rm xense-taccap"
+  if [[ "${IMAGE_TAG}" == "latest" ]]; then
+    log ""
+    log "NOTE: this machine is on the floating \`latest\` tag. Before recording"
+    log "data, pin it in .env so a later release cannot change the image underneath:"
+    log "  LEROBOT_IMAGE_TAG=$(docker_image_version)"
+  fi
 }
 
 main "$@"

--- a/docker/package_customer_delivery.sh
+++ b/docker/package_customer_delivery.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Internal fallback, not the customer path. Customers install online: the image
+# is public on GHCR and docker/install_customer.sh pulls it. This exists for a
+# machine that cannot reach ghcr.io at all, and moving 21 GB by hand is the
+# reason it is the exception rather than the rule.
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-IMAGE_REPOSITORY="${XENSE_IMAGE_REPOSITORY:-xense-taccap-lerobot}"
+# Matches compose.yaml's default image name, so this packages whatever
+# `docker compose build` just produced.
+IMAGE_REPOSITORY="${XENSE_IMAGE_REPOSITORY:-ghcr.io/vertax42/xense-taccap-lerobot}"
 IMAGE_TAG="${1:-${LEROBOT_IMAGE_TAG:-latest}}"
 IMAGE_REF="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
 DIST_ROOT="${XENSE_DIST_DIR:-${ROOT_DIR}/dist/customer}"
@@ -25,14 +31,22 @@ require_command() {
 }
 
 usage() {
-  cat <<'EOF'
+  cat <<EOF
 Usage: ./docker/package_customer_delivery.sh [IMAGE_TAG]
 
-Packages xense-taccap-lerobot:<IMAGE_TAG> for offline customer delivery.
-IMAGE_TAG defaults to LEROBOT_IMAGE_TAG, then latest.
+Packages an already-built image into a tar bundle for a customer machine that
+cannot reach ghcr.io. The normal install is online — see docker/README.md.
+
+IMAGE_TAG defaults to LEROBOT_IMAGE_TAG, then latest. Note that
+\`docker compose build\` tags its output \`latest\`, so packaging a release tag
+means building it under that tag in the first place:
+
+    LEROBOT_IMAGE_TAG=0.0.4 docker compose build
+    LEROBOT_IMAGE_TAG=0.0.4 ./docker/package_customer_delivery.sh
 
 Environment:
-  XENSE_IMAGE_REPOSITORY   Image repository name (default: xense-taccap-lerobot)
+  XENSE_IMAGE_REPOSITORY   Image repository name
+                           (default: ${IMAGE_REPOSITORY})
   XENSE_DIST_DIR           Output root (default: dist/customer)
   XENSE_FORCE_PACKAGE=1    Allow overwriting an existing image archive
 EOF
@@ -47,8 +61,10 @@ main() {
   require_command docker
   require_command sha256sum
 
+  # `docker compose build` tags `latest` unless LEROBOT_IMAGE_TAG was set for
+  # the build too, which is the usual reason this check trips.
   docker image inspect "${IMAGE_REF}" >/dev/null 2>&1 || \
-    fail "Docker image not found: ${IMAGE_REF}"
+    fail "Docker image not found: ${IMAGE_REF}. Build it under that tag with \`LEROBOT_IMAGE_TAG=${IMAGE_TAG} docker compose build\`, or retag an existing build."
 
   local image_arch
   image_arch="$(docker image inspect --format '{{.Architecture}}' "${IMAGE_REF}")"

--- a/docker/push_ghcr.sh
+++ b/docker/push_ghcr.sh
@@ -3,14 +3,25 @@ set -euo pipefail
 
 # Pushes a locally built xense-taccap-lerobot image to GHCR.
 #
-# The normal publishing path is .github/workflows/docker-publish.yml, which
-# builds on a hosted runner and uploads over GitHub's own network. This script
-# is the manual route: it pushes an image that is already on this machine,
-# which is what you want when the workflow is unavailable or when the image you
-# want published is the one you just validated against real hardware.
+# The normal publishing path is a `v*` git tag, which fires
+# .github/workflows/docker-publish.yml to build on a hosted runner and upload
+# over GitHub's own network:
+#
+#     git tag -a v0.0.5 -m 'release 0.0.5' && git push origin v0.0.5
+#
+# This script is the fallback: it pushes an image already on this machine, for
+# when the workflow is unavailable or when the image you want published is the
+# one you just validated against real hardware.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-LOCAL_REPOSITORY="${XENSE_IMAGE_REPOSITORY:-xense-taccap-lerobot}"
+# The bare package name, used to build the target GHCR reference. Kept separate
+# from LOCAL_REPOSITORY below: compose now builds under the full GHCR name, and
+# feeding that back into "${REGISTRY}/${owner}/..." would produce
+# ghcr.io/<owner>/ghcr.io/<owner>/xense-taccap-lerobot.
+IMAGE_NAME="xense-taccap-lerobot"
+# Resolved in main(), once the owner is known: it defaults to the same name
+# compose.yaml builds under.
+LOCAL_REPOSITORY="${XENSE_IMAGE_REPOSITORY:-}"
 REGISTRY="${GHCR_REGISTRY:-ghcr.io}"
 PUSH_LATEST=1
 IMAGE_TAG=""
@@ -32,8 +43,12 @@ usage() {
   cat <<'EOF'
 Usage: ./docker/push_ghcr.sh [IMAGE_TAG] [--no-latest]
 
-Pushes the local image xense-taccap-lerobot:<IMAGE_TAG> to GHCR as
-ghcr.io/<owner>/xense-taccap-lerobot:<IMAGE_TAG>.
+Pushes a locally built image to ghcr.io/<owner>/xense-taccap-lerobot:<IMAGE_TAG>.
+It reads the image compose.yaml builds by default, so with the default settings
+the local and target names are the same and only the push happens.
+
+The normal publishing path is a `v*` git tag, which fires the Docker Publish
+workflow. Use this when that is unavailable.
 
 IMAGE_TAG defaults to LEROBOT_IMAGE_TAG, then to the fork version in
 pyproject.toml (the part after `+xtac.`).
@@ -48,7 +63,9 @@ Environment:
   GHCR_OWNER               GHCR namespace (default: parsed from `origin`)
   GHCR_IMAGE               Full target repository, overriding registry/owner
   GHCR_REGISTRY            Registry host (default: ghcr.io)
-  XENSE_IMAGE_REPOSITORY   Local image name (default: xense-taccap-lerobot)
+  XENSE_IMAGE_REPOSITORY   Local image name to push from
+                           (default: ghcr.io/<owner>/xense-taccap-lerobot,
+                           matching compose.yaml)
   GHCR_PUSH_RETRIES        Push attempts per tag (default: 3)
 EOF
 }
@@ -148,8 +165,11 @@ main() {
 
   local owner target_repository local_ref
   owner="${GHCR_OWNER:-$(resolve_owner)}"
-  target_repository="${GHCR_IMAGE:-${REGISTRY}/${owner}/${LOCAL_REPOSITORY}}"
+  target_repository="${GHCR_IMAGE:-${REGISTRY}/${owner}/${IMAGE_NAME}}"
   GHCR_USER="${GHCR_USER:-${owner}}"
+  # Same default as compose.yaml, so this pushes whatever `docker compose build`
+  # produced. When the two names coincide the `docker tag` below is a no-op.
+  LOCAL_REPOSITORY="${LOCAL_REPOSITORY:-${REGISTRY}/${owner}/${IMAGE_NAME}}"
   local_ref="${LOCAL_REPOSITORY}:${IMAGE_TAG}"
 
   # Same two preflight checks as package_customer_delivery.sh: the image has to


### PR DESCRIPTION
Customers now install by pulling from GHCR. The tar bundle and the manual push
become internal fallbacks, and releases go out by pushing a `v*` git tag —
which `docker-publish.yml` already listens for, though no tag has ever been
pushed, so the first release will be that path's first run.

## The papercut this removes

`docker compose pull` failed on a fresh checkout:

```
pull access denied for xense-taccap-lerobot, repository does not exist
or may require 'docker login'
```

`compose.yaml` defaulted to the **local build** name, which is on no registry.
Worse, the message contradicts `docker/README.md`, which correctly says the
package is public and pulling needs no login — so the obvious next move,
`docker login ghcr.io`, is wasted effort.

The default is now the GHCR reference, so a clone pulls with no `.env` at all.
`latest` still floats; the docs say to pin a rig before recording, and
`install_customer.sh` prints the release it just installed when the tag is
`latest`.

## `install_customer.sh` could not run without a tar

`find_archive` sat near the top of `main()` and failed hard when it found none,
so a pure online install had no path at all. It now picks its image source
first: an archive passed explicitly, or exactly one sitting next to the script,
still installs offline; anything else pulls.

Auto-detection is kept **deliberately** — the emergency bundle's whole point is
a machine with no network, and requiring an argument there would have broken
it. Two or more archives still fails rather than guessing. Host preparation
(Docker, NVIDIA Container Toolkit, udev rules) and the CUDA smoke test are
untouched and shared by both paths.

## A latent bug in `push_ghcr.sh`

The two packaging/push scripts follow compose's default name so they keep
matching what `docker compose build` produces. In `push_ghcr.sh` that needed a
fix rather than a new default: it builds the target as
`"${REGISTRY}/${owner}/${LOCAL_REPOSITORY}"`, so putting a full GHCR ref in
`LOCAL_REPOSITORY` would have produced

```
ghcr.io/<owner>/ghcr.io/<owner>/xense-taccap-lerobot
```

The bare package name now lives in `IMAGE_NAME` for building the target ref,
and `LOCAL_REPOSITORY` resolves after the owner is known.

## Docs

Also documents a trap the delivery flow already had: `docker compose build`
tags `latest`, so packaging a release tag means building under that tag too.
The old §2 said to package `0.0.4` right after a §4 build that produced only
`latest` — which fails the packaging script's first check. Reproduced before
changing it.

`docker/README.md` is reordered around the online path, so the anchor in the
top-level README moves with it. That README also claimed "Both submodule
repositories are public" two lines above saying the repo uses one — 42b44066
removed the other.

## Verification

- `docker compose config --images` resolves GHCR by default, honours the `.env`
  pin, and an env-var override
- `resolve_image_ref` honours env var > env file > default
- `detect_archive` covers 0 / 1 / 2 archives and an explicit path
- all four `docker/*.sh` pass `bash -n`
- both markdown files pass prettier 3.6.2 with the hook's own args
- against the real `0.0.4` image, the pico4 binding and the daemon both report
  `0.2.1` — the invariant §3 documents
- the smoke-test command `install_customer.sh` runs exits 0 on a GPU host

## Not in this PR

`Dockerfile.user` still apt-installs `libudev-dev` / `libusb-1.0-0-dev`, which
d50e49b4 showed nothing compiles against. They should become the runtime
package `libusb-1.0-0` — but **not by simple deletion**: `ubuntu:22.04` ships
`libudev1` and **not** `libusb-1.0-0`, so with `--no-install-recommends` the
runtime library currently arrives only as a dependency of the `-dev` package,
and dropping it would leave pyrealsense2 without `libusb-1.0.so.0`. That change
invalidates the apt layer, so it is kept separate from this docs/scripts work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
