### PR TITLE
docs(docker): cut the usage doc to a quickstart; initialize mamba hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ training scripts) refer to the
 > `ghcr.io/vertax42/xense-taccap-lerobot` and need no login to pull;
 > `docker/install_customer.sh` prepares the host (Docker, NVIDIA Container
 > Toolkit, the udev rules documented below) and pulls one — see
-> [the install section](docker/README.md#2-客户安装在线拉取). Building the image
-> yourself is a maintainer path, not an installation step.
+> [the install section](docker/README.md#2-安装在线拉取). Building the image
+> yourself is a maintainer path, not an installation step — see
+> [`docker/MAINTAINING.md`](docker/MAINTAINING.md) for that.
 
 Tested on Ubuntu 22.04, NVIDIA driver ≥ 570.144. Use
 [`Mamba`](https://github.com/conda-forge/miniforge?tab=readme-ov-file#install)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ training scripts) refer to the
 > `ghcr.io/vertax42/xense-taccap-lerobot` and need no login to pull;
 > `docker/install_customer.sh` prepares the host (Docker, NVIDIA Container
 > Toolkit, the udev rules documented below) and pulls one — see
-> [the install section](docker/README.md#2-安装在线拉取). Building the image
+> [the quickstart](docker/README.md#快速开始). Building the image
 > yourself is a maintainer path, not an installation step — see
 > [`docker/MAINTAINING.md`](docker/MAINTAINING.md) for that.
 

--- a/docker/Dockerfile.user
+++ b/docker/Dockerfile.user
@@ -120,9 +120,17 @@ RUN bash ./setup_env.sh --install \
     && mamba clean -afy \
     && rm -rf /root/.cache/pip /root/.cache/uv
 
+# Writes the mamba hook into /root/.bashrc so `mamba activate` works in an
+# interactive shell. The env is already active without it — the ENV PATH above
+# puts xense-taccap/bin first, which is what makes `docker run <img> python ...`
+# work with no shell setup at all, and that stays the mechanism. This only adds
+# the ability to switch environments by hand; without it mamba answers
+# "Shell not initialized" and prints setup instructions, which reads like a
+# broken image even though nothing is wrong.
 RUN install -m 0755 docker/entrypoint.sh /usr/local/bin/lerobot-entrypoint \
     && mkdir -p /data /root/.xensesdk "${HF_HOME}" "${TORCH_HOME}" "${TRITON_CACHE_DIR}" "${XDG_RUNTIME_DIR}" \
-    && chmod 0700 "${XDG_RUNTIME_DIR}"
+    && chmod 0700 "${XDG_RUNTIME_DIR}" \
+    && mamba shell init --shell bash --root-prefix=/opt/conda
 
 VOLUME ["/data", "/root/.xensesdk", "/root/.cache/huggingface", "/root/.cache/torch"]
 

--- a/docker/MAINTAINING.md
+++ b/docker/MAINTAINING.md
@@ -1,0 +1,130 @@
+# LeRobot-Xense Docker 维护者说明
+
+面向构建和发布镜像的人。**使用镜像不需要看这份文档**，用法见
+[`README.md`](README.md)。
+
+## 1. 镜像 tag 从哪来
+
+镜像的 tag 由 `pyproject.toml` 的 `version = "0.5.1+xtac.<版本>"` 推导（Docker tag
+不能含 `+`，故只取 `+xtac.` 之后的部分）。`.github/workflows/docker-publish.yml` 和
+`docker/push_ghcr.sh` 用同一段 `sed` 推导，改动时要同步两处。
+
+每次发布同时打一个 `sha-<commit>` tag，可以精确追溯镜像是从哪个源码提交构建的。
+
+## 2. 本地构建
+
+构建前必须拉取 git submodule —— `third_party/taccap-gripper` 会在镜像里从源码编译：
+
+```bash
+git submodule update --init --recursive --progress
+docker compose build
+```
+
+> 只剩这一个 submodule。Pico4 的 `xensevr_pc_service_sdk` 仍然会编译（那是仓库内的
+> pybind），但它链接的 C SDK 直接取自安装好的 `xensevr-pc-service` `.deb`，不再需要
+> 克隆 `XenseVR-PC-Service`；`xensesdk` 则是 PyPI 上的预编译 wheel。
+
+首次构建需要下载 Conda/CUDA/Python 依赖并编译原生模块，耗时较长，镜像也会比较大。
+后续未修改 `conda_environment.yaml` 时会复用最耗时的依赖层。
+Dockerfile 已包含 apt/curl 自动重试、CUDA 12.8 构建期覆盖和 flexible channel
+priority，不再需要使用临时 `sed` 命令修改构建过程。
+
+`docker compose build` 打出来的镜像名和 compose 的默认值一致，也就是
+`ghcr.io/vertax42/xense-taccap-lerobot:latest` —— 和拉下来的镜像同名。想构建成别的
+名字或版本，用 `LEROBOT_IMAGE` / `LEROBOT_IMAGE_TAG` 覆盖。
+
+**注意 tag：`docker compose build` 默认打 `latest`。** 要构建一个具体版本，构建时就得
+带上 tag，否则后面按版本号找镜像的脚本会找不到：
+
+```bash
+LEROBOT_IMAGE_TAG=0.0.5 docker compose build
+```
+
+## 3. 发布
+
+**正常发布路径是推一个 `v*` git tag**，由 `.github/workflows/docker-publish.yml`
+在托管 runner 上构建并推送，不占用本机上行带宽：
+
+```bash
+# 1. 改 pyproject.toml 的 version，并更新 README 的版本号与变更说明
+#    例如 version = "0.5.1+xtac.0.0.6"
+# 2. 合并到 main
+# 3. 打 tag
+git tag -a v0.0.6 -m 'release 0.0.6'
+git push origin v0.0.6
+```
+
+tag 名去掉前导 `v` 就是镜像 tag。workflow 同时推 `latest` 和 `sha-<commit>`。
+构建约 13–15 分钟（registry 构建缓存生效时）。
+
+也可以在仓库 Actions 页面手动触发 **Docker Publish**（`workflow_dispatch`），
+tag 留空则取 `pyproject.toml` 里 `+xtac.` 之后的版本号，`push_latest` 可关掉。
+
+发布后确认三件事：
+
+```bash
+R=ghcr.io/vertax42/xense-taccap-lerobot
+docker manifest inspect $R:0.0.6 | grep -m1 digest   # 新 tag 存在
+docker manifest inspect $R:latest | grep -m1 digest  # 与上面一致
+```
+
+`latest` 是浮动的，发布会把它移到新镜像上；**旧的版本号 tag 不受影响**。
+
+> **不要重复发布同一个版本号。** workflow 会用新构建覆盖掉那个 tag，digest 变了但
+> 版本号没变，任何 pin 了它的机器下次 pull 会静默换到另一个镜像。要重发就升版本号。
+
+镜像包是 **public** 的，拉取不需要登录 —— 与仓库本身一致：镜像里的 XenseSDK 来自公开
+PyPI，XenseVR-PC-Service 的 `.deb` 来自公开 GitHub release，taccap-gripper submodule
+也是公开仓库，没有一样是靠镜像才拿得到的。只有**推送**需要凭据。
+
+## 4. 应急手段
+
+以下两条都不是常规路径，也不进客户文档。
+
+### 4.1 手动推送本机镜像
+
+workflow 挂了，或者要发布的就是刚在本机实机验证过的那个镜像时：
+
+```bash
+export GHCR_TOKEN=<classic PAT，需要 write:packages>
+./docker/push_ghcr.sh 0.0.5
+```
+
+不传参数时同样从 `pyproject.toml` 推导 tag；默认连带推 `latest`，用 `--no-latest`
+关闭。镜像很大，脚本内置了推送重试 —— `docker push` 按层续传，重试不会从头再来。
+
+### 4.2 离线 tar 交付
+
+只在客户机**完全无法访问 ghcr.io** 时使用。开发机上：
+
+```bash
+LEROBOT_IMAGE_TAG=0.0.5 docker compose build
+LEROBOT_IMAGE_TAG=0.0.5 ./docker/package_customer_delivery.sh
+```
+
+两条命令的 `LEROBOT_IMAGE_TAG` 必须一致，原因见第 2 节末尾。
+
+脚本会在 `dist/customer/` 下生成一个交付目录，包含 tar、`SHA256SUMS`、
+`compose.yaml`、`.env` 和 `install_customer.sh`。把整个目录复制到客户机后：
+
+```bash
+cd xense-taccap-lerobot-0.0.5-linux-amd64
+./install_customer.sh
+```
+
+`install_customer.sh` 看到同目录下有 tar 就自动走离线装载（校验 SHA256 后
+`docker load`），宿主机准备步骤与在线路径完全相同。目录里有多个 tar 时它会拒绝猜测，
+要求把目标 tar 作为参数传入。
+
+## 5. 维护者侧常见问题
+
+- `Missing git submodules`：在仓库根目录执行
+  `git submodule update --init --recursive` 后重新构建。
+- 打包/推送脚本报 `Docker image not found: ...:0.0.5`：`docker compose build` 打的 tag 是
+  `latest`。用 `LEROBOT_IMAGE_TAG=0.0.5 docker compose build` 重新构建，或先
+  `docker tag` 到目标 tag。
+- `docker push` 报 `denied`：包是公开的，拉取不需要登录，但推送要 —— 确认已
+  `docker login ghcr.io`，且 PAT 带 `write:packages`。
+- 构建需要离线/定制的 vendor wheel 或 `.deb`：先按 `setup_env.sh` 支持的
+  `XENSESDK_WHEEL` / `XENSEVR_DEB` 方式将安装物纳入构建上下文，再定制 Dockerfile；
+  默认镜像从项目规定的公开发布地址下载。

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,8 +4,9 @@
 LeRobot-Xense、XenseSDK、TacCap-Gripper SDK、Pico4 Python 绑定，
 并在容器启动时默认启动 XenseVR PC Service。
 
-**安装方式只有一种：从 GHCR 在线拉取。** 镜像是公开的，拉取不需要登录。离线 tar
-交付是内部应急手段，见第 6 节，不作为常规交付路径。
+**镜像从 GHCR 拉取，不需要自己构建，也不需要登录。** 本文只讲怎么把环境跑起来。
+构建镜像、发布新版本、离线交付这些维护者的事，见
+[`MAINTAINING.md`](MAINTAINING.md)。
 
 ## 0. 镜像里有什么
 
@@ -17,27 +18,18 @@ LeRobot-Xense、XenseSDK、TacCap-Gripper SDK、Pico4 Python 绑定，
 | CUDA 用户态               | 12.8（`CONDA_OVERRIDE_CUDA=12.8`）                                 |
 | XenseVR PC Service daemon | `.deb` **v0.2.1**，装在 `/opt/apps/roboticsservice`                |
 | `xensevr_pc_service_sdk`  | 仓库内 pybind 编译；链接的 C SDK 取自上面那个 `.deb`，版本号也随它 |
-| `xense.taccap`            | 由 `third_party/taccap-gripper` submodule 在镜像内从源码编译       |
+| `xense.taccap`            | 由 `third_party/taccap-gripper` 在镜像内从源码编译                 |
 | `xensesdk`                | PyPI 预编译 wheel                                                  |
-
-镜像的 tag 由 `pyproject.toml` 的 `version = "0.5.1+xtac.<版本>"` 推导（Docker tag 不能含
-`+`，故只取 `+xtac.` 之后的部分）。每次发布同时打一个 `sha-<commit>` tag，可以精确追溯
-镜像是从哪个源码提交构建的。
 
 ### 0.0.4 → 0.0.5 的变化
 
-**镜像内容与 0.0.4 基本相同** —— conda 环境、各个 SDK、daemon（仍是 v0.2.1）都没变。
+**镜像内容与 0.0.4 相同** —— conda 环境、各个 SDK、daemon（仍是 v0.2.1）都没变。
 变的是安装方式，所以已经装好 0.0.4 并且跑得好好的机器，没有必须升级的理由。
 
-- **安装改为从 GHCR 在线拉取。** 干净 clone 之后 `docker compose pull` 直接可用：
-  `compose.yaml` 的默认镜像名从本地构建名换成了
-  `ghcr.io/vertax42/xense-taccap-lerobot`。以前不写 `.env` 会撞
-  `pull access denied ... may require 'docker login'`，而那句提示是误导——包是公开的，
-  拉取从不需要登录。
-- **`install_customer.sh` 不再需要 tar。** 默认在线拉取；显式传入 tar、或同目录下正好有
-  一个 tar 时，才走离线装载。断网客户机的用法不变。
-- **离线 tar 交付和手动推送降为内部应急手段**，移到第 6 节，不再是客户流程。
-- **发布走 `v*` git tag 触发**，见第 5 节。
+- **安装改为从 GHCR 在线拉取。** 干净 clone 之后 `docker compose pull` 直接可用。
+  以前不写 `.env` 会撞 `pull access denied ... may require 'docker login'`，
+  而那句提示是误导——包是公开的，拉取从不需要登录。
+- **不再需要 tar 交付包。** 断网客户机仍可离线安装，用法见 `MAINTAINING.md`。
 
 对**已有命令行用法**没有影响：`lerobot-record` 等一概照旧。
 
@@ -52,8 +44,6 @@ LeRobot-Xense、XenseSDK、TacCap-Gripper SDK、Pico4 Python 绑定，
 其余是内部变化，不改变命令行：
 
 - daemon 升到 v0.2.1（修掉了 Pico 相机每帧刷屏、把调用方控制台冲垮的问题）
-- 镜像不再需要 `XenseVR-PC-Service` submodule：pico4 的 C SDK 直接取自 `.deb`，
-  构建时少一次 cmake + 静态 gRPC 链接
 - `--dataset.vcodec=auto` 现在会真正打开一次编码器再判定，无 GPU 的机器上会正确
   回退到 `libsvtav1`，而不是选中 nvenc 后在第一帧崩掉
 
@@ -66,13 +56,13 @@ LeRobot-Xense、XenseSDK、TacCap-Gripper SDK、Pico4 Python 绑定，
   应能看到显卡
 - USB/串口/HID/CAN 设备仍需在**宿主机**完成 udev 规则，容器不能替宿主机管理热插拔规则
 
-其中 Docker、NVIDIA Container Toolkit 和 udev 规则都由第 2 节的 `install_customer.sh`
+其中 Docker、NVIDIA Container Toolkit 和 udev 规则都由下一节的 `install_customer.sh`
 自动装好，这里列出只是为了说明这台机器最终需要具备什么。
 
 Compose 使用 `privileged: true`、host 网络和 host IPC，以支持运行中热插拔的
 Xense 触觉/手腕相机、TacCap 串口、Pico4 和 CAN。请只在可信的机器人主机上运行。
 
-## 2. 客户安装（在线拉取）
+## 2. 安装（在线拉取）
 
 ```bash
 git clone https://github.com/Vertax42/xense-taccap-lerobot.git
@@ -80,7 +70,7 @@ cd xense-taccap-lerobot
 ./docker/install_customer.sh
 ```
 
-**不需要 `git submodule update`** —— submodule 只在自己构建镜像时才用得上（第 5 节），
+**不需要 `git submodule update`** —— submodule 只在自己构建镜像时才用得上，
 拉现成镜像用不到。
 
 脚本会自动完成：
@@ -100,25 +90,6 @@ XENSE_PROXY_URL=http://127.0.0.1:7897 ./docker/install_customer.sh
 脚本不会自动安装或升级宿主机 NVIDIA 驱动，因为驱动安装涉及显卡型号、
 Secure Boot 和系统重启。若 `nvidia-smi` 不可用或驱动低于 `570.144`，脚本会停止并
 提示先处理驱动。
-
-### 录数据前请 pin 版本
-
-默认拉的是 `latest`，它是**浮动**的：下一次发布会把同一个 tag 指到新镜像上。正式采集
-之前，在仓库根目录的 `.env` 里钉死版本：
-
-```dotenv
-LEROBOT_IMAGE_TAG=0.0.5
-```
-
-`.env` 已在 `.gitignore` 里，不会被提交。想确认手上跑的到底是哪一个镜像：
-
-```bash
-docker image inspect --format '{{index .RepoDigests 0}}' \
-    ghcr.io/vertax42/xense-taccap-lerobot:0.0.5
-```
-
-发布时 `0.0.5` 和 `latest` 指向同一镜像，两者 digest 应当一致。想在**拉之前**看远端的，
-用 `docker manifest inspect <image>:<tag>`，不必先下载 21 GB。
 
 ### 安装完成后的宿主机设置
 
@@ -148,18 +119,42 @@ xhost +si:localuser:root
 xhost -si:localuser:root
 ```
 
-### 后续升级
+## 3. 录数据前请 pin 版本
 
-改 `.env` 里的 `LEROBOT_IMAGE_TAG`，然后：
+默认拉的是 `latest`，它是**浮动**的：下一次发布会把同一个 tag 指到新镜像上。正式采集
+之前，在仓库根目录的 `.env` 里钉死版本：
 
-```bash
-docker compose pull
+```dotenv
+LEROBOT_IMAGE_TAG=0.0.5
 ```
 
-21 GB 里绝大部分是 conda 层和 SDK 层，版本迭代时只会拉变动的那几层，不是重新
-搬一遍整包。
+`.env` 已在 `.gitignore` 里，不会被提交。改完确认 compose 解析成了你要的那个：
 
-## 3. 启动与验证
+```bash
+docker compose config --images
+```
+
+### 想在拉之前看远端有什么
+
+```bash
+docker manifest inspect ghcr.io/vertax42/xense-taccap-lerobot:0.0.5
+```
+
+`manifest inspect` 查的是 registry，**不需要先下载 21 GB**。
+
+### 想确认手上跑的是哪一个
+
+```bash
+docker image inspect --format '{{index .RepoDigests 0}}' \
+    ghcr.io/vertax42/xense-taccap-lerobot:0.0.5
+```
+
+注意 `image inspect` **只看本地已有的镜像**。没拉过这个 tag 就会报
+`No such image`，那不是出错，是还没拉——先 `docker compose pull`。
+
+发布时 `0.0.5` 和 `latest` 指向同一镜像，两者 digest 应当一致。
+
+## 4. 启动与验证
 
 进入容器：
 
@@ -194,7 +189,7 @@ lerobot-info
 docker compose run --rm xense-taccap lerobot-info
 ```
 
-## 4. 数据、缓存与 GUI
+## 5. 数据、缓存与 GUI
 
 LeRobot 数据根目录 `HF_LEROBOT_HOME` 已设为 `/data/lerobot`，Hugging Face
 和 Torch 缓存也使用 Docker volume，删除容器不会丢失：
@@ -236,106 +231,25 @@ START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap
 
 服务日志默认位于容器内 `/tmp/xensevr-service.log`。
 
-## 5. 维护者：构建与发布
+## 6. 升级到新版本
 
-### 本地构建
-
-构建前必须拉取 git submodule —— `third_party/taccap-gripper` 会在镜像里从源码编译：
+改 `.env` 里的 `LEROBOT_IMAGE_TAG`，然后：
 
 ```bash
-git submodule update --init --recursive --progress
-docker compose build
+docker compose pull
 ```
 
-> 只剩这一个 submodule。Pico4 的 `xensevr_pc_service_sdk` 仍然会编译（那是仓库内的
-> pybind），但它链接的 C SDK 直接取自安装好的 `xensevr-pc-service` `.deb`，不再需要
-> 克隆 `XenseVR-PC-Service`；`xensesdk` 则是 PyPI 上的预编译 wheel。
-
-首次构建需要下载 Conda/CUDA/Python 依赖并编译原生模块，耗时较长，镜像也会比较大。
-后续未修改 `conda_environment.yaml` 时会复用最耗时的依赖层。
-Dockerfile 已包含 apt/curl 自动重试、CUDA 12.8 构建期覆盖和 flexible channel
-priority，不再需要使用临时 `sed` 命令修改构建过程。
-
-`docker compose build` 打出来的镜像名和 compose 的默认值一致，也就是
-`ghcr.io/vertax42/xense-taccap-lerobot:latest` —— 和拉下来的镜像同名。想构建成别的
-名字或版本，用 `LEROBOT_IMAGE` / `LEROBOT_IMAGE_TAG` 覆盖。
-
-### 发布
-
-**正常发布路径是推一个 `v*` git tag**，由 `.github/workflows/docker-publish.yml`
-在托管 runner 上构建并推送，不占用本机上行带宽：
-
-```bash
-# 先把 pyproject.toml 的 version 改成 0.5.1+xtac.0.0.5 并提交
-git tag -a v0.0.5 -m 'release 0.0.5'
-git push origin v0.0.5
-```
-
-tag 名去掉前导 `v` 就是镜像 tag。workflow 同时打 `latest` 和 `sha-<commit>`。
-也可以在仓库 Actions 页面手动触发 **Docker Publish**（`workflow_dispatch`），
-tag 留空则取 `pyproject.toml` 里 `+xtac.` 之后的版本号。
-
-发布后确认远端：
-
-```bash
-docker manifest inspect ghcr.io/vertax42/xense-taccap-lerobot:0.0.5
-```
-
-镜像包是 **public** 的，拉取不需要登录 —— 与仓库本身一致：镜像里的 XenseSDK 来自公开
-PyPI，XenseVR-PC-Service 的 `.deb` 来自公开 GitHub release，taccap-gripper submodule
-也是公开仓库，没有一样是靠镜像才拿得到的。只有**推送**需要凭据。
-
-## 6. 内部应急手段
-
-这一节的两个脚本**不进客户文档**，只在常规路径不可用时使用。
-
-### 6.1 手动推送本机镜像
-
-workflow 挂了，或者要发布的就是刚在本机实机验证过的那个镜像时：
-
-```bash
-export GHCR_TOKEN=<classic PAT，需要 write:packages>
-./docker/push_ghcr.sh 0.0.5
-```
-
-不传参数时同样从 `pyproject.toml` 推导 tag；默认连带推 `latest`，用 `--no-latest`
-关闭。镜像很大，脚本内置了推送重试 —— `docker push` 按层续传，重试不会从头再来。
-
-### 6.2 离线 tar 交付
-
-只在客户机**完全无法访问 ghcr.io** 时使用。开发机上：
-
-```bash
-LEROBOT_IMAGE_TAG=0.0.5 docker compose build
-LEROBOT_IMAGE_TAG=0.0.5 ./docker/package_customer_delivery.sh
-```
-
-两条命令的 `LEROBOT_IMAGE_TAG` 必须一致：`docker compose build` 默认打的是
-`latest`，打包脚本按 tag 找镜像，找不到就会报 `Docker image not found`。
-
-脚本会在 `dist/customer/` 下生成一个交付目录，包含 tar、`SHA256SUMS`、
-`compose.yaml`、`.env` 和 `install_customer.sh`。把整个目录复制到客户机后：
-
-```bash
-cd xense-taccap-lerobot-0.0.5-linux-amd64
-./install_customer.sh
-```
-
-`install_customer.sh` 看到同目录下有 tar 就自动走离线装载（校验 SHA256 后
-`docker load`），宿主机准备步骤与在线路径完全相同。目录里有多个 tar 时它会拒绝猜测，
-要求把目标 tar 作为参数传入。
+21 GB 里绝大部分是 conda 层和 SDK 层，版本迭代时只会拉变动的那几层，不是重新
+搬一遍整包。
 
 ## 7. 常见问题
 
+- `No such image: ghcr.io/...`：`docker image inspect` 只查本地。这个 tag 还没拉过，
+  先 `docker compose pull`；只想看远端用 `docker manifest inspect`。
 - `pull access denied ... may require 'docker login'`：**不是权限问题**。GHCR 上的包是
   公开的，拉取从不需要登录。这条报错说明镜像名被解析成了 registry 上不存在的名字 ——
-  检查 `.env` 里的 `LEROBOT_IMAGE` 是否被改成了本地构建名，或用
-  `docker compose config --images` 看看实际解析出来的是什么。
-- 打包/推送脚本报 `Docker image not found: ...:0.0.5`：`docker compose build` 打的 tag 是
-  `latest`。用 `LEROBOT_IMAGE_TAG=0.0.5 docker compose build` 重新构建，或先
-  `docker tag` 到目标 tag。
-- `Missing git submodules`：只有自己构建镜像时才需要 submodule。在仓库根目录执行
-  `git submodule update --init --recursive` 后重新构建。
+  用 `docker compose config --images` 看看实际解析出来的是什么，并检查 `.env` 里的
+  `LEROBOT_IMAGE` 有没有被改掉。
 - `could not select device driver ... gpu`：安装/配置 NVIDIA Container Toolkit，
   然后重启 Docker daemon。
 - 容器能看到 `/dev/ttyACM*` 但设备 busy：按顶层 README 配置宿主机
@@ -343,11 +257,10 @@ cd xense-taccap-lerobot-0.0.5-linux-amd64
 - GUI 不显示：检查 `echo "$DISPLAY"`、`/tmp/.X11-unix` 和上述 `xhost` 授权。
 - Rerun 报 Vulkan adapter 错误：先确认 `nvidia-smi` 和
   `vulkaninfo --summary` 均能在容器中识别 NVIDIA GPU。
+- `torch.cuda.is_available()` 是 `False`，但 `nvidia-smi` 正常：宿主机的 CUDA 状态坏了，
+  与容器无关。笔记本挂起/恢复后常见。先在**宿主机**上确认
+  `python -c 'import ctypes; print(ctypes.CDLL("libcuda.so.1").cuInit(0))'` 是否返回 0；
+  非 0 时用 `sudo rmmod nvidia_uvm && sudo modprobe nvidia_uvm` 重载，或重启。
 - 找不到 GSPS，但宿主机存在：确认容器通过 Compose 启动，并检查
   `ls /dev/v4l/by-id/*GSPS*`；必要时重新插拔 USB Hub 后执行
   `sudo udevadm settle --timeout=20`。
-- `docker push` 报 `denied`：包是公开的，拉取不需要登录，但推送要 —— 确认已
-  `docker login ghcr.io`，且 PAT 带 `write:packages`。
-- 构建需要离线/定制的 vendor wheel 或 `.deb`：先按 `setup_env.sh` 支持的
-  `XENSESDK_WHEEL` / `XENSEVR_DEB` 方式将安装物纳入构建上下文，再定制 Dockerfile；
-  默认镜像从项目规定的公开发布地址下载。

--- a/docker/README.md
+++ b/docker/README.md
@@ -246,6 +246,12 @@ docker compose pull
 
 - `No such image: ghcr.io/...`：`docker image inspect` 只查本地。这个 tag 还没拉过，
   先 `docker compose pull`；只想看远端用 `docker manifest inspect`。
+- `mamba activate` 报 `critical libmamba Shell not initialized`：**环境本来就是激活的**，
+  不需要 activate。镜像把 `xense-taccap/bin` 放在 `PATH` 最前面来激活环境，而不是靠
+  shell hook —— `mamba env list` 里那个 `*` 就在 `xense-taccap` 上。直接敲 `python`、
+  `lerobot-info` 即可。确实想手动切环境时，先在当前 shell 里执行
+  `eval "$(mamba shell hook --shell bash)"`。0.0.5 及更早的镜像需要这一步，之后的镜像
+  已内置 hook。
 - `pull access denied ... may require 'docker login'`：**不是权限问题**。GHCR 上的包是
   公开的，拉取从不需要登录。这条报错说明镜像名被解析成了 registry 上不存在的名字 ——
   用 `docker compose config --images` 看看实际解析出来的是什么，并检查 `.env` 里的

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,272 +1,106 @@
-# LeRobot-Xense Docker 使用说明
+# LeRobot-Xense Docker
 
-该镜像包含项目的完整 `xense-taccap` Conda 环境、CUDA 12.8 用户态库、
-LeRobot-Xense、XenseSDK、TacCap-Gripper SDK、Pico4 Python 绑定，
-并在容器启动时默认启动 XenseVR PC Service。
+预装 `xense-taccap` Conda 环境、CUDA 12.8、LeRobot-Xense、XenseSDK、
+TacCap-Gripper SDK 和 Pico4 绑定的镜像。**从 GHCR 拉取，不需要自己构建，也不需要登录。**
 
-**镜像从 GHCR 拉取，不需要自己构建，也不需要登录。** 本文只讲怎么把环境跑起来。
-构建镜像、发布新版本、离线交付这些维护者的事，见
-[`MAINTAINING.md`](MAINTAINING.md)。
+构建镜像、发布新版本、离线交付见 [`MAINTAINING.md`](MAINTAINING.md)。
 
-## 0. 镜像里有什么
-
-当前发布版本 **0.0.5**（`ghcr.io/vertax42/xense-taccap-lerobot:0.0.5`，`latest` 指向同一镜像）。
-
-| 组成                      | 版本 / 来源                                                        |
-| ------------------------- | ------------------------------------------------------------------ |
-| Conda 环境                | `xense-taccap`，Python 3.12                                        |
-| CUDA 用户态               | 12.8（`CONDA_OVERRIDE_CUDA=12.8`）                                 |
-| XenseVR PC Service daemon | `.deb` **v0.2.1**，装在 `/opt/apps/roboticsservice`                |
-| `xensevr_pc_service_sdk`  | 仓库内 pybind 编译；链接的 C SDK 取自上面那个 `.deb`，版本号也随它 |
-| `xense.taccap`            | 由 `third_party/taccap-gripper` 在镜像内从源码编译                 |
-| `xensesdk`                | PyPI 预编译 wheel                                                  |
-
-### 0.0.4 → 0.0.5 的变化
-
-**镜像内容与 0.0.4 相同** —— conda 环境、各个 SDK、daemon（仍是 v0.2.1）都没变。
-变的是安装方式，所以已经装好 0.0.4 并且跑得好好的机器，没有必须升级的理由。
-
-- **安装改为从 GHCR 在线拉取。** 干净 clone 之后 `docker compose pull` 直接可用。
-  以前不写 `.env` 会撞 `pull access denied ... may require 'docker login'`，
-  而那句提示是误导——包是公开的，拉取从不需要登录。
-- **不再需要 tar 交付包。** 断网客户机仍可离线安装，用法见 `MAINTAINING.md`。
-
-对**已有命令行用法**没有影响：`lerobot-record` 等一概照旧。
-
-### 0.0.3 → 0.0.4 的变化
-
-对**已有使用方式**有影响的只有一条：
-
-- **`--robot.id` 现在接受纯数字**，并按 `--robot.type` 展开：`--robot.id=0` 在单臂上存为
-  `taccap_0`、在双臂上存为 `bi_taccap_0`。**旧写法不受影响** —— 非纯数字一律原样保留，
-  所以 `--robot.id=taccap_0` 和按它命名的标定文件都照常工作。
-
-其余是内部变化，不改变命令行：
-
-- daemon 升到 v0.2.1（修掉了 Pico 相机每帧刷屏、把调用方控制台冲垮的问题）
-- `--dataset.vcodec=auto` 现在会真正打开一次编码器再判定，无 GPU 的机器上会正确
-  回退到 `libsvtav1`，而不是选中 nvenc 后在第一帧崩掉
-
-## 1. 宿主机要求
-
-- Ubuntu 22.04/24.04，`linux/amd64`
-- NVIDIA 驱动 `>= 570.144`
-- Docker Engine + Docker Compose 插件
-- NVIDIA Container Toolkit；`docker run --rm --gpus all ubuntu:22.04 nvidia-smi`
-  应能看到显卡
-- USB/串口/HID/CAN 设备仍需在**宿主机**完成 udev 规则，容器不能替宿主机管理热插拔规则
-
-其中 Docker、NVIDIA Container Toolkit 和 udev 规则都由下一节的 `install_customer.sh`
-自动装好，这里列出只是为了说明这台机器最终需要具备什么。
-
-Compose 使用 `privileged: true`、host 网络和 host IPC，以支持运行中热插拔的
-Xense 触觉/手腕相机、TacCap 串口、Pico4 和 CAN。请只在可信的机器人主机上运行。
-
-## 2. 安装（在线拉取）
+## 快速开始
 
 ```bash
 git clone https://github.com/Vertax42/xense-taccap-lerobot.git
 cd xense-taccap-lerobot
-./docker/install_customer.sh
+./docker/install_customer.sh          # 装 Docker / NVIDIA Toolkit / udev 规则，并拉镜像
+docker compose run --rm xense-taccap  # 进容器
 ```
 
-**不需要 `git submodule update`** —— submodule 只在自己构建镜像时才用得上，
-拉现成镜像用不到。
-
-脚本会自动完成：
-
-1. 检查 Ubuntu/Debian amd64 和宿主机 NVIDIA 驱动。
-2. 缺少时安装 Docker Engine、Buildx 和 Compose 插件。
-3. 缺少时安装 NVIDIA Container Toolkit，并配置 Docker GPU runtime/CDI。
-4. 安装 TacCap 宿主机 udev 规则（CH343 的 ModemManager 屏蔽规则）。
-5. 从 GHCR 拉取镜像并运行 PyTorch CUDA 冒烟测试。
-
-需要本机 HTTP 代理时：
+容器里环境已激活，直接用：
 
 ```bash
-XENSE_PROXY_URL=http://127.0.0.1:7897 ./docker/install_customer.sh
+lerobot-info
+lerobot-find-cameras
 ```
 
-脚本不会自动安装或升级宿主机 NVIDIA 驱动，因为驱动安装涉及显卡型号、
-Secure Boot 和系统重启。若 `nvidia-smi` 不可用或驱动低于 `570.144`，脚本会停止并
-提示先处理驱动。
+`install_customer.sh` 需要几分钟到几十分钟（镜像约 21 GB）。要走代理就加
+`XENSE_PROXY_URL=http://127.0.0.1:7897`。
 
-### 安装完成后的宿主机设置
+## 宿主机要求
 
-`install_customer.sh` 已经执行 Docker 服务启用和用户组配置。为了确保当前用户
-立即获得 Docker 权限，可在宿主机执行以下命令：
+Ubuntu 22.04/24.04、`linux/amd64`、**NVIDIA 驱动 ≥ 570.144**。
+
+Docker、NVIDIA Container Toolkit 和 TacCap 的 udev 规则都由 `install_customer.sh`
+装好；**驱动要你自己先装**（涉及显卡型号、Secure Boot 和重启，脚本不碰）。
+
+装完后当前用户还需要两件事：
 
 ```bash
-sudo systemctl enable --now docker
-sudo usermod -aG docker "$USER"
-newgrp docker
-docker images
+sudo usermod -aG docker "$USER" && newgrp docker  # Docker 权限
+xhost +si:localuser:root                          # 要显示 Rerun 等窗口时
 ```
 
-`newgrp docker` 会为当前终端启动一个应用了新用户组的子 Shell；也可以注销并重新
-登录。这里仅将**当前用户**加入 `docker` 组，不会自动授权所有本地用户。请注意，
-`docker` 组成员拥有接近 root 的系统控制权限，只应加入可信用户。
+> Compose 使用 `privileged: true` + host 网络/IPC，以支持热插拔的触觉相机、串口、
+> Pico4 和 CAN。请只在可信的机器人主机上运行。
 
-如果需要在容器内显示 Rerun 等 X11 图形窗口，还要由宿主机当前图形桌面用户执行：
+## 录数据前请 pin 版本
 
-```bash
-xhost +si:localuser:root
-```
-
-使用完成后可以撤销授权：
-
-```bash
-xhost -si:localuser:root
-```
-
-## 3. 录数据前请 pin 版本
-
-默认拉的是 `latest`，它是**浮动**的：下一次发布会把同一个 tag 指到新镜像上。正式采集
-之前，在仓库根目录的 `.env` 里钉死版本：
+默认拉的是 `latest`，它是**浮动**的 —— 下次发布会把它指向新镜像。正式采集前在仓库根目录
+的 `.env` 里钉死（`.env` 不会被提交）：
 
 ```dotenv
 LEROBOT_IMAGE_TAG=0.0.5
 ```
 
-`.env` 已在 `.gitignore` 里，不会被提交。改完确认 compose 解析成了你要的那个：
+改完用 `docker compose config --images` 确认解析结果。
 
-```bash
-docker compose config --images
-```
+## 常用操作
 
-### 想在拉之前看远端有什么
+| 想做什么                 | 命令                                                                    |
+| ------------------------ | ----------------------------------------------------------------------- |
+| 跑一次性命令             | `docker compose run --rm xense-taccap lerobot-info`                     |
+| 升级镜像                 | 改 `.env` 的 tag，再 `docker compose pull`                              |
+| 确认解析到哪个镜像       | `docker compose config --images`                                        |
+| 看远端有什么（不下载）   | `docker manifest inspect ghcr.io/vertax42/xense-taccap-lerobot:0.0.5`   |
+| 确认本地跑的是哪个       | `docker image inspect --format '{{index .RepoDigests 0}}' <镜像>:<tag>` |
+| 不用 Pico4，关掉随启服务 | `START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap`          |
+| 查看数据                 | `docker compose run --rm xense-taccap bash -lc 'ls -la /data'`          |
 
-```bash
-docker manifest inspect ghcr.io/vertax42/xense-taccap-lerobot:0.0.5
-```
+数据和缓存都在 Docker volume 里，删容器不会丢：`/data`（`HF_LEROBOT_HOME=/data/lerobot`）、
+`/root/.xensesdk`、`/root/.cache/huggingface`、`/root/.cache/torch`。
 
-`manifest inspect` 查的是 registry，**不需要先下载 21 GB**。
+## 验证镜像
 
-### 想确认手上跑的是哪一个
-
-```bash
-docker image inspect --format '{{index .RepoDigests 0}}' \
-    ghcr.io/vertax42/xense-taccap-lerobot:0.0.5
-```
-
-注意 `image inspect` **只看本地已有的镜像**。没拉过这个 tag 就会报
-`No such image`，那不是出错，是还没拉——先 `docker compose pull`。
-
-发布时 `0.0.5` 和 `latest` 指向同一镜像，两者 digest 应当一致。
-
-## 4. 启动与验证
-
-进入容器：
-
-```bash
-docker compose run --rm xense-taccap
-```
-
-验证软件环境和 GPU：
+怀疑镜像有问题时，在容器里跑：
 
 ```bash
 python -c 'import torch; print(torch.__version__, torch.cuda.is_available())'
-python -c 'import xensesdk; print("xensesdk ->", xensesdk.__file__)'
-python -c 'import xense.taccap; print("taccap ->", xense.taccap.__file__)'
 python -c 'import importlib.metadata as M; print("pico4 ->", M.version("xensevr_pc_service_sdk"))'
 dpkg-query -W -f='daemon -> ${Version}\n' xensevr-pc-service
 ```
 
-后两行应当**打印同一个版本号**（0.0.5 镜像里是 `0.2.1`）。这不是巧合：pico4 绑定链接的
-C SDK 就是从那个 `.deb` 里取的，它的包版本也由 `dpkg-query` 推导。两者不一致，说明镜像
-是半新不旧的构建，不要拿它录数据。
+**后两行必须打印同一个版本号**（0.0.5 里是 `0.2.1`）。pico4 绑定链接的 C SDK 就取自那个
+`.deb`，两者不一致说明镜像是半新不旧的构建，不要拿它录数据。
 
-发现相机和串口：
+## 版本
 
-```bash
-lerobot-find-cameras
-lerobot-info
-```
+当前 **0.0.5**（`latest` 指向同一镜像）。只列影响使用方式的变化：
 
-直接执行一次性命令也可以：
+- **0.0.5** — 安装改为从 GHCR 在线拉取，不再需要 tar 交付包。镜像内容与 0.0.4 相同，
+  已装好 0.0.4 的机器没有必须升级的理由。
+- **0.0.4** — `--robot.id` 接受纯数字并按 `--robot.type` 展开（`--robot.id=0` → 单臂
+  `taccap_0`、双臂 `bi_taccap_0`）。旧写法不受影响。`--dataset.vcodec=auto` 改为真正
+  打开一次编码器再判定，无 GPU 的机器会正确回退到 `libsvtav1`。
 
-```bash
-docker compose run --rm xense-taccap lerobot-info
-```
+## 常见问题
 
-## 5. 数据、缓存与 GUI
-
-LeRobot 数据根目录 `HF_LEROBOT_HOME` 已设为 `/data/lerobot`，Hugging Face
-和 Torch 缓存也使用 Docker volume，删除容器不会丢失：
-
-```text
-/data                         -> lerobot-data
-/root/.xensesdk               -> xensesdk-cache（按传感器序列号缓存配置）
-/root/.cache/huggingface      -> huggingface-cache
-/root/.cache/torch            -> torch-cache
-```
-
-Compose 会透传宿主机 `/dev` 和 `/run/udev`，使程序能够读取
-`/dev/v4l/by-id`、`/dev/v4l/by-path` 和 `/dev/serial/by-path` 完成 USB Hub
-自动配对。XenseSDK 的配置缓存会跨 `--rm` 临时容器保留，避免每次启动重新读取
-传感器 flash 并触发 USB 重新枚举。
-
-查看或备份数据可使用：
-
-```bash
-docker compose run --rm xense-taccap bash -lc 'ls -la /data'
-```
-
-Compose 已透传 `DISPLAY` 和 X11 socket。宿主机若拒绝窗口连接，可临时授权本机 root：
-
-```bash
-xhost +si:localuser:root
-# 使用完后撤销
-xhost -si:localuser:root
-```
-
-镜像已包含 Rerun 所需的 XKB、Vulkan 和 XDG 运行库，并默认设置
-`WGPU_BACKEND=vulkan`。可用 `vulkaninfo --summary` 检查 NVIDIA Vulkan 是否正常。
-
-无 Pico4、只处理数据时，可关闭随容器启动的服务：
-
-```bash
-START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap
-```
-
-服务日志默认位于容器内 `/tmp/xensevr-service.log`。
-
-## 6. 升级到新版本
-
-改 `.env` 里的 `LEROBOT_IMAGE_TAG`，然后：
-
-```bash
-docker compose pull
-```
-
-21 GB 里绝大部分是 conda 层和 SDK 层，版本迭代时只会拉变动的那几层，不是重新
-搬一遍整包。
-
-## 7. 常见问题
-
-- `No such image: ghcr.io/...`：`docker image inspect` 只查本地。这个 tag 还没拉过，
-  先 `docker compose pull`；只想看远端用 `docker manifest inspect`。
-- `mamba activate` 报 `critical libmamba Shell not initialized`：**环境本来就是激活的**，
-  不需要 activate。镜像把 `xense-taccap/bin` 放在 `PATH` 最前面来激活环境，而不是靠
-  shell hook —— `mamba env list` 里那个 `*` 就在 `xense-taccap` 上。直接敲 `python`、
-  `lerobot-info` 即可。确实想手动切环境时，先在当前 shell 里执行
-  `eval "$(mamba shell hook --shell bash)"`。0.0.5 及更早的镜像需要这一步，之后的镜像
-  已内置 hook。
-- `pull access denied ... may require 'docker login'`：**不是权限问题**。GHCR 上的包是
-  公开的，拉取从不需要登录。这条报错说明镜像名被解析成了 registry 上不存在的名字 ——
-  用 `docker compose config --images` 看看实际解析出来的是什么，并检查 `.env` 里的
-  `LEROBOT_IMAGE` 有没有被改掉。
-- `could not select device driver ... gpu`：安装/配置 NVIDIA Container Toolkit，
-  然后重启 Docker daemon。
-- 容器能看到 `/dev/ttyACM*` 但设备 busy：按顶层 README 配置宿主机
-  ModemManager udev 规则，重新插拔设备。
-- GUI 不显示：检查 `echo "$DISPLAY"`、`/tmp/.X11-unix` 和上述 `xhost` 授权。
-- Rerun 报 Vulkan adapter 错误：先确认 `nvidia-smi` 和
-  `vulkaninfo --summary` 均能在容器中识别 NVIDIA GPU。
-- `torch.cuda.is_available()` 是 `False`，但 `nvidia-smi` 正常：宿主机的 CUDA 状态坏了，
-  与容器无关。笔记本挂起/恢复后常见。先在**宿主机**上确认
-  `python -c 'import ctypes; print(ctypes.CDLL("libcuda.so.1").cuInit(0))'` 是否返回 0；
-  非 0 时用 `sudo rmmod nvidia_uvm && sudo modprobe nvidia_uvm` 重载，或重启。
-- 找不到 GSPS，但宿主机存在：确认容器通过 Compose 启动，并检查
-  `ls /dev/v4l/by-id/*GSPS*`；必要时重新插拔 USB Hub 后执行
-  `sudo udevadm settle --timeout=20`。
+| 现象                                        | 处理                                                                                                                   |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `No such image: ghcr.io/...`                | `image inspect` 只查本地。先 `docker compose pull`；只想看远端用 `manifest inspect`                                    |
+| `mamba activate` 报 `Shell not initialized` | 环境本来就是激活的，不用 activate。要手动切环境先 `eval "$(mamba shell hook --shell bash)"`                            |
+| `pull access denied ... 'docker login'`     | 不是权限问题（包是公开的）。用 `docker compose config --images` 看镜像名被解析成了什么，检查 `.env` 的 `LEROBOT_IMAGE` |
+| `could not select device driver ... gpu`    | 装/配 NVIDIA Container Toolkit，然后重启 Docker daemon                                                                 |
+| `/dev/ttyACM*` 存在但 busy                  | 按顶层 README 配置宿主机 ModemManager udev 规则，重新插拔                                                              |
+| GUI 不显示                                  | 检查 `$DISPLAY`、`/tmp/.X11-unix` 和 `xhost +si:localuser:root`                                                        |
+| Rerun 报 Vulkan adapter 错误                | 确认容器内 `nvidia-smi` 和 `vulkaninfo --summary` 都能识别 GPU                                                         |
+| `cuda: False` 但 `nvidia-smi` 正常          | 宿主机 CUDA 状态坏了（挂起/恢复后常见），与容器无关。`sudo rmmod nvidia_uvm && sudo modprobe nvidia_uvm`，或重启       |
+| 找不到 GSPS 但宿主机能看到                  | 确认经 Compose 启动，检查 `ls /dev/v4l/by-id/*GSPS*`，必要时重插 USB Hub 后 `sudo udevadm settle --timeout=20`         |
+| `groups: cannot find name for group ID <n>` | 无害。NVIDIA runtime 注入了宿主机的 `render` 组 GID，容器里没有同名组而已                                              |

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,7 +21,7 @@ lerobot-info
 lerobot-find-cameras
 ```
 
-`install_customer.sh` 需要几分钟到几十分钟（镜像约 21 GB）。要走代理就加
+`install_customer.sh` 需要几分钟到几十分钟（镜像约 21 GB）。如果本机要走代理就加
 `XENSE_PROXY_URL=http://127.0.0.1:7897`。
 
 ## 宿主机要求
@@ -31,7 +31,7 @@ Ubuntu 22.04/24.04、`linux/amd64`、**NVIDIA 驱动 ≥ 570.144**。
 Docker、NVIDIA Container Toolkit 和 TacCap 的 udev 规则都由 `install_customer.sh`
 装好；**驱动要你自己先装**（涉及显卡型号、Secure Boot 和重启，脚本不碰）。
 
-装完后当前用户还需要两件事：
+装完后当前用户还需要两件事, 在宿主机器上输入:
 
 ```bash
 sudo usermod -aG docker "$USER" && newgrp docker  # Docker 权限


### PR DESCRIPTION
Repository only — no version bump, no release. The image change here ships with
whatever release comes next.

## docker/README.md: 272 lines → 106

The person reading it is deploying a rig, not studying the image. The four
commands that get a container running were buried under a component table, two
changelogs and a full host-requirements section. Quickstart is now the first
thing after the title.

Everything that is reference rather than instruction became a table (common
operations, troubleshooting), so it is scannable instead of readable. Kept:
host requirements compressed to one line plus the part the installer does *not*
do (the NVIDIA driver — the only thing that can actually block someone), the
changelog entries that change how the thing is used, and the image-verification
block, because "pico4 and daemon must print the same version" is how you catch
a half-stale image before recording against it.

Building, publishing and the offline tar path move to `docker/MAINTAINING.md` —
none of it is reachable by someone installing from GHCR. Moved, not deleted:
the release procedure has no other record. It also picks up the warning this
project nearly walked into, that re-publishing a version number replaces the
image behind a tag rigs have pinned.

## Two reported problems, both fixed

**`docker image inspect` returned `No such image`.** It reads the *local*
store, and the doc sat it next to the pin instructions with no mention of that
precondition. The two questions are now separate — `manifest inspect` for the
registry, `image inspect` for this machine — and it is the first troubleshooting
row, because the message names an image that really does exist on GHCR, which
is when someone starts doubting the tag instead of the command.

**`mamba activate` printed `critical libmamba Shell not initialized`** plus a
wall of setup instructions. Nothing was broken — the image activates the
environment through `ENV PATH`, which is why `docker run <img> python script.py`
needs no shell setup, and that stays. But the message reads like a broken image
for a command people reasonably try first. `mamba shell init` now runs in the
last (cheap) layer.

Verified against the published 0.0.5 image before changing the Dockerfile: the
hook coexists with the ENV PATH rather than fighting it — `mamba activate base`
moves `CONDA_PREFIX` to `/opt/conda` and puts `/opt/conda/bin` first, and
activating back restores it.

> Worth recording: testing this with `mamba activate base | head -2` shows no
> change at all, because the pipe runs activate in a subshell. Drop the pipe
> before concluding activate is broken.

Images up to and including 0.0.5 are published without the hook, so the doc
gets a troubleshooting row rather than relying on the rebuild.

Also documents `groups: cannot find name for group ID <n>`, which prints on
every GPU-attached start: the NVIDIA runtime injects the host's `render` GID
and the container has no group by that name. Confirmed identical on 0.0.4 and
0.0.5, and absent without `--gpus`, so it is not a regression.

## Verification

- `docker build --check` passes on the modified Dockerfile
- all three markdown files pass prettier 3.6.2 with the hook's own args
- anchors: top-level README now points at `#快速开始`; `MAINTAINING.md` exists
  and links back
- the usage doc no longer mentions `compose build`, `push_ghcr`,
  `package_customer_delivery`, `git tag` or `GHCR_TOKEN`

## Still not done

`Dockerfile.user` continues to apt-install `libudev-dev` / `libusb-1.0-0-dev`,
which d50e49b4 showed nothing compiles against. They should become the runtime
package `libusb-1.0-0` — but not by deletion: `ubuntu:22.04` ships `libudev1`
and **not** `libusb-1.0-0`, so with `--no-install-recommends` the runtime
library arrives only as a dependency of the `-dev` package, and dropping it
would leave pyrealsense2 without `libusb-1.0.so.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
