### PR TITLE
fix(record): bound the blocking text-to-speech call

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -181,9 +181,12 @@ dpkg-query -W -f='daemon -> ${Version}\n' xensevr-pc-service
 
 - **0.0.6** — **建议所有机器升级**，三条都是踩过的坑：
   - **录制不再因为语音提示崩溃。** `--play_sounds` 默认开，而镜像里没有 `spd-say`，
-    于是第一集刚开始就 `FileNotFoundError`，清理时又抛一次,最后 `Aborted (core dumped)`。
-    现在装了 `speech-dispatcher`（`/dev/snd` 是通的，语音真能响），并且即使 TTS 不可用也
-    只警告不中断。**升级后不再需要 `--play_sounds=false`。**
+    于是第一集刚开始就 `FileNotFoundError`，清理时又抛一次，最后 `Aborted (core dumped)`。
+    现在 TTS 失败只警告不中断。**升级后不再需要 `--play_sounds=false`。**
+    注意**容器里仍然听不到声音** —— 镜像装了 `speech-dispatcher`，但没有语音合成器
+    模块，`spd-say` 会以非零退出，然后被安全忽略。补上合成器反而更糟：容器里没有可用的
+    音频输出，`spd-say --wait` 会**无限挂住**而不是失败，所以这条 blocking 调用现在带
+    10 秒上限。想真正听到提示音，请在宿主机上跑录制，或自己映射音频服务。
   - **录出来的视频不再是 `-rw------- root`**，改为 `0644`，别的用户/账号读得了。
   - **`LEROBOT_DATA_DIR`** 可以把数据集直接落到宿主机目录，见上面「想直接在宿主机访问
     数据」。这条不需要新镜像，改 `.env` 即可。

--- a/src/lerobot/utils/utils.py
+++ b/src/lerobot/utils/utils.py
@@ -214,6 +214,9 @@ def format_big_number(num, precision=0):
 # a host without the binary would otherwise print the same line hundreds of times.
 _TTS_WARNED = False
 
+# Generous for a five-word announcement, short enough that nobody watches it.
+_TTS_BLOCKING_TIMEOUT_S = 10.0
+
 
 def _warn_tts_once(reason: str) -> None:
     global _TTS_WARNED
@@ -261,7 +264,15 @@ def say(text: str, blocking: bool = False):
 
     try:
         if blocking:
-            subprocess.run(cmd, check=True)
+            # Bounded, because a TTS stack that hangs is a real state, not a
+            # hypothetical one: install a synthesizer in a container with no
+            # working audio sink and `spd-say --wait` blocks forever instead of
+            # failing. The only blocking call site is "Stop recording" in the
+            # record teardown, so an unbounded wait there wedges the whole
+            # session at the end, after the data was captured. TimeoutExpired is
+            # a SubprocessError, so the handler below reports it like any other
+            # failure.
+            subprocess.run(cmd, check=True, timeout=_TTS_BLOCKING_TIMEOUT_S)
         else:
             subprocess.Popen(cmd, creationflags=subprocess.CREATE_NO_WINDOW if system == "Windows" else 0)
     except FileNotFoundError:
@@ -269,7 +280,8 @@ def say(text: str, blocking: bool = False):
         _warn_tts_once(f"{cmd[0]} not found")
     except (OSError, subprocess.SubprocessError) as exc:
         # It exists but did not work — no audio sink, no speech-dispatcher
-        # daemon, device busy. Same verdict: not worth failing a recording over.
+        # daemon, device busy, or it hung. Same verdict: not worth failing or
+        # stalling a recording over.
         _warn_tts_once(f"{cmd[0]} failed: {exc}")
 
 


### PR DESCRIPTION
Verifying 0.0.6 turned up a worse failure than the one it fixed, and a claim I
should not have made.

## The claim

The 0.0.6 notes said installing `speech-dispatcher` meant the announcements
"can actually play". **They cannot.** The image has the binary but no
synthesizer module — Ubuntu's `speech-dispatcher` only *Recommends* `espeak-ng`
and the build uses `--no-install-recommends` — so speechd refuses to start and
`spd-say` exits non-zero:

```
Failed to connect to Speech Dispatcher: ... Autospawn failed.
/usr/lib/speech-dispatcher-modules/ -> sd_dummy  sd_generic     # no synth
```

That is caught and warned about, so recording is fine, but nothing is audible.
I wrote that line without testing it.

## The worse failure

What happens if you *do* install the synthesizer. Measured in the released
image, after adding `speech-dispatcher-espeak-ng`:

```
MODULES: sd_dummy sd_espeak-ng sd_espeak-ng-mbrola sd_generic
spd-say --wait "hello"  ->  still running after 20s, killed by timeout
```

With a synthesizer present and no working audio sink, `spd-say` stops failing
and starts **hanging**. A hang is not an exception, so the guard added in
94597ba2 does not catch it, and `subprocess.run(..., check=True)` had no
timeout.

The only blocking call site is `"Stop recording"` in the record teardown — so
this would wedge a session at the very end, after the episodes were captured,
at the point that finalizes them.

## Fix

A 10s timeout on the blocking path. `TimeoutExpired` is a `SubprocessError`,
which the existing handler already reports, so the change is small.

Tested against a stub that sleeps 300s (stub verified to actually hang —
`timeout 3` on it returns 124):

```
WARNING Text-to-speech unavailable (spd-say failed: ... timed out after 10.0 seconds)
返回了,耗时 10.0s
```

Previously it would not have returned at all.

**Deliberately not adding `espeak-ng` to the image.** It trades a fast, caught
failure for a slow one and buys no audio.

The README now says plainly that the container has no speech, why, and that
running on the host is the way to hear it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
