### PR TITLE
fix: prevent accidental remote downloads and metadata overwrites

### DIFF
--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -92,6 +92,7 @@ class LeRobotDatasetMetadata:
         revision: str | None = None,
         force_cache_sync: bool = False,
         metadata_buffer_size: int = 10,
+        local_files_only: bool = False,
     ):
         self.repo_id = repo_id
         self.revision = revision if revision else CODEBASE_VERSION
@@ -100,12 +101,21 @@ class LeRobotDatasetMetadata:
         self.latest_episode = None
         self.metadata_buffer: list[dict] = []
         self.metadata_buffer_size = metadata_buffer_size
+        self.local_files_only = local_files_only
+
+        if force_cache_sync and local_files_only:
+            raise ValueError("`force_cache_sync` and `local_files_only` cannot both be True.")
 
         try:
             if force_cache_sync:
                 raise FileNotFoundError
             self.load_metadata()
-        except (FileNotFoundError, NotADirectoryError):
+        except (FileNotFoundError, NotADirectoryError) as err:
+            if local_files_only:
+                raise FileNotFoundError(
+                    f"Cannot find dataset metadata in local directory: {self.root}. "
+                    "Set local_files_only=False to download metadata from the Hugging Face Hub."
+                ) from err
             if is_valid_version(self.revision):
                 self.revision = get_safe_version(self.repo_id, self.revision)
 
@@ -177,6 +187,7 @@ class LeRobotDatasetMetadata:
             repo_type="dataset",
             revision=self.revision,
             local_dir=self.root,
+            local_files_only=getattr(self, "local_files_only", False),
             allow_patterns=allow_patterns,
             ignore_patterns=ignore_patterns,
         )
@@ -578,6 +589,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         streaming_encoding: bool = False,
         encoder_queue_maxsize: int = 30,
         encoder_threads: int | None = None,
+        local_files_only: bool = False,
     ):
         """
         2 modes are available for instantiating this class, depending on 2 different use cases:
@@ -700,6 +712,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
             encoder_threads (int | None, optional): Number of threads per encoder instance. None lets the
                 codec auto-detect (default). Lower values reduce CPU usage per encoder. Maps to 'lp' (via svtav1-params) for
                 libsvtav1 and 'threads' for h264/hevc.
+            local_files_only (bool, optional): If True, never download from the Hugging Face Hub. Fails if
+                local metadata, data, or videos are missing or incomplete. Defaults to False.
         """
         super().__init__()
         self.repo_id = repo_id
@@ -715,6 +729,10 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self.episodes_since_last_encoding = 0
         self.vcodec = resolve_vcodec(vcodec)
         self._encoder_threads = encoder_threads
+        self.local_files_only = local_files_only
+
+        if force_cache_sync and local_files_only:
+            raise ValueError("`force_cache_sync` and `local_files_only` cannot both be True.")
 
         # Unused attributes
         self.image_writer = None
@@ -727,7 +745,13 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self.root.mkdir(exist_ok=True, parents=True)
 
         # Load metadata
-        self.meta = LeRobotDatasetMetadata(self.repo_id, self.root, self.revision, force_cache_sync=force_cache_sync)
+        self.meta = LeRobotDatasetMetadata(
+            self.repo_id,
+            self.root,
+            self.revision,
+            force_cache_sync=force_cache_sync,
+            local_files_only=local_files_only,
+        )
 
         # Track dataset state for efficient incremental writing
         self._lazy_loading = False
@@ -742,7 +766,12 @@ class LeRobotDataset(torch.utils.data.Dataset):
             # Check if cached dataset contains all requested episodes
             if not self._check_cached_episodes_sufficient():
                 raise FileNotFoundError("Cached dataset doesn't contain all requested episodes")
-        except (FileNotFoundError, NotADirectoryError):
+        except (FileNotFoundError, NotADirectoryError) as err:
+            if local_files_only:
+                raise FileNotFoundError(
+                    f"Cannot find all requested dataset data and videos in local directory: {self.root}. "
+                    "Set local_files_only=False to download missing files from the Hugging Face Hub."
+                ) from err
             if is_valid_version(self.revision):
                 self.revision = get_safe_version(self.repo_id, self.revision)
             self.download(download_videos)
@@ -853,6 +882,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
             repo_type="dataset",
             revision=self.revision,
             local_dir=self.root,
+            local_files_only=getattr(self, "local_files_only", False),
             allow_patterns=allow_patterns,
             ignore_patterns=ignore_patterns,
         )

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -1709,6 +1709,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         obj.episodes_since_last_encoding = 0
         obj.vcodec = vcodec
         obj._encoder_threads = encoder_threads
+        obj.local_files_only = False
 
         if image_writer_processes or image_writer_threads:
             obj.start_image_writer(image_writer_processes, image_writer_threads)

--- a/src/lerobot/datasets/v30/augment_dataset_quantile_stats.py
+++ b/src/lerobot/datasets/v30/augment_dataset_quantile_stats.py
@@ -187,6 +187,7 @@ def augment_dataset_with_quantile_stats(
     dataset = LeRobotDataset(
         repo_id=repo_id,
         root=root,
+        local_files_only=root is not None,
     )
 
     if not overwrite and has_quantile_stats(dataset.meta.stats):

--- a/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
@@ -497,8 +497,7 @@ def convert_dataset(
 
     if new_root.is_dir():
         raise FileExistsError(
-            f"Conversion staging directory already exists: {new_root}. "
-            "Remove it manually before retrying."
+            f"Conversion staging directory already exists: {new_root}. Remove it manually before retrying."
         )
 
     if not use_local_dataset:

--- a/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
@@ -458,6 +458,8 @@ def convert_dataset(
     if video_file_size_in_mb is None:
         video_file_size_in_mb = DEFAULT_VIDEO_FILE_SIZE_IN_MB
 
+    root_provided = root is not None
+
     # First check if the dataset already has a v3.0 version
     if root is None and not force_conversion:
         try:
@@ -478,13 +480,26 @@ def convert_dataset(
     old_root = root.parent / f"{root.name}_old"
     new_root = root.parent / f"{root.name}_v30"
 
-    # Handle old_root cleanup if both old_root and root exist
     if old_root.is_dir() and root.is_dir():
-        shutil.rmtree(str(root))
-        shutil.move(str(old_root), str(root))
+        raise FileExistsError(
+            f"Both {root} and backup {old_root} exist. Refusing to delete either directory automatically.\n"
+            "Remove or rename the stale directory, then retry."
+        )
+
+    if old_root.is_dir() and not root.exists():
+        raise FileNotFoundError(
+            f"Input dataset {root} is missing, but a previous conversion backup exists at {old_root}.\n"
+            "Restore the backup before retrying, or pass a different --root."
+        )
+
+    if root_provided and not root.exists():
+        raise FileNotFoundError(f"Input dataset directory does not exist: {root}")
 
     if new_root.is_dir():
-        shutil.rmtree(new_root)
+        raise FileExistsError(
+            f"Conversion staging directory already exists: {new_root}. "
+            "Remove it manually before retrying."
+        )
 
     if not use_local_dataset:
         snapshot_download(

--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -244,6 +244,8 @@ class EditDatasetConfig:
     repo_id: str | None = None
     # Root directory where the input dataset is stored. If not specified, defaults to $HF_LEROBOT_HOME/repo_id.
     root: str | None = None
+    # Only read from the local root/cache. Do not download missing files from the Hugging Face Hub.
+    local_files_only: bool = False
     # Edited dataset identifier. When both new_repo_id (resp. new_root) and repo_id (resp. root) are identical, modifications are applied in-place and a backup of the original dataset is created. Required for Merge operation.
     new_repo_id: str | None = None
     # Root directory where the edited dataset will be stored. If not specified, defaults to $HF_LEROBOT_HOME/new_repo_id. For Split operation, this is the base directory for the split datasets.
@@ -275,6 +277,38 @@ def get_output_path(
     return output_repo_id, output_path
 
 
+def _validate_input_root(
+    repo_id: str,
+    root: str | Path | None,
+    *,
+    local_files_only: bool,
+) -> None:
+    input_path = Path(root) if root else HF_LEROBOT_HOME / repo_id
+    if input_path.exists():
+        return
+
+    backup_path = input_path.with_name(input_path.name + "_old")
+    if backup_path.exists():
+        raise FileNotFoundError(
+            f"Input dataset directory does not exist: {input_path}\n"
+            f"A backup from a previous in-place edit exists at: {backup_path}\n"
+            "Restore the backup, or pass that path via --root (or --operation.roots)."
+        )
+
+    if root is not None or local_files_only:
+        raise FileNotFoundError(f"Input dataset directory does not exist: {input_path}")
+
+
+def _load_input_dataset(
+    repo_id: str,
+    root: str | Path | None,
+    *,
+    local_files_only: bool,
+) -> LeRobotDataset:
+    _validate_input_root(repo_id, root, local_files_only=local_files_only)
+    return LeRobotDataset(repo_id, root=root, local_files_only=local_files_only)
+
+
 def handle_delete_episodes(cfg: EditDatasetConfig) -> None:
     if not isinstance(cfg.operation, DeleteEpisodesConfig):
         raise ValueError("Operation config must be DeleteEpisodesConfig")
@@ -282,7 +316,11 @@ def handle_delete_episodes(cfg: EditDatasetConfig) -> None:
     if not cfg.operation.episode_indices:
         raise ValueError("episode_indices must be specified for delete_episodes operation")
 
-    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
+    dataset = _load_input_dataset(
+        cfg.repo_id,
+        cfg.root,
+        local_files_only=cfg.local_files_only or cfg.root is not None,
+    )
     output_repo_id, output_dir = get_output_path(
         cfg.repo_id,
         new_repo_id=cfg.new_repo_id,
@@ -307,7 +345,7 @@ def handle_delete_episodes(cfg: EditDatasetConfig) -> None:
 
     if cfg.push_to_hub:
         logging.info(f"Pushing to hub as {output_repo_id}")
-        LeRobotDataset(output_repo_id, root=output_dir).push_to_hub()
+        LeRobotDataset(output_repo_id, root=output_dir, local_files_only=True).push_to_hub()
 
 
 def handle_split(cfg: EditDatasetConfig) -> None:
@@ -322,7 +360,11 @@ def handle_split(cfg: EditDatasetConfig) -> None:
             "split uses the original dataset identifier --repo_id to generate split names. The --new_repo_id parameter is ignored."
         )
 
-    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
+    dataset = _load_input_dataset(
+        cfg.repo_id,
+        cfg.root,
+        local_files_only=cfg.local_files_only or cfg.root is not None,
+    )
 
     logging.info(f"Splitting dataset {cfg.repo_id} with splits: {cfg.operation.splits}")
     split_datasets = split_dataset(
@@ -336,7 +378,7 @@ def handle_split(cfg: EditDatasetConfig) -> None:
 
         if cfg.push_to_hub:
             logging.info(f"Pushing {split_name} split to hub as {split_ds.repo_id}")
-            LeRobotDataset(split_ds.repo_id, root=split_ds.root).push_to_hub()
+            LeRobotDataset(split_ds.repo_id, root=split_ds.root, local_files_only=True).push_to_hub()
 
 
 def handle_merge(cfg: EditDatasetConfig) -> None:
@@ -356,12 +398,15 @@ def handle_merge(cfg: EditDatasetConfig) -> None:
             raise ValueError("repo_ids and roots must have the same length for merge operation")
         logging.info(f"Loading {len(cfg.operation.roots)} datasets to merge")
         datasets = [
-            LeRobotDataset(repo_id=repo_id, root=root)
+            _load_input_dataset(repo_id, root, local_files_only=True)
             for repo_id, root in zip(cfg.operation.repo_ids, cfg.operation.roots, strict=True)
         ]
     else:
         logging.info(f"Loading {len(cfg.operation.repo_ids)} datasets to merge")
-        datasets = [LeRobotDataset(repo_id) for repo_id in cfg.operation.repo_ids]
+        datasets = [
+            _load_input_dataset(repo_id, None, local_files_only=cfg.local_files_only)
+            for repo_id in cfg.operation.repo_ids
+        ]
 
     output_dir = Path(cfg.new_root) if cfg.new_root else HF_LEROBOT_HOME / cfg.new_repo_id
 
@@ -377,7 +422,7 @@ def handle_merge(cfg: EditDatasetConfig) -> None:
 
     if cfg.push_to_hub:
         logging.info(f"Pushing to hub as {cfg.new_repo_id}")
-        LeRobotDataset(merged_dataset.repo_id, root=output_dir).push_to_hub()
+        LeRobotDataset(merged_dataset.repo_id, root=output_dir, local_files_only=True).push_to_hub()
 
 
 def handle_remove_feature(cfg: EditDatasetConfig) -> None:
@@ -387,7 +432,11 @@ def handle_remove_feature(cfg: EditDatasetConfig) -> None:
     if not cfg.operation.feature_names:
         raise ValueError("feature_names must be specified for remove_feature operation")
 
-    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
+    dataset = _load_input_dataset(
+        cfg.repo_id,
+        cfg.root,
+        local_files_only=cfg.local_files_only or cfg.root is not None,
+    )
     output_repo_id, output_dir = get_output_path(
         cfg.repo_id,
         new_repo_id=cfg.new_repo_id,
@@ -412,7 +461,7 @@ def handle_remove_feature(cfg: EditDatasetConfig) -> None:
 
     if cfg.push_to_hub:
         logging.info(f"Pushing to hub as {output_repo_id}")
-        LeRobotDataset(output_repo_id, root=output_dir).push_to_hub()
+        LeRobotDataset(output_repo_id, root=output_dir, local_files_only=True).push_to_hub()
 
 
 def handle_modify_tasks(cfg: EditDatasetConfig) -> None:
@@ -430,7 +479,11 @@ def handle_modify_tasks(cfg: EditDatasetConfig) -> None:
             "modify_tasks modifies datasets in-place. The --new_repo_id and --new_root parameters are ignored."
         )
 
-    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
+    dataset = _load_input_dataset(
+        cfg.repo_id,
+        cfg.root,
+        local_files_only=cfg.local_files_only or cfg.root is not None,
+    )
     logging.warning(f"Modifying dataset in-place at {dataset.root}. Original data will be overwritten.")
 
     # Convert episode_tasks keys from string to int if needed (CLI passes strings)
@@ -461,7 +514,11 @@ def handle_modify_tasks(cfg: EditDatasetConfig) -> None:
 def handle_convert_image_to_video(cfg: EditDatasetConfig) -> None:
     # Note: Parser may create any config type with the right fields, so we access fields directly
     # instead of checking isinstance()
-    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
+    dataset = _load_input_dataset(
+        cfg.repo_id,
+        cfg.root,
+        local_files_only=cfg.local_files_only or cfg.root is not None,
+    )
 
     # Determine output directory and repo_id
     # Priority: 1) new_root, 2) new_repo_id, 3) operation.output_dir, 4) auto-generated name
@@ -536,7 +593,11 @@ def handle_info(cfg: EditDatasetConfig):
     if not isinstance(cfg.operation, InfoConfig):
         raise ValueError("Operation config must be InfoConfig")
 
-    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
+    dataset = _load_input_dataset(
+        cfg.repo_id,
+        cfg.root,
+        local_files_only=cfg.local_files_only or cfg.root is not None,
+    )
     sys.stdout.write(f"======Info {dataset.meta.repo_id}\n")
     sys.stdout.write(f"Repository ID: {dataset.meta.repo_id} \n")
     sys.stdout.write(f"Total episode: {dataset.meta.total_episodes} \n")

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -434,6 +434,7 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
 
     try:
         if cfg.resume:
+            # Resume must operate on the local dataset; never fall back to a remote copy.
             dataset = LeRobotDataset(
                 cfg.dataset.repo_id,
                 root=cfg.dataset.root,
@@ -442,6 +443,7 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                 streaming_encoding=cfg.dataset.streaming_encoding,
                 encoder_queue_maxsize=cfg.dataset.encoder_queue_maxsize,
                 encoder_threads=cfg.dataset.encoder_threads,
+                local_files_only=True,
             )
 
             if hasattr(robot, "cameras") and len(robot.cameras) > 0:

--- a/src/lerobot/scripts/push_dataset_to_hub.py
+++ b/src/lerobot/scripts/push_dataset_to_hub.py
@@ -102,7 +102,7 @@ def push_dataset_to_hub(
         logging.info("Skipping video files")
 
     logging.info("Loading local LeRobot dataset...")
-    dataset = LeRobotDataset(repo_id=repo_id, root=dataset_path)
+    dataset = LeRobotDataset(repo_id=repo_id, root=dataset_path, local_files_only=True)
 
     logging.info("Starting upload...")
     try:

--- a/tests/datasets/test_convert_dataset_v21_to_v30.py
+++ b/tests/datasets/test_convert_dataset_v21_to_v30.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from lerobot.datasets.v30.convert_dataset_v21_to_v30 import convert_dataset
+
+
+def _write_minimal_v21_info(root: Path) -> None:
+    (root / "meta").mkdir(parents=True, exist_ok=True)
+    (root / "meta" / "info.json").write_text('{"codebase_version": "v2.1", "features": {}}')
+
+
+def test_convert_dataset_refuses_to_delete_current_root_when_backup_exists(tmp_path):
+    root = tmp_path / "ds"
+    old_root = tmp_path / "ds_old"
+    _write_minimal_v21_info(root)
+    old_root.mkdir()
+
+    with pytest.raises(FileExistsError, match="Refusing to delete"):
+        convert_dataset("test/repo", root=root, push_to_hub=False)
+
+
+def test_convert_dataset_refuses_remote_fallback_when_backup_exists(tmp_path):
+    old_root = tmp_path / "ds_old"
+    old_root.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="previous conversion backup"):
+        convert_dataset("test/repo", root=tmp_path / "ds", push_to_hub=False)
+
+
+def test_convert_dataset_refuses_missing_explicit_root(tmp_path):
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        convert_dataset("test/repo", root=tmp_path / "ds", push_to_hub=False)
+
+
+def test_convert_dataset_refuses_to_delete_staging_dir(tmp_path):
+    root = tmp_path / "ds"
+    _write_minimal_v21_info(root)
+    (tmp_path / "ds_v30").mkdir()
+
+    with pytest.raises(FileExistsError, match="staging directory"):
+        convert_dataset("test/repo", root=root, push_to_hub=False)

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+import shutil
 from itertools import chain
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -101,6 +103,34 @@ def test_dataset_initialization(tmp_path, lerobot_dataset_factory):
     assert dataset.episodes == kwargs["episodes"]
     assert dataset.num_episodes == len(kwargs["episodes"])
     assert dataset.num_frames == len(dataset)
+
+
+def test_local_files_only_does_not_download_missing_metadata(tmp_path):
+    with (
+        patch("lerobot.datasets.lerobot_dataset.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.lerobot_dataset.snapshot_download") as mock_snapshot_download,
+    ):
+        with pytest.raises(FileNotFoundError, match="Cannot find dataset metadata in local directory"):
+            LeRobotDataset(DUMMY_REPO_ID, root=tmp_path / "missing", local_files_only=True)
+
+    mock_get_safe_version.assert_not_called()
+    mock_snapshot_download.assert_not_called()
+
+
+def test_local_files_only_does_not_download_missing_data(tmp_path, lerobot_dataset_factory):
+    root = tmp_path / "test"
+    lerobot_dataset_factory(root=root, total_episodes=1, total_frames=1)
+    shutil.rmtree(root / "data")
+
+    with (
+        patch("lerobot.datasets.lerobot_dataset.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.lerobot_dataset.snapshot_download") as mock_snapshot_download,
+    ):
+        with pytest.raises(FileNotFoundError, match="Cannot find all requested dataset data and videos"):
+            LeRobotDataset(DUMMY_REPO_ID, root=root, local_files_only=True)
+
+    mock_get_safe_version.assert_not_called()
+    mock_snapshot_download.assert_not_called()
 
 
 # TODO(rcadene, aliberts): do not run LeRobotDataset.create, instead refactor LeRobotDatasetMetadata.create

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -109,9 +109,9 @@ def test_local_files_only_does_not_download_missing_metadata(tmp_path):
     with (
         patch("lerobot.datasets.lerobot_dataset.get_safe_version") as mock_get_safe_version,
         patch("lerobot.datasets.lerobot_dataset.snapshot_download") as mock_snapshot_download,
+        pytest.raises(FileNotFoundError, match="Cannot find dataset metadata in local directory"),
     ):
-        with pytest.raises(FileNotFoundError, match="Cannot find dataset metadata in local directory"):
-            LeRobotDataset(DUMMY_REPO_ID, root=tmp_path / "missing", local_files_only=True)
+        LeRobotDataset(DUMMY_REPO_ID, root=tmp_path / "missing", local_files_only=True)
 
     mock_get_safe_version.assert_not_called()
     mock_snapshot_download.assert_not_called()
@@ -125,9 +125,9 @@ def test_local_files_only_does_not_download_missing_data(tmp_path, lerobot_datas
     with (
         patch("lerobot.datasets.lerobot_dataset.get_safe_version") as mock_get_safe_version,
         patch("lerobot.datasets.lerobot_dataset.snapshot_download") as mock_snapshot_download,
+        pytest.raises(FileNotFoundError, match="Cannot find all requested dataset data and videos"),
     ):
-        with pytest.raises(FileNotFoundError, match="Cannot find all requested dataset data and videos"):
-            LeRobotDataset(DUMMY_REPO_ID, root=root, local_files_only=True)
+        LeRobotDataset(DUMMY_REPO_ID, root=root, local_files_only=True)
 
     mock_get_safe_version.assert_not_called()
     mock_snapshot_download.assert_not_called()

--- a/tests/scripts/test_edit_dataset_parsing.py
+++ b/tests/scripts/test_edit_dataset_parsing.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 import draccus
 import pytest
 
@@ -28,6 +30,7 @@ from lerobot.scripts.lerobot_edit_dataset import (
     RemoveFeatureConfig,
     SplitConfig,
     _validate_config,
+    _validate_input_root,
 )
 
 
@@ -83,3 +86,16 @@ class TestOperationTypeParsing:
         cfg = parse_cfg(["--repo_id", "test/repo", "--new_repo_id", "test/merged", "--operation.type", type_name])
         resolved_name = OperationConfig.get_choice_name(type(cfg.operation))
         assert resolved_name == type_name
+
+
+class TestLocalInputValidation:
+    def test_missing_explicit_root_fails_without_download(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            _validate_input_root("test/repo", tmp_path / "missing", local_files_only=True)
+
+    def test_stale_inplace_backup_gives_restore_hint(self, tmp_path):
+        backup = tmp_path / "dataset_old"
+        backup.mkdir()
+
+        with pytest.raises(FileNotFoundError, match="Restore the backup"):
+            _validate_input_root("test/repo", tmp_path / "dataset", local_files_only=True)

--- a/tests/scripts/test_edit_dataset_parsing.py
+++ b/tests/scripts/test_edit_dataset_parsing.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
-
 import draccus
 import pytest
 


### PR DESCRIPTION
# Pull Request

## Background

`LeRobotDataset(root=...)` treats `root` as a local cache rather than an offline dataset root by default. When local `meta/`, `data/`, or `videos/` files are missing or incomplete, the constructor automatically calls `snapshot_download` to backfill them from the Hub. Local workflows such as dataset editing, resume, push, and stats augmentation may therefore unintentionally download and overwrite files like `meta/info.json` when the user only wanted to work with local data.

`convert_dataset_v21_to_v30` also had a more direct overwrite risk: if both `root` and `root_old` existed, it deleted `root` and replaced it with `root_old`.

## Changes

- Add `local_files_only` to `LeRobotDatasetMetadata` and `LeRobotDataset`:
  - fail when local metadata is missing;
  - fail when local data or videos are incomplete;
  - avoid calling `get_safe_version` or `snapshot_download`;
  - reject `force_cache_sync=True` combined with `local_files_only=True`.
- Update `lerobot-edit-dataset`:
  - treat explicit `--root` as a local dataset;
  - add `--local_files_only true`;
  - fail fast when the input path is missing and a `xxx_old` backup exists, with a restore hint;
  - load output datasets in local mode before pushing.
- Update `lerobot-record --resume` to force `local_files_only=True`, preventing resume from downloading and overwriting a local recording.
- Update `push_dataset_to_hub` to load the local dataset with `local_files_only=True`.
- Update `augment_dataset_with_quantile_stats` to use `local_files_only` when `root` is explicit.
- Harden `convert_dataset_v21_to_v30`:
  - refuse to delete `root`, `root_old`, or `*_v30`;
  - fail when an explicit `--root` is missing;
  - require manual cleanup when a conversion staging directory already exists.

## Tests

- Added tests for `local_files_only` behavior.
- Added tests for conversion path protection in `convert_dataset_v21_to_v30`.
- Related script parsing, dataset loading, and dataset tools tests pass.

## Known Issues (not fixed)

1. Automatic downloading remains the default behavior of `LeRobotDataset`.
   This PR only enables `local_files_only` for edit, resume, push, and quantile stats paths. Training, replay, visualization, annotation, and other tools may still trigger remote downloads when given an incomplete local `root`.

2. `force_cache_sync=True` still forces a Hub sync and may overwrite local metadata/data.
   This is an explicit opt-in and intentionally unchanged.

3. The `_old` backup strategy in `lerobot-edit-dataset` still has data-loss risk.
   If `xxx_old` already exists, it is deleted before creating a new backup; a failed in-place edit is not rolled back automatically. A future improvement could use timestamped backups or restore the original directory on failure.

4. `write_json` is not atomic.
   Files such as `meta/info.json` and `meta/stats.json` are written directly with `open(..., "w")`. An interrupted process can leave a truncated file, which may trigger the automatic download path later. A future improvement could write to a temporary file and use `os.replace`.

5. `StreamingLeRobotDataset` does not yet expose `local_files_only`.
   It uses `LeRobotDatasetMetadata` internally but does not pass through `local_files_only`, so streaming reads may still fall back to the default download behavior.

6. Other read-only/annotation scripts have not been migrated to local mode.
   Examples include `lerobot_annotate_reward`, `lerobot_replay`, and `lerobot_dataset_viz`. If they are intended to read local datasets, they should also use `local_files_only=True`.

7. Remote resume needs an explicit safety precondition.
   Downloading and overwriting a local recording during resume is safe only when the recording was uploaded automatically and the remote copy is always up to date. Without auto-upload, the remote copy can be stale and can overwrite newer local files such as `meta/info.json`, `meta/episodes`, and `data/`.

   This PR makes resume use `local_files_only=True`, so it will not automatically fall back to remote. If remote resume is restored later, it should:

   - require auto-upload or verify the remote data is newer;
   - compare remote and local versions/timestamps before downloading;
   - keep `local_files_only=True` as the default and make remote resume an explicit opt-in.

## Scope

This PR is a standalone fix based on upstream `main` and does not include the 8-to-6 camera conversion feature from PR #47. PR #47 is intentionally feature-only and does not duplicate this fix.

To keep full coverage after PR #47 merges, this PR (or a follow-up) should be rebased onto the merged `main` and apply `local_files_only` to the newly added `handle_convert_8_to_6_cameras` handler.
