### PR TITLE
fix(teleoperate): drop --dryrun, which promises something it cannot do

### DIFF
--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -107,8 +107,6 @@ class TeleoperateConfig:
     show_trajectory: bool = True
     # Print per-step timing breakdown instead of action values.
     debug_timing: bool = False
-    # Dryrun mode: print actions but do not send to robot
-    dryrun: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -313,8 +311,6 @@ def self_driven_teleop_loop(
 @parser.wrap()
 def teleoperate(cfg: TeleoperateConfig):
     logger.info(pformat(asdict(cfg)))
-    if cfg.dryrun:
-        logger.warn("DRYRUN MODE ENABLED - Actions will be printed but NOT sent to robot")
 
     if cfg.display_data:
         teleop_name = cfg.teleop.type if cfg.teleop else "none"


### PR DESCRIPTION
## The problem

`--dryrun` announces:

```
DRYRUN MODE ENABLED - Actions will be printed but NOT sent to robot
```

…and then nothing reads it. `cfg.dryrun` appears exactly **twice** in `lerobot_teleoperate.py` — the field declaration and that warning:

```
src/lerobot/scripts/lerobot_teleoperate.py:111:    dryrun: bool = False
src/lerobot/scripts/lerobot_teleoperate.py:316:    if cfg.dryrun:
src/lerobot/scripts/lerobot_teleoperate.py:317:        logger.warn("DRYRUN MODE ENABLED - ...")
```

No loop consults it. Passing the flag drives the hardware exactly as if it had not been passed, while telling the operator the opposite.

## How it got here

It was not always dead. The specialised loops honoured it properly — `if not dryrun: robot.send_action(...)`, with a `[DRYRUN]` tag in the status line (see `e851a6a7`, `07bc7628`).

`88aa3dc6` ("refactor: slim lerobot to TacCap-Gripper + Pico4 only") removed **2274 lines** from this file, taking every one of those loops with it, and left the config field and the banner behind.

## Why nothing replaces it

On the robots this fork still supports there is nothing for it to suppress. `taccap_gripper` / `bi_taccap_gripper` are self-driven and sensor-only — as `self_driven_teleop_loop`'s own docstring puts it:

> These robots have no teleoperator: we only read `robot.get_observation()` and stream it to Rerun with an empty action. **`send_action` is a no-op, so nothing is ever commanded.**

A dry run of a loop that never commands anything is just the loop.

A flag whose only observable effect is a false reassurance is worse than no flag: someone reaches for it precisely when they are unsure whether it is safe to let the rig move.

## Verification

```
$ lerobot-teleoperate --help        # exit 0
```

- `--dryrun` gone (0 occurrences)
- neighbouring options intact: `--fps`, `--show_trajectory`, `--debug_timing`
- no `dryrun` / `dry_run` / `dry-run` references remain outside `third_party/`

Found while auditing the manual against `main` for [XTac-UMI-G1-Docs](https://github.com/XenseRobotics/XTac-UMI-G1-Docs) — it was deliberately left undocumented rather than described to customers as a working safety switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)