### PR TITLE
fix(record): never let text-to-speech abort a recording

### DIFF
--- a/src/lerobot/utils/utils.py
+++ b/src/lerobot/utils/utils.py
@@ -210,7 +210,33 @@ def format_big_number(num, precision=0):
     return num
 
 
+# Warn once per process. A recording session calls log_say on every episode, so
+# a host without the binary would otherwise print the same line hundreds of times.
+_TTS_WARNED = False
+
+
+def _warn_tts_once(reason: str) -> None:
+    global _TTS_WARNED
+    if not _TTS_WARNED:
+        _TTS_WARNED = True
+        logging.warning(
+            f"Text-to-speech unavailable ({reason}); continuing without it. Use --play_sounds=false to silence this."
+        )
+
+
 def say(text: str, blocking: bool = False):
+    """Speak `text`, or quietly carry on if the host cannot.
+
+    Never raises. Speech is a convenience — `play_sounds` defaults to True, and
+    the record loop calls this from its cleanup path as well as its main path,
+    so an exception here can land *while another one is being handled*. That is
+    not hypothetical: in the container, where `spd-say` is not installed, the
+    FileNotFoundError from the episode announcement was immediately followed by
+    a second one from "Stop recording" in the teardown, the process died with an
+    unhandled exception, and the XenseVR SDK's joinable std::threads — never
+    closed — turned it into `terminate called without an active exception` and a
+    core dump. A missing text-to-speech binary must not be able to do that.
+    """
     system = platform.system()
 
     if system == "Darwin":
@@ -230,12 +256,21 @@ def say(text: str, blocking: bool = False):
         ]
 
     else:
-        raise RuntimeError("Unsupported operating system for text-to-speech.")
+        _warn_tts_once(f"unsupported operating system {system!r}")
+        return
 
-    if blocking:
-        subprocess.run(cmd, check=True)
-    else:
-        subprocess.Popen(cmd, creationflags=subprocess.CREATE_NO_WINDOW if system == "Windows" else 0)
+    try:
+        if blocking:
+            subprocess.run(cmd, check=True)
+        else:
+            subprocess.Popen(cmd, creationflags=subprocess.CREATE_NO_WINDOW if system == "Windows" else 0)
+    except FileNotFoundError:
+        # The usual case: the TTS binary is not installed.
+        _warn_tts_once(f"{cmd[0]} not found")
+    except (OSError, subprocess.SubprocessError) as exc:
+        # It exists but did not work — no audio sink, no speech-dispatcher
+        # daemon, device busy. Same verdict: not worth failing a recording over.
+        _warn_tts_once(f"{cmd[0]} failed: {exc}")
 
 
 def log_say(text: str, play_sounds: bool = True, blocking: bool = False):


### PR DESCRIPTION
`say()` shells out to `spd-say` on Linux with no guard. That binary is not in
the container image, and `play_sounds` defaults to True, so recording died on
the first episode announcement — then died again, worse:

```
FileNotFoundError: 'spd-say'          # lerobot_record.py:520, episode start
During handling of the above exception, another exception occurred:
FileNotFoundError: 'spd-say'          # lerobot_record.py:572, "Stop recording"
terminate called without an active exception
Aborted (core dumped)
```

The second call is in the **teardown** path, so it raised while the first
exception was being handled and replaced it. The process exited with an
unhandled exception, the XenseVR SDK's joinable `std::thread`s were never
closed, and `std::terminate` turned a missing speech binary into a core dump.

## Change

`say()` warns once and returns instead of raising, for three cases:

| case | before |
| --- | --- |
| binary absent | `FileNotFoundError` |
| binary present but fails — no audio sink, no speech-dispatcher daemon, device busy | `CalledProcessError` from `subprocess.run(..., check=True)` |
| unsupported platform | `RuntimeError` |

The middle row is why installing the package alone would not have closed this
hole. Warned **once per process**: a session announces every episode and would
otherwise repeat the line hundreds of times.

## Verification

- `PATH` emptied (binary absent): blocking and non-blocking paths both return,
  one warning across six calls
- stub `spd-say` exiting 1 (binary present, fails): returns, warns
- `ruff` 0.14.1 `check` and `format --check` clean (the pinned pre-commit
  version, run via uv)

## Workaround for images already shipped

`--play_sounds=false`. The source is baked into the image, not mounted, so this
fix only reaches a container on the next release.

## Related, not done here

`/dev/snd` **is** visible in the container (compose maps `/dev` and runs
privileged) and `pactl` is present, so speech could actually work if
`speech-dispatcher` were installed. Adding it invalidates the apt layer, the
same cost as the deferred `libusb-1.0-0` change — worth doing together when the
next image is built, if the audio announcements are wanted at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
