### PR TITLE
fix(docker): keep .env out of the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,16 @@ nautilus/*.yaml
 *.key
 sbatch*.sh
 
+# Compose's env file. .gitignore already keeps this out of the repository, which
+# is why CI-built images never contained it — but .gitignore has no say over the
+# build context, and Dockerfile.user does `COPY . /opt/lerobot`. Without this
+# rule a local `docker compose build` bakes the developer's .env into the image,
+# and that image has two routes out: docker/push_ghcr.sh to a *public* GHCR
+# package, and docker/package_customer_delivery.sh to a customer. compose.yaml
+# passes `HF_TOKEN: ${HF_TOKEN:-}`, so a token in .env is the expected case.
+.env
+.env.*
+
 # Byte-compiled / optimized files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Raised by a question about whether `.env` can leak. In git, no — `.gitignore`
covers it and it is untracked. But `.gitignore` has no say over the **Docker
build context**, and `Dockerfile.user` does `COPY . /opt/lerobot`.

Verified rather than assumed, with a throwaway `FROM busybox` / `COPY . /ctx`
build against this repository:

```
before:  -rw-rw-r--  76  /ctx/.env      # and `cat` returns its contents verbatim
after:   ls: /ctx/.env: No such file or directory
```

## Why it matters

A local `docker compose build` bakes that machine's `.env` into the image, and
that image has two routes out of the building:

| path | destination |
| --- | --- |
| `docker/push_ghcr.sh` | a **public** GHCR package |
| `docker/package_customer_delivery.sh` | a customer machine |

`compose.yaml` passes `HF_TOKEN: ${HF_TOKEN:-}`, so a Hugging Face token in
`.env` is the expected case, not a hypothetical one.

## Scope

**No published image is affected.** CI builds from a clean checkout where
`.env` does not exist, which is exactly why this went unnoticed. Checked
`ghcr.io/vertax42/xense-taccap-lerobot:0.0.5` for `/opt/lerobot/.env` — absent.

`.dockerignore` already excludes `.git`, `.github`, `*.key` and `dist/`, so the
intent was there; `.env` was simply the gap. `.env.*` covers the usual variants.

Deliberately kept off #32 so a credential fix is not buried inside a
documentation rewrite. The two do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
