### PR TITLE
feat(docker): let the dataset directory be a host path

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -78,7 +78,19 @@ services:
       - /dev:/dev
       - /run/udev:/run/udev:ro
       - xensesdk-cache:/root/.xensesdk
-      - lerobot-data:/data
+      # Recorded datasets. Defaults to the `lerobot-data` named volume, which
+      # survives `--rm` but lives under /var/lib/docker and is root-owned, so
+      # getting data out means a copy through a container.
+      #
+      # Point LEROBOT_DATA_DIR at a host directory in .env to bind-mount
+      # instead, and the datasets land somewhere you can open directly:
+      #
+      #     LEROBOT_DATA_DIR=/home/you/.cache/huggingface/docker_data
+      #
+      # A value containing `/` is a bind mount; anything else is a named
+      # volume. Recording still runs as root either way, so the files are
+      # root-owned until you chown them — see docker/README.md.
+      - ${LEROBOT_DATA_DIR:-lerobot-data}:/data
       - huggingface-cache:/root/.cache/huggingface
       - torch-cache:/root/.cache/torch
       - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/docker/README.md
+++ b/docker/README.md
@@ -93,6 +93,32 @@ LEROBOT_IMAGE_TAG=0.0.5
 环境变量在 `docker/Dockerfile.user` 里设，卷映射在 `compose.yaml` 里。用 Docker
 **具名卷**而不是仓库目录，所以 `docker compose run --rm` 每次删容器都不会丢数据。
 
+### 想直接在宿主机访问数据（推荐给要频繁看/删数据的机器）
+
+在 `.env` 里把数据目录指到宿主机，数据集就直接落在你能打开的地方，不用每次拷出来：
+
+```dotenv
+LEROBOT_DATA_DIR=/home/你的用户名/.cache/huggingface/docker_data
+```
+
+带 `/` 的值是 bind mount，不带的当具名卷 —— 不设就还是默认的 `lerobot-data`。改完
+`docker compose config` 确认一下，然后正常录制，数据会出现在
+`<那个目录>/lerobot/`。
+
+**但录制仍以 root 运行，所以文件属主是 root。** 录完把属主交还给自己：
+
+```bash
+docker compose run --rm --no-deps --entrypoint /bin/bash --user 0:0 \
+    xense-taccap -lc "chown -R $(id -u):$(id -g) /data"
+```
+
+或者直接在宿主机 `sudo chown -R "$(id -u):$(id -g)" ~/.cache/huggingface/docker_data`。
+用 `ls -ln` 检查（显示数字 uid/gid，比 `ls -l` 直观）：
+
+```bash
+ls -ln ~/.cache/huggingface/docker_data/lerobot
+```
+
 宿主机上的实际位置是 `/var/lib/docker/volumes/xense-taccap-lerobot_<卷名>/_data`，
 属 root，直接 `ls` 要 sudo。查数据走容器更省事：
 


### PR DESCRIPTION
Named volumes keep data across `--rm`, but they live under `/var/lib/docker`,
they are root-owned, and getting anything out means copying through a
container. On a rig where someone looks at or deletes recordings regularly,
that is friction on every session.

`LEROBOT_DATA_DIR` in `.env` now redirects `/data`:

```dotenv
LEROBOT_DATA_DIR=/home/you/.cache/huggingface/docker_data
```

compose resolves a value containing `/` as a bind mount and anything else as a
named volume, so **the default is unchanged** — verified with `docker compose
config` both ways:

```
unset            -> type: volume, source: lerobot-data
LEROBOT_DATA_DIR -> type: bind,   source: /tmp/hostdata
```

This is a colleague's workflow, generalised. Their version hardcoded an
absolute home directory into `compose.yaml`, which cannot be committed — every
other machine would mount a path that does not exist there.

## Ownership is the part a bind mount does not fix

Recording runs as root, so files arrive root-owned even inside your own
directory. Documented with both ways to hand them back:

```bash
docker compose run --rm --no-deps --entrypoint /bin/bash --user 0:0 \
    xense-taccap -lc "chown -R $(id -u):$(id -g) /data"
```

or plain `sudo chown -R` on the host — plus `ls -ln` to check, since numeric
ids make it obvious whether the chown took.

## Verification

Wrote through the bind mount, saw `-rw------- 1 0 0` on the host, ran the chown
recipe, saw `1000 1000`, deleted it as an ordinary user.

Complements dac15f74, which stops new videos being 0600: **that one made them
readable, this one makes them yours.** Neither alone is enough — 0644 still
cannot be deleted by a non-owner, and a chown alone leaves them 0600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
