### PR TITLE
fix(docker): repair the graphics check landed in d1ed6d46

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -61,9 +61,14 @@ services:
       START_XENSEVR_SERVICE: ${START_XENSEVR_SERVICE:-1}
       XDG_RUNTIME_DIR: /tmp/xdg-runtime
       WGPU_BACKEND: vulkan
-      # Both are read by the NVIDIA hook. VISIBLE_DEVICES replaces what
-      # `gpus: all` used to say; DRIVER_CAPABILITIES is what actually pulls in
-      # the graphics group (libGLX/libEGL plus the Vulkan and GLVND manifests).
+      # VISIBLE_DEVICES replaces what `gpus: all` used to say and is required.
+      #
+      # DRIVER_CAPABILITIES is NOT what fixed the missing graphics libraries —
+      # Dockerfile.user already bakes it into the image, and it was set all
+      # along while graphics was broken. `runtime: nvidia` above is the load
+      # bearing part; this line only restates the image default so the wiring
+      # is readable in one place. Do not "simplify" by keeping this and
+      # dropping the runtime.
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DRIVER_CAPABILITIES: all
       HF_TOKEN: ${HF_TOKEN:-}

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,25 +2,33 @@
 
 预装 `xense-taccap` Conda 环境、CUDA 12.8、LeRobot-Xense、XenseSDK、
 TacCap-Gripper SDK 和 Pico4 绑定的镜像。**从 GHCR 拉取，不需要自己构建，也不需要登录。**
+
 构建镜像、发布新版本、离线交付见 [`MAINTAINING.md`](MAINTAINING.md)。
 
 ## 快速开始
+
+**逐条敲,不要整块粘贴** —— `newgrp` 会开一个子 shell，整块粘贴时它后面的命令会被吃掉。
 
 ```bash
 git clone https://github.com/Vertax42/xense-taccap-lerobot.git
 cd xense-taccap-lerobot
 ./docker/install_customer.sh          # 装 Docker / NVIDIA Toolkit / udev 规则，并拉镜像
+```
 
-# 宿主机上执行，缺一不可
+装完在**宿主机**上继续，这两条不能跳过：
+
+```bash
 newgrp docker                         # 让 docker 组权限在当前终端生效
 xhost +si:localuser:root              # 要显示 Rerun 等窗口
+```
 
+```bash
 docker compose run --rm xense-taccap  # 进容器
 ```
 
-**中间那两条不能跳过。** 脚本已经把你加进 `docker` 组了，但**当前终端不会自动生效** ——
-不执行 `newgrp docker` 就直接跑最后一条，会得到 `permission denied`。也可以注销后重新
-登录，效果一样。
+脚本已经把你加进 `docker` 组了，但**当前终端不会自动生效** —— 不执行 `newgrp docker`
+就直接进容器会得到 `permission denied`。**注销后重新登录是更干净的做法**:`newgrp` 之后
+你在该终端新建的文件属组会变成 `docker`，重新登录则没有这个副作用。
 
 容器里环境已激活，直接用：
 
@@ -104,10 +112,11 @@ dpkg-query -W -f='daemon -> ${Version}\n' xensevr-pc-service
 | `No such image: ghcr.io/...`                 | `image inspect` 只查本地。先 `docker compose pull`；只想看远端用 `manifest inspect`                                                                                                                                                                                             |
 | `mamba activate` 报 `Shell not initialized`  | 环境本来就是激活的，不用 activate。要手动切环境先 `eval "$(mamba shell hook --shell bash)"`                                                                                                                                                                                     |
 | `pull access denied ... 'docker login'`      | 不是权限问题（包是公开的）。用 `docker compose config --images` 看镜像名被解析成了什么，检查 `.env` 的 `LEROBOT_IMAGE`                                                                                                                                                          |
-| `could not select device driver ... gpu`     | 装/配 NVIDIA Container Toolkit，然后重启 Docker daemon                                                                                                                                                                                                                          |
+| `Unknown runtime specified nvidia`           | NVIDIA runtime 没在 Docker 里注册。`sudo nvidia-ctk runtime configure --runtime=docker && sudo systemctl restart docker`，再用 `docker info --format '{{json .Runtimes}}'` 确认列出了 `nvidia`                                                                                  |
+| `could not select device driver ... gpu`     | 没装 NVIDIA Container Toolkit,或装完没重启 Docker daemon                                                                                                                                                                                                                        |
 | `/dev/ttyACM*` 存在但 busy                   | 按顶层 README 配置宿主机 ModemManager udev 规则，重新插拔                                                                                                                                                                                                                       |
 | GUI 不显示                                   | 检查 `$DISPLAY`、`/tmp/.X11-unix` 和 `xhost +si:localuser:root`                                                                                                                                                                                                                 |
-| Rerun 报 `Failed to create surface`          | 容器没拿到 NVIDIA 的 Vulkan ICD。`ls /etc/vulkan/icd.d/` 里应有 `nvidia_icd.json`，空的话看下一行                                                                                                                                                                               |
+| Rerun 报 `Failed to create surface`          | 容器没拿到 NVIDIA 的 Vulkan ICD。容器里跑 `vulkaninfo --summary` 看有没有 NVIDIA 设备，没有就看下一行                                                                                                                                                                           |
 | 容器内 `vulkaninfo` 报 `INCOMPATIBLE_DRIVER` | CUDA 正常但图形能力没注入。确认 `docker info --format '{{json .Runtimes}}'` 列出了 `nvidia`；没有就 `sudo nvidia-ctk runtime configure --runtime=docker && sudo systemctl restart docker`。**别把 compose 的 `runtime: nvidia` 改回 `gpus: all`** —— 后者只申请 compute+utility |
 | `cuda: False` 但 `nvidia-smi` 正常           | 宿主机 CUDA 状态坏了（挂起/恢复后常见），与容器无关。`sudo rmmod nvidia_uvm && sudo modprobe nvidia_uvm`，或重启                                                                                                                                                                |
 | 找不到 GSPS 但宿主机能看到                   | 确认经 Compose 启动，检查 `ls /dev/v4l/by-id/*GSPS*`，必要时重插 USB Hub 后 `sudo udevadm settle --timeout=20`                                                                                                                                                                  |

--- a/docker/install_customer.sh
+++ b/docker/install_customer.sh
@@ -361,42 +361,64 @@ verify_image() {
   )
 
   log "Running GPU and Python smoke test with ${image_ref}"
-  "${DOCKER_CMD[@]}" run --rm "${gpu_args[@]}" \
-    --entrypoint python "${image_ref}" \
-    -c 'import torch; print("torch:", torch.__version__); print("cuda:", torch.cuda.is_available()); raise SystemExit(0 if torch.cuda.is_available() else 1)'
 
-  # Graphics is a separate driver capability from compute, and it fails
-  # separately: CUDA and nvidia-smi keep working while Rerun dies with
-  # "Failed to create surface for any enabled backend". Checking it here turns
-  # that into an install-time failure with a fix, instead of a puzzle the
-  # operator meets the first time they pass --display_data=true.
-  log "Checking the NVIDIA Vulkan ICD (Rerun needs it)"
-  if ! "${DOCKER_CMD[@]}" run --rm "${gpu_args[@]}" \
-      --entrypoint bash "${image_ref}" \
-      -c 'test -s /etc/vulkan/icd.d/nvidia_icd.json' 2>/dev/null; then
-    fail "$(
-      cat <<'EOF'
-The container did not receive the NVIDIA Vulkan ICD
-(/etc/vulkan/icd.d/nvidia_icd.json). CUDA works, but Rerun and any other
-GPU-rendered window will fail with:
+  # Both checks in one container: every start pays the full NVIDIA injection
+  # (39-53 bind mounts), and running them together lets the script distinguish
+  # "compute ok, graphics missing" from "nothing works".
+  #
+  # docker's own stderr is captured and printed rather than discarded. An
+  # unregistered runtime, a missing shell in the image or a full disk all make
+  # this `docker run` fail, and silencing it would report every one of them as
+  # a graphics problem.
+  local output="" rc=0
+  output="$(
+    "${DOCKER_CMD[@]}" run --rm "${gpu_args[@]}" --entrypoint bash "${image_ref}" -c '
+      if python -c "import torch; print(\"torch:\", torch.__version__); print(\"cuda:\", torch.cuda.is_available()); raise SystemExit(0 if torch.cuda.is_available() else 1)"; then
+        echo "SMOKE cuda=ok"
+      else
+        echo "SMOKE cuda=fail"
+      fi
+      # Ask the Vulkan loader instead of testing a path. Packaged drivers put
+      # the ICD in /etc/vulkan/icd.d, NVIDIA'"'"'s .run installer puts it in
+      # /usr/share/vulkan/icd.d, and the container runtime mounts it wherever
+      # the host happens to keep it — so a hardcoded path fails a working host.
+      if vulkaninfo --summary 2>/dev/null | grep -qi "deviceName.*NVIDIA"; then
+        echo "SMOKE graphics=ok"
+      else
+        echo "SMOKE graphics=fail"
+      fi
+    ' 2>&1
+  )" || rc=$?
 
-    WGPU error: Failed to create surface for any enabled backend
+  printf '%s\n' "${output}"
 
-The ICD is not part of the image — the NVIDIA container runtime mounts it from
-the host. Check, in this order:
+  if ! printf '%s' "${output}" | grep -q "^SMOKE "; then
+    fail "The smoke-test container did not run (exit ${rc}). See its output above."
+  fi
 
-  1. The host has it:      ls /etc/vulkan/icd.d/nvidia_icd.json
-     Missing means the driver's graphics half is not installed (a headless or
-     compute-only driver). Install the matching libnvidia-gl-<branch> package.
+  printf '%s' "${output}" | grep -q "SMOKE cuda=ok" || \
+    fail "PyTorch cannot see the GPU inside the container. Check the host driver and NVIDIA Container Toolkit, then rerun."
 
-  2. The runtime is registered:   docker info --format '{{json .Runtimes}}'
-     Must list "nvidia". If not: sudo nvidia-ctk runtime configure
-     --runtime=docker && sudo systemctl restart docker
-
-  3. Regenerate the CDI spec if you use one:
-     sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
-EOF
-    )"
+  # Graphics is a separate driver capability from compute and fails separately:
+  # CUDA and nvidia-smi keep working while Rerun dies with "Failed to create
+  # surface for any enabled backend". It is also optional — only
+  # --display_data=true needs it — so this warns and lets the install finish
+  # rather than discarding a completed 21 GB install over a Rerun window.
+  if ! printf '%s' "${output}" | grep -q "SMOKE graphics=ok"; then
+    log ""
+    log "WARNING: the container has CUDA but no working Vulkan/NVIDIA graphics."
+    log "Recording works. Rerun (--display_data=true) will fail with:"
+    log "    WGPU error: Failed to create surface for any enabled backend"
+    log ""
+    log "The Vulkan ICD is not part of the image — the NVIDIA container runtime"
+    log "mounts it from the host. Check, in this order:"
+    log "  1. The host has it:  ls /etc/vulkan/icd.d/nvidia_icd.json /usr/share/vulkan/icd.d/nvidia_icd.json"
+    log "     Missing from both means the driver's graphics half is not installed"
+    log "     (a headless or compute-only driver). Install libnvidia-gl-<branch>."
+    log "  2. The runtime is registered:  docker info --format '{{json .Runtimes}}'"
+    log "     Must list \"nvidia\". If not:"
+    log "       sudo nvidia-ctk runtime configure --runtime=docker && sudo systemctl restart docker"
+    log ""
   fi
 }
 
@@ -439,9 +461,14 @@ main() {
   verify_image
 
   log "Installation completed successfully."
-  log "Log out and back in once so docker/video/plugdev group membership takes effect."
-  log "Then start the container from this directory with:"
-  log "  xhost +SI:localuser:root"
+  log ""
+  # This epilogue is what the operator actually reads after a long install, so
+  # it has to carry the newgrp step rather than leave it to docker/README.md.
+  # Without it the very next line they type is a permission denied.
+  log "Your docker/video/plugdev group membership is not active in this shell yet."
+  log "Log out and back in, or run these in order:"
+  log "  newgrp docker                         # else the last line is 'permission denied'"
+  log "  xhost +si:localuser:root              # only if you want Rerun windows"
   log "  docker compose run --rm xense-taccap"
   if [[ "${IMAGE_TAG}" == "latest" ]]; then
     log ""


### PR DESCRIPTION
Review follow-ups on d1ed6d46. As landed, that check would have **failed
working hosts and aborted good installs**.

## Three defects in the new check

**It tested a path, not the capability.** `test -s
/etc/vulkan/icd.d/nvidia_icd.json` assumes the packaged-driver location, but
NVIDIA's `.run` installer puts the ICD in `/usr/share/vulkan/icd.d`, and the
runtime mounts it wherever the host keeps it. The README leaves driver
installation to the operator, so a working machine would have been told to
install `libnvidia-gl`. It now asks the Vulkan loader instead — `vulkaninfo
--summary` must name an NVIDIA device — which is what Rerun actually needs and
is path-independent.

Verified both directions on the host that originally failed:

```
--gpus all         -> graphics=fail
runtime: nvidia    -> graphics=ok
```

**Missing graphics was a hard failure.** Docker, the toolkit, the udev rules
and 21 GB of image all installed, CUDA passing — and the script still exited 1,
skipping `Installation completed successfully` and the `latest`-tag pinning
note, which is the one piece of advice that protects recorded data. Graphics is
optional; only `--display_data=true` needs it. It warns and finishes now.

**`2>/dev/null` hid docker's own errors.** An unregistered runtime, a missing
shell in the image, or a full disk each make `docker run` fail — and all three
were reported as "no Vulkan ICD" with thirty lines of graphics advice. stderr
is captured and printed, and a container that never ran says so:

```
[install_customer] ERROR: The smoke-test container did not run (exit 125).
                          See its output above.
```

## Also from the review

- Remediation text drops its CDI step: `runtime: nvidia` uses the legacy hook
  and never reads `/etc/cdi`, so regenerating the spec changes nothing.
- Both checks now share one container instead of paying the NVIDIA injection
  (39–53 bind mounts) twice.
- `compose.yaml`'s comment no longer credits `NVIDIA_DRIVER_CAPABILITIES` with
  the fix. `Dockerfile.user` already bakes that variable in and it was set the
  whole time graphics was broken — `runtime: nvidia` is the load-bearing line,
  and implying otherwise invites someone to drop it while tidying.
- Installer epilogue carries `newgrp docker` and matches the README's `+si:`
  casing. It told operators to log out, then printed `docker compose run` on
  the next line — following it in order hit the exact permission denied the
  README warns about.
- README: `newgrp` is out of the paste-as-one-block quickstart. It spawns a
  subshell that swallows the lines after it, so the block was not runnable as
  written; log-out/in is now named as the cleaner path, since `newgrp` also
  leaves newly created files group-owned by `docker`.
- README: added the `Unknown runtime specified nvidia` row — the failure this
  change introduces, and one `compose.yaml` predicts by name.
- README: restored the blank line that had merged the intro and the
  `MAINTAINING.md` pointer into a single paragraph.

## Verification

- `bash -n`, `docker compose config`, prettier 3.6.2 with the hook's own args
- `verify_image` exercised in isolation: happy path prints `SMOKE cuda=ok` /
  `SMOKE graphics=ok`; a bad image reference surfaces docker's `denied` and the
  "container did not run" message rather than a graphics diagnosis
- the graphics probe negative-controlled on the originally failing host

## Not done

Having `install_customer.sh` drive `docker compose run` rather than
hand-copying its GPU flags. That duplication is exactly the drift risk this
whole thread was about, but fixing it changes how the script locates compose
across the checkout and delivery layouts — worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
