### PR TITLE
feat(pico): default the head camera to the headset's own 640x480

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,10 @@ something different) plus `head_camera.*`, the headset pose.
   separate messages, left first, so sampling at loop rate catches one updated
   and not the other (measured 7% of frames). `cameras/pico/stereo_poller.py`
   polls at 120 Hz and publishes only pairs whose `frame_sequence` agrees.
-- **Resolution is a whitelist**, `1024x768` / `1280x960`, both 4:3 like the
-  sensor. Unlisted sizes and a first frame that disagrees with the config are
+- **Resolution is a whitelist**, `640x480` / `1024x768` / `1280x960`, all 4:3
+  like the sensor and all three offered by the headset app's Resolution setting.
+  The default is `640x480` because that is the app's default, so the two line up
+  untouched. Unlisted sizes and a first frame that disagrees with the config are
   errors, deliberately — silent rescaling would change the recorded field of
   view without trace. Do not "fix" this with a resize.
 

--- a/README.md
+++ b/README.md
@@ -267,10 +267,12 @@ lerobot-record --robot.type=bi_taccap_gripper \
   something different here.
 - **`--robot.head_camera_eyes=left`** (or `right`) records a single eye, halving
   the JPEG decoding and the encoder load.
-- **`--robot.head_camera_width/_height`** accept `1024x768` (default) or
-  `1280x960`. Both are 4:3, matching the sensor. An unlisted size is an error
-  rather than a silent downgrade, and so is a first frame whose size disagrees
-  with the config — rescaling would quietly change the recorded field of view.
+- **`--robot.head_camera_width/_height`** accept `640x480` (default), `1024x768`
+  or `1280x960` — the three the headset app's Resolution setting offers, and the
+  default matches the app's own. All are 4:3, matching the sensor. An unlisted
+  size is an error rather than a silent downgrade, and so is a first frame whose
+  size disagrees with the config — rescaling would quietly change the recorded
+  field of view, so raising the app's setting means raising these too.
 - **`head_camera.*` shares the world frame with `tcp.*`**, remapped through the
   same Pico→world rotation the tracker uses, so the headset and the grippers can
   be compared directly and are drawn in one 3D scene.

--- a/src/lerobot/cameras/pico/configuration_pico.py
+++ b/src/lerobot/cameras/pico/configuration_pico.py
@@ -19,15 +19,17 @@ from typing import ClassVar
 
 from ..configs import CameraConfig
 
-# The two modes the headset app is configured to emit. Both are 4:3, matching
-# the sensor: PICO's camera-access API caps a frame at 2328x1748 (= 1.332), so
-# a 16:9 request would be a crop or a stretch rather than more field of view.
+# The three modes the headset app offers, in the order its Resolution setting
+# lists them; the first is both the app's default and the one we default to.
+# All are 4:3, matching the sensor: PICO's camera-access API caps a frame at
+# 2328x1748 (= 1.332), so a 16:9 request would be a crop or a stretch rather
+# than more field of view.
 #
 # Unlike the ZED path in XenseVR-RobotVision-PC, which silently falls back to
 # HD720 when asked for a resolution it does not have, an unlisted size here is
 # an error. That silent fallback is exactly why that repo's README documents a
 # frame size the code never produces.
-SUPPORTED_MODES: tuple[tuple[int, int], ...] = ((1024, 768), (1280, 960))
+SUPPORTED_MODES: tuple[tuple[int, int], ...] = ((640, 480), (1024, 768), (1280, 960))
 
 
 @CameraConfig.register_subclass("pico")
@@ -42,7 +44,7 @@ class PicoCameraConfig(CameraConfig):
     ``width``/``height`` describe **one eye**, following the same convention as
     the ZED stereo path (``--width`` there is per-eye and the merge doubles it
     internally). With the default ``eyes="both"`` the recorded frame is
-    therefore ``height x (2 * width)`` — 768x2048 by default. The two eyes are
+    therefore ``height x (2 * width)`` — 480x1280 by default. The two eyes are
     concatenated at full resolution rather than squeezed into a single-eye
     budget, so nothing is thrown away; the cost is one extra video key's worth
     of pixels.
@@ -84,7 +86,7 @@ class PicoCameraConfig(CameraConfig):
             raise ValueError("Pico camera fps must be positive.")
 
         if (self.width, self.height) not in SUPPORTED_MODES:
-            modes = " or ".join(f"{w}x{h}" for w, h in SUPPORTED_MODES)
+            modes = ", ".join(f"{w}x{h}" for w, h in SUPPORTED_MODES)
             raise ValueError(
                 f"Pico camera supports {modes} per eye, got {self.width}x{self.height}. "
                 "These are the modes the headset app emits; a different size would have to "

--- a/src/lerobot/robots/bi_taccap_gripper/README.md
+++ b/src/lerobot/robots/bi_taccap_gripper/README.md
@@ -116,20 +116,23 @@ and/or `--robot.right_tracker_serial=<SN>`. A pinned side uses its serial **verb
 enumeration, no rule check); un-pinned sides still auto-discover by the second-to-last-digit
 rule. Use this for a tracker whose serial does not follow the rule, or when enumeration is flaky.
 
-Enable the head camera with `--robot.enable_head_camera=true`. It records `width=1024`,
-`height=768` at dataset FPS 30 as **two keys, one per eye** — `left_head` and
-`right_head`, each 768x1024. `--robot.head_camera_eyes=left` (or `right`) records a
+Enable the head camera with `--robot.enable_head_camera=true`. It records `width=640`,
+`height=480` at dataset FPS 30 as **two keys, one per eye** — `left_head` and
+`right_head`, each 480x640. `--robot.head_camera_eyes=left` (or `right`) records a
 single eye, halving both the JPEG decoding and the encoder load.
 
 > These names refer to the headset's **eyes**, not to the left/right arm. There is one
 > headset on a bimanual rig, so they are not per-arm the way `{s}_wrist` is.
 
-Only `1024x768` and `1280x960` are accepted, via `--robot.head_camera_width/_height`.
-Both are 4:3, matching the sensor: PICO's camera-access API caps a frame at 2328x1748,
-which is 4:3, so a 16:9 request would crop or stretch rather than widen the field of
-view. An unlisted size is an error rather than a silent fallback. Changing the size or
-the eye selection changes the recorded frame, so episodes either side of such a change
-are not comparable.
+Only `640x480` (default), `1024x768` and `1280x960` are accepted, via
+`--robot.head_camera_width/_height` — the three the headset app's Resolution setting
+offers, and it defaults to `640` as well, so the defaults line up out of the box. Raise
+it in the app and the command line has to follow, or `connect()` fails on the first
+frame's size. All three are 4:3, matching the sensor: PICO's camera-access API caps a
+frame at 2328x1748, which is 4:3, so a 16:9 request would crop or stretch rather than
+widen the field of view. An unlisted size is an error rather than a silent fallback.
+Changing the size or the eye selection changes the recorded frame, so episodes either
+side of such a change are not comparable.
 
 The two eyes arrive as separate messages, each with its own sequence number and
 timestamp, and recording them under separate keys means a mismatched pair leaves no

--- a/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
@@ -203,13 +203,15 @@ class BiTaccapGripperConfig(RobotConfig):
     head_camera_eyes: str = "both"
     """``"both"`` records the eyes side by side, ``"left"``/``"right"`` one of
     them. Merged frames are ``head_camera_height x (2 * head_camera_width)``."""
-    head_camera_width: int = 1024
-    head_camera_height: int = 768
+    head_camera_width: int = 640
+    head_camera_height: int = 480
     """Per-eye size, following the stereo convention that width is one eye and
-    a merge doubles it. Only 1024x768 and 1280x960 are supported — both 4:3,
-    matching the sensor (PICO's camera-access API caps a frame at 2328x1748,
-    which is 4:3, so a 16:9 request would crop or stretch rather than widen
-    the field of view)."""
+    a merge doubles it. Only 640x480 (the headset app's own default, and this
+    one), 1024x768 and 1280x960 are supported — all 4:3, matching the sensor
+    (PICO's camera-access API caps a frame at 2328x1748, which is 4:3, so a
+    16:9 request would crop or stretch rather than widen the field of view).
+    The headset is what produces the frames, so this has to match the app's
+    Resolution setting or ``connect()`` fails on the first frame's size."""
     head_camera_fps: int = 30
     head_camera_startup_timeout_s: float = 5.0
     head_camera_stale_after_s: float = 0.2

--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -626,7 +626,8 @@ at connect). Leave it unset (default) to keep auto-discovery.
   `--robot.wrist_camera_width/_height/_fps`.
 - **Head** → obs keys `left_head` / `right_head`, off by default;
   `--robot.enable_head_camera=true` streams the Pico headset's stereo camera as **one key
-  per eye**. `--robot.head_camera_width/_height` accept `1024x768` (default) or `1280x960`;
+  per eye**. `--robot.head_camera_width/_height` accept `640x480` (default), `1024x768` or
+  `1280x960`, and must match the headset app's Resolution setting;
   `--robot.head_camera_eyes=left` (or `right`) records a single eye. It shares the
   XenseVR SDK connection with the tracker, so the headset app must be streaming. There is
   **one headset**, so this is the same view the bimanual robot records — running two
@@ -752,7 +753,7 @@ column subset of a bimanual one.
 | `imu.mag.{x,y,z}`               | `enable_imu`          | TacCap IMU                                             | float (µT)                                           |
 | `tactile_left`, `tactile_right` | auto-discovered       | Xense sensor on that finger, recorded view (`rectify`) | uint8 (H, W, 3), landscape — currently (400, 700, 3) |
 | `wrist_cam`                     | `enable_wrist_camera` | wrist UVC via `cameras/`                               | uint8 (H, W, 3)                                      |
-| `left_head`, `right_head`       | `enable_head_camera`  | Pico headset camera, one key per eye                   | uint8 (H, W, 3) — default (768, 1024, 3)             |
+| `left_head`, `right_head`       | `enable_head_camera`  | Pico headset camera, one key per eye                   | uint8 (H, W, 3) — default (480, 640, 3)              |
 | `head_camera.x/y/z/r1..r6`      | `enable_head_camera`  | headset pose, same world frame as `tcp.*`              | float                                                |
 
 The flags are all `--robot.*` (e.g. `--robot.enable_imu=true`); the tracker and gripper

--- a/src/lerobot/robots/taccap_gripper/config_taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/config_taccap_gripper.py
@@ -205,13 +205,15 @@ class TaccapGripperConfig(RobotConfig):
     head_camera_eyes: str = "both"
     """``"both"`` records the eyes side by side, ``"left"``/``"right"`` one of
     them. Merged frames are ``head_camera_height x (2 * head_camera_width)``."""
-    head_camera_width: int = 1024
-    head_camera_height: int = 768
+    head_camera_width: int = 640
+    head_camera_height: int = 480
     """Per-eye size, following the stereo convention that width is one eye and
-    a merge doubles it. Only 1024x768 and 1280x960 are supported — both 4:3,
-    matching the sensor (PICO's camera-access API caps a frame at 2328x1748,
-    which is 4:3, so a 16:9 request would crop or stretch rather than widen
-    the field of view)."""
+    a merge doubles it. Only 640x480 (the headset app's own default, and this
+    one), 1024x768 and 1280x960 are supported — all 4:3, matching the sensor
+    (PICO's camera-access API caps a frame at 2328x1748, which is 4:3, so a
+    16:9 request would crop or stretch rather than widen the field of view).
+    The headset is what produces the frames, so this has to match the app's
+    Resolution setting or ``connect()`` fails on the first frame's size."""
     head_camera_fps: int = 30
     head_camera_startup_timeout_s: float = 5.0
     head_camera_stale_after_s: float = 0.2

--- a/src/lerobot/scripts/client_commands.md
+++ b/src/lerobot/scripts/client_commands.md
@@ -96,10 +96,11 @@ The bimanual rig can add the Pico headset camera with:
     --robot.head_camera_eyes=both \
 ```
 
-`head_camera_width`/`height` are **per eye** and default to 1024x768. Only that and
-1280x960 are accepted — both 4:3, matching the sensor — and an unlisted size is an error
-rather than a silent resize, as is a first frame whose size disagrees with the config,
-since rescaling would quietly change the recorded field of view.
+`head_camera_width`/`height` are **per eye** and default to 640x480, the headset app's
+own default. Only that, 1024x768 and 1280x960 are accepted — all 4:3, matching the sensor
+— and an unlisted size is an error rather than a silent resize, as is a first frame whose
+size disagrees with the config, since rescaling would quietly change the recorded field of
+view. The app's Resolution setting is what produces the frames, so the two must agree.
 
 Capture stores `left_head` and `right_head` — one video key per eye, not a merged frame —
 plus the headset pose as `head_camera.x/y/z/r1..r6`. That pose goes through the same

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -23,6 +23,8 @@ import time
 import numpy as np
 import pytest
 
+from lerobot.cameras.pico import SUPPORTED_MODES
+from lerobot.robots.bi_taccap_gripper.config_bi_taccap_gripper import BiTaccapGripperConfig
 from lerobot.robots.taccap_gripper.common import (
     HARDWARE_MANIFEST_PATH,
     HEAD_CAMERA_KEYS,
@@ -44,6 +46,7 @@ from lerobot.robots.taccap_gripper.common import (
     validate_robot_id,
     write_hardware_manifest,
 )
+from lerobot.robots.taccap_gripper.config_taccap_gripper import TaccapGripperConfig
 from lerobot.robots.taccap_gripper.ee_transform import resolve_tracker_to_ee, tracker_to_tcp
 
 
@@ -425,6 +428,27 @@ class TestBuildHeadCameraConfigs:
         config.head_camera_height = 1080
         with pytest.raises(ValueError, match="supports"):
             build_head_camera_configs(config)
+
+    @pytest.mark.parametrize("size", [(640, 480), (1024, 768), (1280, 960)])
+    def test_every_mode_the_headset_app_offers_is_accepted(self, size):
+        """The app's Resolution setting has these three; a size it can emit
+        must not be rejected here, or that setting becomes unusable."""
+        config = HeadConfig("left")
+        config.head_camera_width, config.head_camera_height = size
+        assert (configs := build_head_camera_configs(config))["left_head"].width == size[0]
+        assert configs["left_head"].height == size[1]
+
+
+class TestHeadCameraDefaultResolution:
+    """The default has to be the headset app's own default, or enabling the
+    head camera fails on the first frame's size until someone finds the flags."""
+
+    @pytest.mark.parametrize("config_class", [TaccapGripperConfig, BiTaccapGripperConfig], ids=["single", "bimanual"])
+    def test_defaults_to_the_app_default_mode(self, config_class):
+        assert (config_class.head_camera_width, config_class.head_camera_height) == (640, 480)
+
+    def test_app_default_is_first_in_supported_modes(self):
+        assert SUPPORTED_MODES[0] == (640, 480)
 
 
 class TestHeadPoseKeys:


### PR DESCRIPTION
The XTac-UMI XR app's **Resolution** setting now has three sizes — `640` / `1024` / `1280` — and defaults to `640`, which is also the one to run day to day. The whitelist here had only the two larger modes, so the app's default was a size the collection side refused:

- `--robot.head_camera_width=640` failed the config check outright;
- leaving the flags alone failed later on the first frame instead, since the headset sends 640x480 while the config declared 1024x768.

Either way, enabling the head camera started by discovering the headset had to be turned up.

## What changes

- `SUPPORTED_MODES` gains `(640, 480)` as its **first** entry, which also makes it what `PicoCameraConfig` falls back to.
- `TaccapGripperConfig` / `BiTaccapGripperConfig` default `head_camera_width/_height` to `640` / `480`. Default now meets the app's default; the flags are needed only when someone raises the app's setting.
- The error message joined modes with `" or "`, which read as "A or B or C" once there were three — commas now.
- Docs updated in step: root `README.md`, `CLAUDE.md`, both robot READMEs, `scripts/client_commands.md`.

The whitelist is still a whitelist — an unlisted size is an error rather than a silent rescale — and 640x480 is 4:3 like the other two, so the field of view is unchanged, only the sampling. Recorded `left_head` / `right_head` frames are `(480, 640, 3)` by default instead of `(768, 1024, 3)`.

## Tests

New cases pin all three modes as accepted and both robot defaults as the app's default, so the two cannot drift apart unnoticed again. `pytest tests/robots/` → 187 passed; `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)