### PR TITLE
fix(docker): stop the installer silently aborting when no proxy is set

### DIFF
--- a/docker/install_customer.sh
+++ b/docker/install_customer.sh
@@ -55,6 +55,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# `set -e` aborts with no output at all, which is how a bare `return` in
+# configure_docker_proxy silently ended every non-proxy install right after the
+# Docker step — the toolkit, the runtime registration, the image and the smoke
+# test were all skipped and nothing said so. Anything that dies without going
+# through fail() now names the line it died on.
+on_unexpected_exit() {
+  local code=$?
+  printf '[install_customer] ERROR: aborted at line %s (exit %s) without a message.\n' "$1" "${code}" >&2
+  printf '[install_customer] This is a bug in the installer. Report it with the output above.\n' >&2
+  exit "${code}"
+}
+trap 'on_unexpected_exit ${LINENO}' ERR
+
 require_normal_user() {
   if [[ "${EUID}" -eq 0 ]]; then
     fail "Run this script as a normal user with sudo privileges, not as root."
@@ -139,7 +152,15 @@ install_docker() {
 }
 
 configure_docker_proxy() {
-  [[ -n "${PROXY_URL}" ]] || return
+  # `return 0`, not a bare `return`. A bare one hands back the status of the
+  # test that just failed — 1 — and under `set -e` a non-zero return from a
+  # function called on its own line kills the script. With no XENSE_PROXY_URL
+  # set, that is every run: the installer exited silently right after the
+  # Docker step and never installed the NVIDIA toolkit.
+  if [[ -z "${PROXY_URL}" ]]; then
+    log "No XENSE_PROXY_URL set; not configuring a proxy."
+    return 0
+  fi
 
   local proxy_conf="${TEMP_DIR}/http-proxy.conf"
   printf '%s\n' \
@@ -155,6 +176,10 @@ configure_docker_proxy() {
 }
 
 configure_docker_access() {
+  # Logged because this step is otherwise silent and calls sudo: if the sudo
+  # timestamp has expired it stops at a password prompt, and without a line
+  # here that is indistinguishable from a hang.
+  log "Configuring Docker group access for ${USER}..."
   sudo groupadd --force docker
   sudo usermod -aG docker "${USER}"
   if docker info >/dev/null 2>&1; then


### PR DESCRIPTION
`configure_docker_proxy` opened with:

```bash
[[ -n "${PROXY_URL}" ]] || return
```

A bare `return` hands back the status of the last command — here the `[[ ]]`
test that just failed — so the function returned **1**. Under `set -euo
pipefail`, a non-zero return from a function called on its own line ends the
script, and `set -e` prints nothing.

## Impact

With no `XENSE_PROXY_URL` set — the default, and every install not behind a
proxy — `install_customer.sh` stopped immediately after

```
[install_customer] Docker Engine and Docker Compose are already installed.
```

and exited 1 **in silence**. Everything after that step was skipped:

- NVIDIA Container Toolkit install
- `nvidia-ctk runtime configure --runtime=docker`
- TacCap udev rules
- image pull
- smoke test

The operator saw what looked like progress, then a shell prompt, and no error.

This is why a rig reported `unknown or invalid runtime name: nvidia` from
`docker compose run` after "running the installer" — the installer had never
reached the line that registers the runtime, and `nvidia-ctk` was not installed
at all.

**Present since 9387ef05**, the commit that introduced the Docker setup. The
customer install path has never completed on a machine without a proxy. Hosts
that did work were run with `XENSE_PROXY_URL` set, which takes the other
branch — which is also why this survived several installs without being
noticed.

## Beyond the one-line fix

- `configure_docker_access` now logs before it starts. It is silent and calls
  sudo, so an expired sudo timestamp leaves the script at a password prompt
  that reads as a hang — that was the second guess when this was reported, and
  it cost a round trip.
- An `ERR` trap names the line on any exit that did not go through `fail()`.
  This bug stayed invisible precisely because `set -e` says nothing; that
  should not be possible a second time.

## Verification

- reproduced first: a minimal script exits 1 right after the log line, and the
  real `configure_docker_proxy` returns 1 with `PROXY_URL=""`
- after the fix: the proxy step logs that it is skipping, and the flow
  continues into the toolkit install
- the ERR trap fires on the old pattern (`aborted at line 14 (exit 1)`) and
  does **not** double-report ordinary `fail()` exits
- audited every other bare `return`: `derive_tag_from_archive`,
  `resolve_image_ref`, `env_lookup` and `locate_compose_file` all return 0 as
  main() calls them; `detect_archive`'s non-zero is deliberate and consumed by
  an `if`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
