### PR TITLE
chore: version 0.5.1+xtac.0.0.6

### DIFF
--- a/docker/Dockerfile.user
+++ b/docker/Dockerfile.user
@@ -21,6 +21,19 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Runtime libraries cover USB/HID/video/X11 access. Build tools are retained on
 # purpose: taccap-gripper and the Pico4 Python extension are editable installs,
 # making the image useful for both end users and hardware SDK development.
+#
+# libusb-1.0-0, not libusb-1.0-0-dev: d50e49b4 established that nothing here
+# compiles against the headers — taccap-gripper's only find_package is Threads,
+# and the Pico4 bindings link the SDK out of the .deb. The library is needed at
+# *runtime* by pyrealsense2, and pyudev (under xensesdk) dlopens libudev by
+# name. libudev1 ships in the base image; libusb-1.0-0 does not, which is why
+# the -dev package cannot simply be deleted — it was the only thing dragging
+# the runtime library in.
+#
+# speech-dispatcher provides spd-say, which lerobot's --play_sounds path shells
+# out to. Missing, it used to abort recording; that is fixed in code now, but
+# /dev/snd reaches the container through the /dev mount, so the announcements
+# can actually play.
 RUN test "${TARGETARCH}" = "amd64" || \
         (echo "LeRobot-Xense Docker currently supports linux/amd64 only" >&2; exit 1) \
     && apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=60 update \
@@ -38,8 +51,7 @@ RUN test "${TARGETARCH}" = "amd64" || \
         libglib2.0-0 \
         libhidapi-hidraw0 \
         libsm6 \
-        libudev-dev \
-        libusb-1.0-0-dev \
+        libusb-1.0-0 \
         libvulkan1 \
         libx11-6 \
         libxkbcommon-x11-0 \
@@ -47,6 +59,7 @@ RUN test "${TARGETARCH}" = "amd64" || \
         libxrender1 \
         ninja-build \
         pkg-config \
+        speech-dispatcher \
         sudo \
         tini \
         udev \

--- a/docker/README.md
+++ b/docker/README.md
@@ -62,7 +62,7 @@ xhost -si:localuser:root
 的 `.env` 里钉死（`.env` 不会被提交）：
 
 ```dotenv
-LEROBOT_IMAGE_TAG=0.0.5
+LEROBOT_IMAGE_TAG=0.0.6
 ```
 
 改完用 `docker compose config --images` 确认解析结果。
@@ -74,7 +74,7 @@ LEROBOT_IMAGE_TAG=0.0.5
 | 跑一次性命令             | `docker compose run --rm xense-taccap lerobot-info`                     |
 | 升级镜像                 | 改 `.env` 的 tag，再 `docker compose pull`                              |
 | 确认解析到哪个镜像       | `docker compose config --images`                                        |
-| 看远端有什么（不下载）   | `docker manifest inspect ghcr.io/vertax42/xense-taccap-lerobot:0.0.5`   |
+| 看远端有什么（不下载）   | `docker manifest inspect ghcr.io/vertax42/xense-taccap-lerobot:0.0.6`   |
 | 确认本地跑的是哪个       | `docker image inspect --format '{{index .RepoDigests 0}}' <镜像>:<tag>` |
 | 不用 Pico4，关掉随启服务 | `START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap`          |
 | 查看数据                 | `docker compose run --rm xense-taccap bash -lc 'ls -la /data'`          |
@@ -172,13 +172,21 @@ python -c 'import importlib.metadata as M; print("pico4 ->", M.version("xensevr_
 dpkg-query -W -f='daemon -> ${Version}\n' xensevr-pc-service
 ```
 
-**后两行必须打印同一个版本号**（0.0.5 里是 `0.2.1`）。pico4 绑定链接的 C SDK 就取自那个
+**后两行必须打印同一个版本号**（0.0.6 里是 `0.2.1`）。pico4 绑定链接的 C SDK 就取自那个
 `.deb`，两者不一致说明镜像是半新不旧的构建，不要拿它录数据。
 
 ## 版本
 
-当前 **0.0.5**（`latest` 指向同一镜像）。只列影响使用方式的变化：
+当前 **0.0.6**（`latest` 指向同一镜像）。只列影响使用方式的变化：
 
+- **0.0.6** — **建议所有机器升级**，三条都是踩过的坑：
+  - **录制不再因为语音提示崩溃。** `--play_sounds` 默认开，而镜像里没有 `spd-say`，
+    于是第一集刚开始就 `FileNotFoundError`，清理时又抛一次,最后 `Aborted (core dumped)`。
+    现在装了 `speech-dispatcher`（`/dev/snd` 是通的，语音真能响），并且即使 TTS 不可用也
+    只警告不中断。**升级后不再需要 `--play_sounds=false`。**
+  - **录出来的视频不再是 `-rw------- root`**，改为 `0644`，别的用户/账号读得了。
+  - **`LEROBOT_DATA_DIR`** 可以把数据集直接落到宿主机目录，见上面「想直接在宿主机访问
+    数据」。这条不需要新镜像，改 `.env` 即可。
 - **0.0.5** — 安装改为从 GHCR 在线拉取，不再需要 tar 交付包。镜像内容与 0.0.4 相同，
   已装好 0.0.4 的机器没有必须升级的理由。
 - **0.0.4** — `--robot.id` 接受纯数字并按 `--robot.type` 展开（`--robot.id=0` → 单臂

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ discord = "https://discord.gg/s3KuuzsPFb"
 
 [project]
 name = "lerobot"
-version = "0.5.1+xtac.0.0.5"
+version = "0.5.1+xtac.0.0.6"
 description = "🤗 LeRobot (xense fork, no-ML build): datasets / record / replay / teleoperate with vendor hardware"
 dynamic = ["readme"]
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Ships the three fixes sitting on main that cannot reach a container without a
rebuild, plus the two Dockerfile changes that were waiting for a build to
piggyback on.

## What a user feels, since 0.0.5

- **Recording no longer dies on the speech announcement.** `--play_sounds`
  defaults on, `spd-say` was not in the image, and the failure repeated from the
  teardown path *while the first exception was being handled* — the process
  ended as `Aborted (core dumped)`. `say()` now degrades to a warning, and
  `speech-dispatcher` is installed so announcements actually play (`/dev/snd`
  reaches the container through the `/dev` mount). **`--play_sounds=false` stops
  being a required workaround.**
- **Recorded videos land 0644**, not 0600-root, so copying a dataset out as
  yourself stops failing on every `.mp4`.
- **`mamba activate`** inside the container stops answering with a wall of setup
  instructions.

`LEROBOT_DATA_DIR` is also new since 0.0.5, but it needs no image — it is a
compose change, usable today by editing `.env`.

## Dockerfile

`libusb-1.0-0-dev` and `libudev-dev` become plain `libusb-1.0-0`. d50e49b4
showed nothing compiles against either, but the `-dev` package could not simply
be deleted: it was the only thing pulling in the runtime library pyrealsense2
needs, and unlike `libudev1` that one is **absent from the base image**.

Verified in a throwaway `ubuntu:22.04` before touching the Dockerfile — after
installing `libusb-1.0-0` and `speech-dispatcher`:

```
libusb-1.0.so.0 => /lib/x86_64-linux-gnu/libusb-1.0.so.0
libudev.so.1    => /lib/x86_64-linux-gnu/libudev.so.1
/usr/bin/spd-say   (spd-say 0.11.1)
```

`docker build --check` clean.

## Note on the version table

README's current-version references move to 0.0.6, but the "0.0.5 and earlier
recorded 0600 videos" line deliberately still says 0.0.5 — that is a statement
about images already in the field, not about the current one.

## After merge

`git tag -a v0.0.6 && git push origin v0.0.6` builds and publishes. This is the
first build since the apt layer changed, so it will not hit the registry cache
for that layer and will take longer than the usual ~13 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
