### PR TITLE
feat(taccap): record a mid-dataset hardware swap instead of losing it

### DIFF
--- a/src/lerobot/cameras/xense/camera_xense.py
+++ b/src/lerobot/cameras/xense/camera_xense.py
@@ -569,6 +569,33 @@ class XenseTactileCamera(Camera):
         # Do NOT call _format_read_result() again, as it would double-convert BGR<->RGB.
         return data
 
+    def export_runtime_config(self) -> bytes | None:
+        """This sensor's runtime config as bytes, or ``None`` if unavailable.
+
+        The runtime bundle is what lets the multimodal tactile channels (depth,
+        force, difference) be rebuilt offline from the recorded ``rectify``
+        stream. It carries this unit's own calibration *and* the reference image
+        captured when the sensor came up, so it has to be taken from the sensor
+        that is recording — another unit's bundle, or this one's from another
+        session, does not fail loudly. It reports plausible depth and force from
+        an untouched gel.
+
+        Returns ``None`` rather than raising when the sensor is not connected or
+        the SDK cannot produce one: a missing bundle costs the derived channels
+        for those episodes, which is not a reason to lose the recording itself.
+        """
+        sensor = getattr(self, "sensor", None)
+        if sensor is None:
+            return None
+        try:
+            return sensor.exportRuntimeConfig(binary=True)
+        except Exception as e:  # noqa: BLE001 - vendor SDK, and no failure here is fatal
+            logger.warn(
+                f"{self}: could not export the runtime config ({e}); "
+                "tactile derivation will need this sensor's bundle from elsewhere."
+            )
+            return None
+
     def disconnect(self):
         """
         Disconnects from the sensor and cleans up resources.

--- a/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
@@ -237,6 +237,30 @@ class BiTaccapGripper(Robot):
         return configs
 
     @property
+    def tactile_runtimes(self) -> dict[str, bytes]:
+        """Each connected tactile sensor's runtime bundle, keyed by serial.
+
+        Recorded into the dataset so the derived channels (depth, force,
+        difference) can be rebuilt from the ``rectify`` stream later without the
+        physical sensor — and without the risk that it has since been
+        recalibrated, which changes the reference image the reconstruction is
+        measured against.
+
+        Sensors that cannot produce one are simply absent: that costs the derived
+        channels for those episodes, which is not a reason to fail a recording.
+        """
+        runtimes: dict[str, bytes] = {}
+        for camera in self.cameras.values():
+            export = getattr(camera, "export_runtime_config", None)
+            serial = getattr(camera, "serial_number", None)
+            if export is None or not serial:
+                continue
+            blob = export()
+            if blob:
+                runtimes[serial] = blob
+        return runtimes
+
+    @property
     def hardware_manifest(self) -> dict[str, Any]:
         """Which physical devices this rig is, for the recording to carry along.
 

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -881,7 +881,17 @@ def manifest_epochs(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     epochs = manifest.get("epochs")
     if isinstance(epochs, list):
         return epochs
-    return [{"from_episode": 0, "to_episode": None, "units": manifest.get("units", [])}]
+    # Pre-epoch file: the station labels sit at the top level, so lift them in
+    # to give callers one shape to read regardless of when the file was written.
+    return [
+        {
+            "from_episode": 0,
+            "to_episode": None,
+            "robot_id": manifest.get("robot_id"),
+            "role": manifest.get("role"),
+            "units": manifest.get("units", []),
+        }
+    ]
 
 
 def epoch_for_episode(manifest: dict[str, Any], episode_index: int) -> dict[str, Any] | None:
@@ -899,13 +909,21 @@ def epoch_for_episode(manifest: dict[str, Any], episode_index: int) -> dict[str,
     return None
 
 
-def _manifest_identity(manifest: dict[str, Any]) -> dict[str, Any]:
-    """The parts that must not differ between runs of the same dataset.
+def _epoch_payload(manifest: dict[str, Any]) -> dict[str, Any]:
+    """What a run records about the rig: the devices, and where they were run.
 
-    Excludes ``epochs`` / ``units`` on purpose — those are exactly what a swap
-    changes, and recording that change is the case this module now supports.
+    ``units`` is the identity that matters downstream — which physical sensor fed
+    which observation key. ``robot_id`` / ``role`` ride along as context: the
+    label names a *station*, and the devices are the parts you swap in and out of
+    it (see ``validate_robot_id``). So the same gripper moved to another PC is a
+    change worth recording, but it is not a change of hardware, and a consumer
+    picking a per-sensor calibration keys on ``units`` alone.
     """
-    return {key: manifest.get(key) for key in ("robot_type", "robot_id", "role")}
+    return {
+        "robot_id": manifest.get("robot_id"),
+        "role": manifest.get("role"),
+        "units": manifest.get("units", []),
+    }
 
 
 def write_hardware_manifest(
@@ -918,20 +936,32 @@ def write_hardware_manifest(
     """Write ``manifest`` to ``root/meta/hardware.json`` and return the path.
 
     ``episode_index`` is how many episodes the dataset already holds, i.e. the
-    first index this run will write. It is what closes the previous epoch and
-    opens the next one, so a caller that resumes must pass it
+    first index this run will write. It is what closes the open epoch and opens
+    the next one, so a caller that resumes must pass it
     (``dataset.num_episodes``); the default only suits a fresh dataset.
 
     Three cases:
 
     * **New dataset** — one open epoch starting at ``episode_index``.
-    * **Resumed on the same hardware** — nothing to record; the open epoch already
+    * **Resumed on the same rig** — nothing to record; the open epoch already
       covers what is about to be written.
-    * **Resumed on different hardware** — close the open epoch at ``episode_index``
-      and append a new one. Both rigs stay named, and every episode keeps pointing
-      at the devices that actually produced it.
+    * **Resumed on a different rig** — close the open epoch at ``episode_index``
+      and append a new one. Both stay named, and every episode keeps pointing at
+      the devices that actually produced it.
 
-    That last case used to keep the original file and warn. The warning went to
+    "Different" means anything in ``units`` / ``robot_id`` / ``role`` changed.
+    Note that this includes running the *same* devices from another PC: the
+    station label changes while the hardware does not. That is recorded rather
+    than refused, because refusing would also drop a device swap that happened
+    to coincide with the move — and the devices are the part downstream cannot
+    guess. Consumers key on ``units``; an epoch boundary with identical ``units``
+    is simply the rig moving.
+
+    Only ``robot_type`` is treated as a hard mismatch: single vs bimanual changes
+    the observation keys, so it is not the same dataset at all, and epochs do not
+    model that.
+
+    The swap case used to keep the original file and warn. The warning went to
     the log and never reached the dataset, so afterwards nothing on disk said the
     rig had changed, while the manifest quietly misattributed every episode
     recorded after the swap. Downstream that is worse than a loud failure:
@@ -943,13 +973,13 @@ def write_hardware_manifest(
     destroy the only record of it.
     """
     path = Path(root) / HARDWARE_MANIFEST_PATH
-    units = manifest.get("units", [])
+    payload = _epoch_payload(manifest)
 
     if not path.exists():
         path.parent.mkdir(parents=True, exist_ok=True)
         fresh = {
-            **_manifest_identity(manifest),
-            "epochs": [{"from_episode": int(episode_index), "to_episode": None, "units": units}],
+            "robot_type": manifest.get("robot_type"),
+            "epochs": [{"from_episode": int(episode_index), "to_episode": None, **payload}],
         }
         path.write_text(json.dumps(fresh, indent=2) + "\n")
         logger.info(f"Hardware manifest written to {path}")
@@ -961,29 +991,28 @@ def write_hardware_manifest(
         logger.warn(f"Could not read the existing hardware manifest {path} ({e}); leaving it alone.")
         return path
 
-    if _manifest_identity(existing) != _manifest_identity(manifest):
-        # robot_type / robot_id / role identify the station, not the devices on
-        # it. A mismatch means this is not the same rig at all, which epochs do
-        # not model — appending would assert a continuity that is not there.
+    if existing.get("robot_type") != manifest.get("robot_type"):
         logger.warn(
-            f"Hardware manifest {path} describes a different robot "
-            f"({json.dumps(_manifest_identity(existing), sort_keys=True)}); keeping the original. "
-            f"Current: {json.dumps(_manifest_identity(manifest), sort_keys=True)}"
+            f"Hardware manifest {path} was recorded on {existing.get('robot_type')!r} but this run "
+            f"is {manifest.get('robot_type')!r}; keeping the original. A different robot type means "
+            f"different observation keys, which is not a hardware swap."
         )
         return path
 
     epochs = manifest_epochs(existing)
-    if epochs and epochs[-1].get("units") == units:
-        return path  # same hardware; the open epoch already covers this run
+    last = epochs[-1] if epochs else None
+    if last is not None and all(last.get(key) == value for key, value in payload.items()):
+        return path  # same rig; the open epoch already covers this run
 
-    # Different hardware. Close the epoch that was open and start a new one.
     updated = [dict(epoch) for epoch in epochs]
-    updated[-1]["to_episode"] = int(episode_index)
-    updated.append({"from_episode": int(episode_index), "to_episode": None, "units": units})
+    if updated:
+        updated[-1]["to_episode"] = int(episode_index)
+    updated.append({"from_episode": int(episode_index), "to_episode": None, **payload})
 
-    path.write_text(json.dumps({**_manifest_identity(existing), "epochs": updated}, indent=2) + "\n")
+    path.write_text(json.dumps({"robot_type": existing.get("robot_type"), "epochs": updated}, indent=2) + "\n")
+    hardware_changed = last is None or last.get("units") != payload["units"]
     logger.info(
-        f"Hardware changed at episode {episode_index}; recorded as a new epoch in {path}. "
-        f"This dataset now spans {len(updated)} hardware configurations."
+        f"{'Hardware' if hardware_changed else 'Station'} changed at episode {episode_index}; "
+        f"recorded as a new epoch in {path}. This dataset now spans {len(updated)} configurations."
     )
     return path

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -28,11 +28,11 @@ single gripper, ``"[left] "`` for one arm of the bimanual rig.
 from __future__ import annotations
 
 import glob
-import hashlib
 import json
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -923,17 +923,30 @@ makes that reconstruction possible from the dataset alone — no hunting down th
 physical unit months later, and no risk that the unit has since been recalibrated
 into a different reference.
 
-Files are named ``<serial>-<digest>.bin``. The digest is what makes it correct
-rather than merely tidy: a sensor removed for maintenance and reinstalled comes
-back with the same serial but a new reference image, so ``<serial>.bin`` alone
-would have one epoch silently overwrite the other's calibration. Identical
-bundles collapse onto one file, so re-recording on unchanged hardware costs
-nothing.
+Files are named ``<serial>-<UTC timestamp>.bin``, because a serial alone is not
+unique over time: a sensor pulled for maintenance and reinstalled keeps its
+serial and comes back with a new reference image, so ``<serial>.bin`` would have
+the later run overwrite the earlier one — silently re-deriving those episodes
+against a calibration they were never recorded with.
+
+The timestamp rather than a content hash: every export is a fresh AES-GCM
+encryption with a random salt and IV, so two exports of the *same* sensor state
+have different bytes. A digest would therefore never collapse duplicates while
+also saying nothing a reader can use. The time is what the file actually is —
+this unit's calibration as of that moment.
+
+One bundle per recording session is the right granularity, not an accident of
+naming: the reference image is captured fresh at every ``Sensor.create()``, so
+each session genuinely has its own. Measured on an untouched sensor, reusing the
+previous session's bundle moves ``Depth`` by 2.9e-4 and ``ForceResultant`` by
+7.3e-3 — the noise floor, and ~1000x smaller than the error from using another
+*unit's* bundle. Small, but there is no reason to accept it when the correct
+bundle costs 841 KB.
 """
 
 
-def _runtime_filename(serial: str, blob: bytes) -> str:
-    return f"{serial}-{hashlib.sha256(blob).hexdigest()[:12]}.bin"
+def _runtime_filename(serial: str, taken_at: datetime) -> str:
+    return f"{serial}-{taken_at.strftime('%Y%m%dT%H%M%SZ')}.bin"
 
 
 def write_tactile_runtimes(root: str | Path, runtimes: dict[str, bytes]) -> dict[str, str]:
@@ -943,13 +956,22 @@ def write_tactile_runtimes(root: str | Path, runtimes: dict[str, bytes]) -> dict
     different bundles from the same serial coexist. Paths are relative to the
     dataset root, which is what goes in the manifest.
     """
+    taken_at = datetime.now(timezone.utc)
     written: dict[str, str] = {}
     for serial, blob in sorted(runtimes.items()):
         if not blob:
             continue
-        relative = f"{RUNTIME_DIR}/{_runtime_filename(serial, blob)}"
+        relative = f"{RUNTIME_DIR}/{_runtime_filename(serial, taken_at)}"
         path = Path(root) / relative
         path.parent.mkdir(parents=True, exist_ok=True)
+        # Two exports in the same second would otherwise land on one name and the
+        # second would win, leaving an epoch pointing at a bundle that is not its
+        # own. Rare, but the failure is silent, so it gets a suffix instead.
+        suffix = 1
+        while path.exists() and path.read_bytes() != blob:
+            relative = f"{RUNTIME_DIR}/{_runtime_filename(serial, taken_at)[:-4]}-{suffix}.bin"
+            path = Path(root) / relative
+            suffix += 1
         if not path.exists():
             path.write_bytes(blob)
         written[serial] = relative
@@ -1048,13 +1070,26 @@ def _describe_change(previous: dict[str, Any] | None, current: dict[str, Any]) -
     def by_side(units: Any) -> dict[str, Any]:
         return {unit.get("side"): unit for unit in units or []}
 
+    def serials(unit: Any) -> tuple:
+        return (
+            unit.get("gripper_sn"),
+            tuple(s.get("serial") for s in unit.get("tactile_sensors") or []),
+        )
+
     before, after = by_side(previous.get("units")), by_side(current["units"])
-    sides = sorted(side for side in before.keys() | after.keys() if before.get(side) != after.get(side))
-    if sides:
-        return f"Hardware changed on the {' and '.join(sides)} unit(s)"
+    swapped = sorted(
+        side
+        for side in before.keys() | after.keys()
+        if serials(before.get(side) or {}) != serials(after.get(side) or {})
+    )
+    if swapped:
+        return f"Hardware changed on the {' and '.join(swapped)} unit(s)"
     if previous.get("robot_id") != current.get("robot_id"):
         return f"Station changed ({previous.get('robot_id')} -> {current.get('robot_id')})"
-    return "Rig changed"
+    # Same serials, same station: what differs is the runtime bundle, which the
+    # sensor re-captures at every ``Sensor.create()``. Calling that "hardware
+    # changed" would send someone hunting for a swap that never happened.
+    return "New capture session on the same hardware"
 
 
 def write_hardware_manifest(

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -32,7 +32,7 @@ import json
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -923,7 +923,7 @@ makes that reconstruction possible from the dataset alone — no hunting down th
 physical unit months later, and no risk that the unit has since been recalibrated
 into a different reference.
 
-Files are named ``<serial>-<UTC timestamp>.bin``, because a serial alone is not
+Files are named ``<serial>-<local timestamp>.bin``, because a serial alone is not
 unique over time: a sensor pulled for maintenance and reinstalled keeps its
 serial and comes back with a new reference image, so ``<serial>.bin`` would have
 the later run overwrite the earlier one — silently re-deriving those episodes
@@ -935,6 +935,12 @@ have different bytes. A digest would therefore never collapse duplicates while
 also saying nothing a reader can use. The time is what the file actually is —
 this unit's calibration as of that moment.
 
+The name carries wall-clock time in ``CAPTURE_TZ`` (UTC+08:00, where the rigs
+run) and no offset marker, so it reads as the hour someone was standing at the
+bench. That makes it a label, not a timestamp to compute with — the authoritative
+value is ``recorded_at`` on the epoch, which is full ISO-8601 with offset. Two
+readers, two jobs; the ambiguous-looking one is the one nothing parses.
+
 One bundle per recording session is the right granularity, not an accident of
 naming: the reference image is captured fresh at every ``Sensor.create()``, so
 each session genuinely has its own. Measured on an untouched sensor, reusing the
@@ -944,19 +950,27 @@ previous session's bundle moves ``Depth`` by 2.9e-4 and ``ForceResultant`` by
 bundle costs 841 KB.
 """
 
+#: Where the rigs are. Fixed offset rather than a named zone: China has observed
+#: no DST since 1991, so there is no ambiguous hour for a bare local time to land
+#: in, and a fixed offset needs no tz database to reproduce.
+CAPTURE_TZ = timezone(timedelta(hours=8), "UTC+08:00")
+
 
 def _runtime_filename(serial: str, taken_at: datetime) -> str:
-    return f"{serial}-{taken_at.strftime('%Y%m%dT%H%M%SZ')}.bin"
+    return f"{serial}-{taken_at.astimezone(CAPTURE_TZ).strftime('%Y%m%dT%H%M%S')}.bin"
 
 
-def write_tactile_runtimes(root: str | Path, runtimes: dict[str, bytes]) -> dict[str, str]:
+def write_tactile_runtimes(
+    root: str | Path, runtimes: dict[str, bytes], taken_at: datetime | None = None
+) -> dict[str, str]:
     """Write each sensor's runtime bundle and return ``{serial: relative path}``.
 
-    Content-addressed, so writing the same bundle twice is a no-op and two
-    different bundles from the same serial coexist. Paths are relative to the
-    dataset root, which is what goes in the manifest.
+    Every bundle from one call shares ``taken_at``, so a rig's sensors are named
+    for the session rather than for whichever microsecond each export finished
+    in. Paths are relative to the dataset root, which is what goes in the
+    manifest.
     """
-    taken_at = datetime.now(timezone.utc)
+    taken_at = taken_at or datetime.now(CAPTURE_TZ)
     written: dict[str, str] = {}
     for serial, blob in sorted(runtimes.items()):
         if not blob:
@@ -1147,6 +1161,10 @@ def write_hardware_manifest(
     destroy the only record of it.
     """
     path = Path(root) / HARDWARE_MANIFEST_PATH
+    # Deliberately not part of ``payload``: the comparison below asks "is this the
+    # same rig", and a clock reading is different every run. It rides on the epoch
+    # once one is actually opened.
+    recorded_at = datetime.now(CAPTURE_TZ)
     payload = _epoch_payload(manifest)
     if runtimes:
         # Written before the comparison below, so a re-calibrated sensor — same
@@ -1154,13 +1172,20 @@ def write_hardware_manifest(
         # change and opens its own epoch. That is the point: the old episodes
         # must keep pointing at the bundle that was current when they were
         # recorded.
-        payload["units"] = _stamp_runtimes(payload["units"], write_tactile_runtimes(root, runtimes))
+        payload["units"] = _stamp_runtimes(payload["units"], write_tactile_runtimes(root, runtimes, recorded_at))
 
     if not path.exists():
         path.parent.mkdir(parents=True, exist_ok=True)
         fresh = {
             "robot_type": manifest.get("robot_type"),
-            "epochs": [{"from_episode": int(episode_index), "to_episode": None, **payload}],
+            "epochs": [
+                {
+                    "from_episode": int(episode_index),
+                    "to_episode": None,
+                    "recorded_at": recorded_at.isoformat(timespec="seconds"),
+                    **payload,
+                }
+            ],
         }
         path.write_text(json.dumps(fresh, indent=2) + "\n")
         logger.info(f"Hardware manifest written to {path}")
@@ -1188,7 +1213,14 @@ def write_hardware_manifest(
     updated = [dict(epoch) for epoch in epochs]
     if updated:
         updated[-1]["to_episode"] = int(episode_index)
-    updated.append({"from_episode": int(episode_index), "to_episode": None, **payload})
+    updated.append(
+        {
+            "from_episode": int(episode_index),
+            "to_episode": None,
+            "recorded_at": recorded_at.isoformat(timespec="seconds"),
+            **payload,
+        }
+    )
 
     path.write_text(json.dumps({"robot_type": existing.get("robot_type"), "epochs": updated}, indent=2) + "\n")
     logger.info(

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -28,6 +28,7 @@ single gripper, ``"[left] "`` for one arm of the bimanual rig.
 from __future__ import annotations
 
 import glob
+import hashlib
 import json
 import os
 import time
@@ -55,6 +56,7 @@ __all__ = [
     "HEAD_POSE_KEYS",
     "HEAD_CAMERA_KEYS",
     "HARDWARE_MANIFEST_PATH",
+    "RUNTIME_DIR",
     "GripperReadGuard",
     "HeadSkewMonitor",
     "build_hardware_manifest",
@@ -74,11 +76,13 @@ __all__ = [
     "resolve_wrist_camera_path",
     "split_camera_read",
     "swap_tactile_display_features",
+    "tactile_runtime_for_key",
     "tactile_serial_for_key",
     "tactile_camera_output_types",
     "tactile_display_key",
     "validate_robot_id",
     "write_hardware_manifest",
+    "write_tactile_runtimes",
 ]
 
 
@@ -910,6 +914,65 @@ def epoch_for_episode(manifest: dict[str, Any], episode_index: int) -> dict[str,
     return None
 
 
+RUNTIME_DIR = "meta/runtimes"
+"""Where a dataset keeps the tactile runtime bundles its episodes need.
+
+Rebuilding depth / force / difference from the recorded ``rectify`` stream needs
+the recording sensor's own runtime config. Keeping it *in* the dataset is what
+makes that reconstruction possible from the dataset alone — no hunting down the
+physical unit months later, and no risk that the unit has since been recalibrated
+into a different reference.
+
+Files are named ``<serial>-<digest>.bin``. The digest is what makes it correct
+rather than merely tidy: a sensor removed for maintenance and reinstalled comes
+back with the same serial but a new reference image, so ``<serial>.bin`` alone
+would have one epoch silently overwrite the other's calibration. Identical
+bundles collapse onto one file, so re-recording on unchanged hardware costs
+nothing.
+"""
+
+
+def _runtime_filename(serial: str, blob: bytes) -> str:
+    return f"{serial}-{hashlib.sha256(blob).hexdigest()[:12]}.bin"
+
+
+def write_tactile_runtimes(root: str | Path, runtimes: dict[str, bytes]) -> dict[str, str]:
+    """Write each sensor's runtime bundle and return ``{serial: relative path}``.
+
+    Content-addressed, so writing the same bundle twice is a no-op and two
+    different bundles from the same serial coexist. Paths are relative to the
+    dataset root, which is what goes in the manifest.
+    """
+    written: dict[str, str] = {}
+    for serial, blob in sorted(runtimes.items()):
+        if not blob:
+            continue
+        relative = f"{RUNTIME_DIR}/{_runtime_filename(serial, blob)}"
+        path = Path(root) / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not path.exists():
+            path.write_bytes(blob)
+        written[serial] = relative
+    return written
+
+
+def _stamp_runtimes(units: list[dict[str, Any]], paths: dict[str, str]) -> list[dict[str, Any]]:
+    """Copy ``units`` with each tactile sensor pointing at its runtime bundle.
+
+    A sensor with no bundle is left without the key rather than given a null:
+    absent means "not recorded", and a null would read like "recorded as
+    nothing". Consumers check for the key.
+    """
+    stamped = []
+    for unit in units:
+        sensors = []
+        for sensor in unit.get("tactile_sensors") or []:
+            relative = paths.get(sensor.get("serial"))
+            sensors.append({**sensor, "runtime": relative} if relative else dict(sensor))
+        stamped.append({**unit, "tactile_sensors": sensors})
+    return stamped
+
+
 def _epoch_payload(manifest: dict[str, Any]) -> dict[str, Any]:
     """What a run records about the rig: the devices, and where they were run.
 
@@ -951,6 +1014,27 @@ def tactile_serial_for_key(manifest: dict[str, Any], episode_index: int, observa
     return None
 
 
+def tactile_runtime_for_key(manifest: dict[str, Any], episode_index: int, observation_key: str) -> str | None:
+    """Path (dataset-relative) of the runtime bundle needed to rebuild this
+    stream's derived channels, or ``None`` if the dataset does not carry one.
+
+    ``None`` covers both "no epoch claims that episode" and "recorded before
+    bundles were stored". Either way the honest move is to skip derivation for
+    those episodes rather than reach for another bundle: a bundle from a
+    different unit — or from the same unit after a recalibration — turns an
+    untouched gel into plausible depth and force, with nothing in the output
+    saying so.
+    """
+    epoch = epoch_for_episode(manifest, episode_index)
+    if epoch is None:
+        return None
+    for unit in epoch.get("units") or []:
+        for sensor in unit.get("tactile_sensors") or []:
+            if sensor.get("observation_key") == observation_key:
+                return sensor.get("runtime")
+    return None
+
+
 def _describe_change(previous: dict[str, Any] | None, current: dict[str, Any]) -> str:
     """Name what actually changed, so the log points at the thing to check.
 
@@ -979,6 +1063,7 @@ def write_hardware_manifest(
     logger: Any,
     *,
     episode_index: int = 0,
+    runtimes: dict[str, bytes] | None = None,
 ) -> Path:
     """Write ``manifest`` to ``root/meta/hardware.json`` and return the path.
 
@@ -1015,12 +1100,26 @@ def write_hardware_manifest(
     solving a tactile stream against another sensor's calibration yields
     plausible depth and force from an untouched gel — no error, no signal.
 
+    ``runtimes`` maps a tactile serial to its runtime bundle
+    (``XenseCamera.export_runtime_config()``). Given one, each bundle is written
+    under ``meta/runtimes/`` and the epoch's sensors point at it, so the derived
+    tactile channels can be rebuilt from the dataset alone. A sensor that comes
+    back from maintenance with a new reference image produces a different bundle
+    under the same serial, which counts as a change and opens its own epoch.
+
     A truncated or unreadable file is still left alone: whatever episodes are
     already there have provenance we cannot reconstruct, and clobbering it would
     destroy the only record of it.
     """
     path = Path(root) / HARDWARE_MANIFEST_PATH
     payload = _epoch_payload(manifest)
+    if runtimes:
+        # Written before the comparison below, so a re-calibrated sensor — same
+        # serial, new reference image, hence a new bundle path — is seen as a
+        # change and opens its own epoch. That is the point: the old episodes
+        # must keep pointing at the bundle that was current when they were
+        # recorded.
+        payload["units"] = _stamp_runtimes(payload["units"], write_tactile_runtimes(root, runtimes))
 
     if not path.exists():
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -926,6 +926,28 @@ def _epoch_payload(manifest: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _describe_change(previous: dict[str, Any] | None, current: dict[str, Any]) -> str:
+    """Name what actually changed, so the log points at the thing to check.
+
+    The two grippers are swapped independently — a customer may replace only the
+    left one — so "hardware changed" alone would leave someone diffing the whole
+    manifest to find out which arm to look at.
+    """
+    if previous is None:
+        return "Hardware recorded"
+
+    def by_side(units: Any) -> dict[str, Any]:
+        return {unit.get("side"): unit for unit in units or []}
+
+    before, after = by_side(previous.get("units")), by_side(current["units"])
+    sides = sorted(side for side in before.keys() | after.keys() if before.get(side) != after.get(side))
+    if sides:
+        return f"Hardware changed on the {' and '.join(sides)} unit(s)"
+    if previous.get("robot_id") != current.get("robot_id"):
+        return f"Station changed ({previous.get('robot_id')} -> {current.get('robot_id')})"
+    return "Rig changed"
+
+
 def write_hardware_manifest(
     root: str | Path,
     manifest: dict[str, Any],
@@ -1010,9 +1032,8 @@ def write_hardware_manifest(
     updated.append({"from_episode": int(episode_index), "to_episode": None, **payload})
 
     path.write_text(json.dumps({"robot_type": existing.get("robot_type"), "epochs": updated}, indent=2) + "\n")
-    hardware_changed = last is None or last.get("units") != payload["units"]
     logger.info(
-        f"{'Hardware' if hardware_changed else 'Station'} changed at episode {episode_index}; "
-        f"recorded as a new epoch in {path}. This dataset now spans {len(updated)} configurations."
+        f"{_describe_change(last, payload)} at episode {episode_index}; recorded as a new epoch "
+        f"in {path}. This dataset now spans {len(updated)} configurations."
     )
     return path

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -63,7 +63,9 @@ __all__ = [
     "build_wrist_camera_config",
     "connect_cameras_parallel",
     "disconnect_cameras_parallel",
+    "epoch_for_episode",
     "hardware_manifest_unit",
+    "manifest_epochs",
     "open_gripper",
     "prewarm_tactile_config_cache",
     "read_gripper_normalized",
@@ -785,6 +787,14 @@ file's schema belongs to upstream lerobot, and a fork-local key in it would
 collide on the next v5.x sync. ``robot.id`` does not reach the dataset at all
 (``LeRobotDataset.create`` takes only ``robot_type``), so this manifest is the
 only thing tying recorded episodes to the physical devices that produced them.
+
+The same reasoning is why a swap mid-dataset is recorded here as another
+``epochs`` entry rather than as a per-episode column in
+``meta/episodes/*.parquet``: adding a column part-way through makes the dataset
+unreadable. ``datasets.Dataset.from_parquet`` casts every later file to the
+*first* file's schema, so a dataset whose early files predate the column raises
+``CastError`` on load — not a missing column, the whole dataset. (The bare
+``pyarrow.dataset`` path is worse: it drops the column silently.)
 """
 
 
@@ -836,6 +846,10 @@ def build_hardware_manifest(
     ``robot_id`` is the station label (``--robot.id``, e.g. ``taccap_0``) and is
     free to be ``None``; the serials below are the actual identity, and they are
     what a dataset should be trusted to be traced by.
+
+    ``units`` describes what is connected *now*. Which episodes it produced is
+    decided at write time (``write_hardware_manifest``), because only the dataset
+    knows how many episodes precede this run.
     """
     return {
         "robot_type": robot_type,
@@ -845,31 +859,131 @@ def build_hardware_manifest(
     }
 
 
-def write_hardware_manifest(root: str | Path, manifest: dict[str, Any], logger: Any) -> Path:
+def manifest_epochs(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """The manifest's hardware epochs, oldest first, for old and new files alike.
+
+    A manifest written before epochs existed has a bare ``units`` and no episode
+    bounds. It is reported as a single open-ended epoch (``from_episode`` 0,
+    ``to_episode`` ``None``) rather than being rejected: those datasets are real
+    and mostly single-rig.
+
+    ``to_episode`` is exclusive, matching ``dataset_from_index`` /
+    ``dataset_to_index``. It is ``None`` on the epoch still being recorded — the
+    count is only known once the run ends, and guessing would be worse than
+    saying "still open".
+
+    .. warning::
+       An open-ended single epoch means *"nothing here says the rig changed"*,
+       **not** *"the rig did not change"*. Pre-epoch manifests could not express
+       a swap, so a consumer that must not mix rigs (per-sensor tactile solving,
+       for one) has to verify it some other way.
+    """
+    epochs = manifest.get("epochs")
+    if isinstance(epochs, list):
+        return epochs
+    return [{"from_episode": 0, "to_episode": None, "units": manifest.get("units", [])}]
+
+
+def epoch_for_episode(manifest: dict[str, Any], episode_index: int) -> dict[str, Any] | None:
+    """The epoch that recorded ``episode_index``, or ``None`` if none claims it.
+
+    ``None`` is a real answer, not an error: an episode past the last closed
+    epoch belongs to hardware nobody recorded. Callers that would otherwise
+    attribute it to the wrong rig need to see that.
+    """
+    for epoch in manifest_epochs(manifest):
+        start = epoch.get("from_episode") or 0
+        end = epoch.get("to_episode")
+        if episode_index >= start and (end is None or episode_index < end):
+            return epoch
+    return None
+
+
+def _manifest_identity(manifest: dict[str, Any]) -> dict[str, Any]:
+    """The parts that must not differ between runs of the same dataset.
+
+    Excludes ``epochs`` / ``units`` on purpose — those are exactly what a swap
+    changes, and recording that change is the case this module now supports.
+    """
+    return {key: manifest.get(key) for key in ("robot_type", "robot_id", "role")}
+
+
+def write_hardware_manifest(
+    root: str | Path,
+    manifest: dict[str, Any],
+    logger: Any,
+    *,
+    episode_index: int = 0,
+) -> Path:
     """Write ``manifest`` to ``root/meta/hardware.json`` and return the path.
 
-    Written once, when the file is absent. Resuming a dataset with *different*
-    hardware keeps the original file and warns instead of overwriting: the
-    episodes already in the dataset came from the devices named there, and
-    silently replacing them would misattribute every one of them. The warning is
-    the signal that the dataset now spans two rigs.
+    ``episode_index`` is how many episodes the dataset already holds, i.e. the
+    first index this run will write. It is what closes the previous epoch and
+    opens the next one, so a caller that resumes must pass it
+    (``dataset.num_episodes``); the default only suits a fresh dataset.
+
+    Three cases:
+
+    * **New dataset** — one open epoch starting at ``episode_index``.
+    * **Resumed on the same hardware** — nothing to record; the open epoch already
+      covers what is about to be written.
+    * **Resumed on different hardware** — close the open epoch at ``episode_index``
+      and append a new one. Both rigs stay named, and every episode keeps pointing
+      at the devices that actually produced it.
+
+    That last case used to keep the original file and warn. The warning went to
+    the log and never reached the dataset, so afterwards nothing on disk said the
+    rig had changed, while the manifest quietly misattributed every episode
+    recorded after the swap. Downstream that is worse than a loud failure:
+    solving a tactile stream against another sensor's calibration yields
+    plausible depth and force from an untouched gel — no error, no signal.
+
+    A truncated or unreadable file is still left alone: whatever episodes are
+    already there have provenance we cannot reconstruct, and clobbering it would
+    destroy the only record of it.
     """
     path = Path(root) / HARDWARE_MANIFEST_PATH
-    if path.exists():
-        try:
-            existing = json.loads(path.read_text())
-        except (OSError, ValueError) as e:
-            logger.warn(f"Could not read the existing hardware manifest {path} ({e}); leaving it alone.")
-            return path
-        if existing != manifest:
-            logger.warn(
-                f"Hardware manifest {path} does not match the devices connected now — this dataset "
-                f"already holds episodes recorded on other hardware. Keeping the original; "
-                f"current: {json.dumps(manifest, sort_keys=True)}"
-            )
+    units = manifest.get("units", [])
+
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fresh = {
+            **_manifest_identity(manifest),
+            "epochs": [{"from_episode": int(episode_index), "to_episode": None, "units": units}],
+        }
+        path.write_text(json.dumps(fresh, indent=2) + "\n")
+        logger.info(f"Hardware manifest written to {path}")
         return path
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(manifest, indent=2) + "\n")
-    logger.info(f"Hardware manifest written to {path}")
+    try:
+        existing = json.loads(path.read_text())
+    except (OSError, ValueError) as e:
+        logger.warn(f"Could not read the existing hardware manifest {path} ({e}); leaving it alone.")
+        return path
+
+    if _manifest_identity(existing) != _manifest_identity(manifest):
+        # robot_type / robot_id / role identify the station, not the devices on
+        # it. A mismatch means this is not the same rig at all, which epochs do
+        # not model — appending would assert a continuity that is not there.
+        logger.warn(
+            f"Hardware manifest {path} describes a different robot "
+            f"({json.dumps(_manifest_identity(existing), sort_keys=True)}); keeping the original. "
+            f"Current: {json.dumps(_manifest_identity(manifest), sort_keys=True)}"
+        )
+        return path
+
+    epochs = manifest_epochs(existing)
+    if epochs and epochs[-1].get("units") == units:
+        return path  # same hardware; the open epoch already covers this run
+
+    # Different hardware. Close the epoch that was open and start a new one.
+    updated = [dict(epoch) for epoch in epochs]
+    updated[-1]["to_episode"] = int(episode_index)
+    updated.append({"from_episode": int(episode_index), "to_episode": None, "units": units})
+
+    path.write_text(json.dumps({**_manifest_identity(existing), "epochs": updated}, indent=2) + "\n")
+    logger.info(
+        f"Hardware changed at episode {episode_index}; recorded as a new epoch in {path}. "
+        f"This dataset now spans {len(updated)} hardware configurations."
+    )
     return path

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -74,6 +74,7 @@ __all__ = [
     "resolve_wrist_camera_path",
     "split_camera_read",
     "swap_tactile_display_features",
+    "tactile_serial_for_key",
     "tactile_camera_output_types",
     "tactile_display_key",
     "validate_robot_id",
@@ -924,6 +925,30 @@ def _epoch_payload(manifest: dict[str, Any]) -> dict[str, Any]:
         "role": manifest.get("role"),
         "units": manifest.get("units", []),
     }
+
+
+def tactile_serial_for_key(manifest: dict[str, Any], episode_index: int, observation_key: str) -> str | None:
+    """Which physical sensor fed ``observation_key`` in ``episode_index``.
+
+    The one lookup every consumer of this file actually wants, so it lives here
+    rather than being re-derived — getting it wrong is not visible in the output.
+    Deriving the multimodal tactile channels (depth, force, difference) needs the
+    sensor's own runtime config, and solving a stream against another unit's
+    calibration does not fail loudly: it reports plausible depth and force from
+    an untouched gel.
+
+    ``None`` means the manifest cannot answer — no epoch covers that episode, or
+    no sensor in it feeds that key. Callers must treat that as "do not derive",
+    never as "use whichever sensor is nearest".
+    """
+    epoch = epoch_for_episode(manifest, episode_index)
+    if epoch is None:
+        return None
+    for unit in epoch.get("units") or []:
+        for sensor in unit.get("tactile_sensors") or []:
+            if sensor.get("observation_key") == observation_key:
+                return sensor.get("serial")
+    return None
 
 
 def _describe_change(previous: dict[str, Any] | None, current: dict[str, Any]) -> str:

--- a/src/lerobot/robots/taccap_gripper/taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/taccap_gripper.py
@@ -246,6 +246,30 @@ class TaccapGripper(Robot):
         return configs
 
     @property
+    def tactile_runtimes(self) -> dict[str, bytes]:
+        """Each connected tactile sensor's runtime bundle, keyed by serial.
+
+        Recorded into the dataset so the derived channels (depth, force,
+        difference) can be rebuilt from the ``rectify`` stream later without the
+        physical sensor — and without the risk that it has since been
+        recalibrated, which changes the reference image the reconstruction is
+        measured against.
+
+        Sensors that cannot produce one are simply absent: that costs the derived
+        channels for those episodes, which is not a reason to fail a recording.
+        """
+        runtimes: dict[str, bytes] = {}
+        for camera in self.cameras.values():
+            export = getattr(camera, "export_runtime_config", None)
+            serial = getattr(camera, "serial_number", None)
+            if export is None or not serial:
+                continue
+            blob = export()
+            if blob:
+                runtimes[serial] = blob
+        return runtimes
+
+    @property
     def hardware_manifest(self) -> dict[str, Any]:
         """Which physical device this unit is, for the recording to carry along.
 

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -484,8 +484,16 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
         # (asked of the class, not the instance: ``getattr(robot, ...)`` with a
         # default would also swallow an AttributeError raised *inside* the
         # property, turning a bug into a silently missing manifest.)
+        # ``num_episodes`` is where this run starts writing, and it is what
+        # bounds the hardware epochs: on a resume after a device swap it closes
+        # the epoch the earlier episodes belong to and opens the one for these.
         if hasattr(type(robot), "hardware_manifest"):
-            write_hardware_manifest(dataset.root, robot.hardware_manifest, logger)
+            write_hardware_manifest(
+                dataset.root,
+                robot.hardware_manifest,
+                logger,
+                episode_index=dataset.num_episodes,
+            )
 
         # 3D pose + trajectory overlay (no-op if the device emits no tcp.* poses).
         # The viewer is laid out from display_features when the robot has one —

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -493,6 +493,9 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                 robot.hardware_manifest,
                 logger,
                 episode_index=dataset.num_episodes,
+                # Each tactile sensor's runtime bundle goes in with it, so the
+                # derived channels can be rebuilt from this dataset alone later.
+                runtimes=getattr(robot, "tactile_runtimes", None) or None,
             )
 
         # 3D pose + trajectory overlay (no-op if the device emits no tcp.* poses).

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -817,6 +817,37 @@ class TestWriteHardwareManifest:
         assert epochs[0]["units"] == epochs[1]["units"]
         assert logger.warnings == []
 
+    def test_swapping_one_arm_carries_the_other_over_untouched(self, tmp_path):
+        """The two grippers are swapped independently — a customer may replace
+        only the left one. The new epoch has to describe the *whole* rig, or the
+        arm that did not change would have no serial for those episodes."""
+        bimanual = build_hardware_manifest(
+            robot_type="bi_taccap_gripper",
+            robot_id="bi_taccap_0",
+            role="leader",
+            units=[
+                hardware_manifest_unit(
+                    side,
+                    endpoints=FakeEndpoints(f"TCGU01A24Z000{n}m"),
+                    tactile_serials={"left": f"GSPS01A25Z00{n}1", "right": f"GSPS01A25Z00{n}2"},
+                    key_prefix=f"{side}_",
+                )
+                for n, side in enumerate(("left", "right"), start=1)
+            ],
+        )
+        write_hardware_manifest(tmp_path, bimanual, FakeLogger())
+
+        swapped_left = json.loads(json.dumps(bimanual))
+        swapped_left["units"][0]["gripper_sn"] = "TCGU01A24Z0009m"
+        logger = FakeLogger()
+        write_hardware_manifest(tmp_path, swapped_left, logger, episode_index=40)
+
+        epochs = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())["epochs"]
+        assert len(epochs) == 2
+        assert epochs[1]["units"][0]["gripper_sn"] == "TCGU01A24Z0009m"  # the swap
+        assert epochs[1]["units"][1] == bimanual["units"][1]  # right arm carried over whole
+        assert logger.warnings == []
+
     def test_a_different_robot_type_is_kept_apart_not_appended(self, tmp_path):
         """Single vs bimanual changes the observation keys, so it is not the same
         dataset at all — epochs do not model that."""

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -20,6 +20,7 @@ import functools
 import json
 import re
 import time
+from datetime import datetime, timedelta
 
 import numpy as np
 import pytest
@@ -27,6 +28,7 @@ import pytest
 from lerobot.cameras.pico import SUPPORTED_MODES
 from lerobot.robots.bi_taccap_gripper.config_bi_taccap_gripper import BiTaccapGripperConfig
 from lerobot.robots.taccap_gripper.common import (
+    CAPTURE_TZ,
     HARDWARE_MANIFEST_PATH,
     HEAD_CAMERA_KEYS,
     HEAD_POSE_KEYS,
@@ -751,15 +753,17 @@ class TestWriteHardwareManifest:
         path = write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
         on_disk = json.loads(path.read_text())
         assert on_disk["robot_type"] == "taccap_gripper"
-        assert on_disk["epochs"] == [
-            {
-                "from_episode": 0,
-                "to_episode": None,
-                "robot_id": "taccap_0",
-                "role": "leader",
-                "units": self.MANIFEST["units"],
-            }
-        ]
+        (written,) = on_disk["epochs"]
+        # Its shape is checked where it is the subject; dropped here so this
+        # stays a test about the epoch boundary rather than about the clock.
+        assert written.pop("recorded_at")
+        assert written == {
+            "from_episode": 0,
+            "to_episode": None,
+            "robot_id": "taccap_0",
+            "role": "leader",
+            "units": self.MANIFEST["units"],
+        }
 
     def test_rewriting_the_same_hardware_is_a_silent_no_op(self, tmp_path):
         write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
@@ -1022,12 +1026,32 @@ class TestTactileRuntimes:
         assert (tmp_path / tactile_runtime_for_key(manifest, 0, "tactile_left")).read_bytes() == b"first"
         assert (tmp_path / tactile_runtime_for_key(manifest, 1, "tactile_left")).read_bytes() == b"second"
 
-    def test_the_filename_carries_the_serial_and_a_sortable_time(self, tmp_path):
+    def test_the_filename_reads_as_bench_local_time(self, tmp_path):
         """A content hash would never collapse duplicates (random salt) while
-        telling a reader nothing. The time is what the file actually is."""
+        telling a reader nothing. The time is what the file actually is — and in
+        the timezone of the bench it was taken at, so it reads without arithmetic.
+        """
         write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), runtimes={"GSPS01A25Z0011": b"b"})
         (name,) = [p.name for p in (tmp_path / RUNTIME_DIR).iterdir()]
-        assert re.fullmatch(r"GSPS01A25Z0011-\d{8}T\d{6}Z\.bin", name), name
+        assert re.fullmatch(r"GSPS01A25Z0011-\d{8}T\d{6}\.bin", name), name
+        stamped = datetime.strptime(name.split("-")[1][: -len(".bin")], "%Y%m%dT%H%M%S")
+        assert abs(stamped - datetime.now(CAPTURE_TZ).replace(tzinfo=None)) < timedelta(minutes=1)
+
+    def test_the_epoch_carries_the_unambiguous_time(self, tmp_path):
+        """The filename is a label a human reads; anything that computes with the
+        time uses this, which carries its offset."""
+        write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), runtimes={"GSPS01A25Z0011": b"b"})
+        (epoch,) = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())["epochs"]
+        recorded = datetime.fromisoformat(epoch["recorded_at"])
+        assert recorded.utcoffset() == timedelta(hours=8)
+        assert abs(recorded - datetime.now(CAPTURE_TZ)) < timedelta(minutes=1)
+
+    def test_the_clock_alone_does_not_open_an_epoch(self, tmp_path):
+        """``recorded_at`` differs on every run by construction. If it were part
+        of the rig comparison, every resume would look like a hardware change."""
+        for episode in (0, 20):
+            write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), episode_index=episode)
+        assert len(json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())["epochs"]) == 1
 
     def test_a_sensor_without_a_bundle_is_absent_not_null(self, tmp_path):
         """Absent means "not recorded"; a null would read like "recorded as

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -747,7 +747,15 @@ class TestWriteHardwareManifest:
         path = write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
         on_disk = json.loads(path.read_text())
         assert on_disk["robot_type"] == "taccap_gripper"
-        assert on_disk["epochs"] == [{"from_episode": 0, "to_episode": None, "units": self.MANIFEST["units"]}]
+        assert on_disk["epochs"] == [
+            {
+                "from_episode": 0,
+                "to_episode": None,
+                "robot_id": "taccap_0",
+                "role": "leader",
+                "units": self.MANIFEST["units"],
+            }
+        ]
 
     def test_rewriting_the_same_hardware_is_a_silent_no_op(self, tmp_path):
         write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
@@ -788,22 +796,42 @@ class TestWriteHardwareManifest:
         epochs = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())["epochs"]
         assert [(e["from_episode"], e["to_episode"]) for e in epochs] == [(0, 57), (57, 90), (90, None)]
 
-    def test_a_different_robot_is_kept_apart_not_appended(self, tmp_path):
-        """``robot_type`` / ``robot_id`` / ``role`` identify the station, not the
-        devices on it. A mismatch is not a swap — appending would assert a
-        continuity that is not there."""
+    def test_the_same_devices_on_another_station_are_recorded_not_refused(self, tmp_path):
+        """``robot_id`` labels the station; the devices are the parts you swap in
+        and out of it. Moving a rig to another PC must not block the record —
+        refusing would also drop a device swap that coincided with the move, and
+        the devices are the part downstream cannot guess."""
         write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
-        other_station = json.loads(json.dumps(self.MANIFEST))
-        other_station["robot_id"] = "taccap_9"
+        moved = json.loads(json.dumps(self.MANIFEST))
+        moved["robot_id"] = "taccap_9"
 
         logger = FakeLogger()
-        write_hardware_manifest(tmp_path, other_station, logger, episode_index=57)
+        write_hardware_manifest(tmp_path, moved, logger, episode_index=57)
+
+        epochs = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())["epochs"]
+        assert [(e["from_episode"], e["robot_id"]) for e in epochs] == [
+            (0, "taccap_0"),
+            (57, "taccap_9"),
+        ]
+        # Same hardware either side, so nothing downstream has to change sensor.
+        assert epochs[0]["units"] == epochs[1]["units"]
+        assert logger.warnings == []
+
+    def test_a_different_robot_type_is_kept_apart_not_appended(self, tmp_path):
+        """Single vs bimanual changes the observation keys, so it is not the same
+        dataset at all — epochs do not model that."""
+        write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        other_type = json.loads(json.dumps(self.MANIFEST))
+        other_type["robot_type"] = "bi_taccap_gripper"
+
+        logger = FakeLogger()
+        write_hardware_manifest(tmp_path, other_type, logger, episode_index=57)
 
         on_disk = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
-        assert on_disk["robot_id"] == "taccap_0"
+        assert on_disk["robot_type"] == "taccap_gripper"
         assert len(on_disk["epochs"]) == 1
         assert len(logger.warnings) == 1
-        assert "taccap_9" in logger.warnings[0]  # names what is connected now
+        assert "bi_taccap_gripper" in logger.warnings[0]
 
     def test_an_unreadable_manifest_is_left_alone(self, tmp_path):
         """A truncated file is someone else's problem to fix; clobbering it would
@@ -829,8 +857,21 @@ class TestManifestEpochs:
     def test_a_pre_epoch_manifest_reads_as_one_open_epoch(self):
         """Those datasets are real and mostly single-rig; rejecting them would
         strand every recording made before epochs existed."""
-        legacy = {"robot_type": "taccap_gripper", "units": self.UNITS_A}
-        assert manifest_epochs(legacy) == [{"from_episode": 0, "to_episode": None, "units": self.UNITS_A}]
+        legacy = {
+            "robot_type": "taccap_gripper",
+            "robot_id": "taccap_0",
+            "role": "leader",
+            "units": self.UNITS_A,
+        }
+        assert manifest_epochs(legacy) == [
+            {
+                "from_episode": 0,
+                "to_episode": None,
+                "robot_id": "taccap_0",  # lifted from the top level
+                "role": "leader",
+                "units": self.UNITS_A,
+            }
+        ]
 
     def test_an_open_epoch_claims_every_later_episode(self):
         legacy = {"units": self.UNITS_A}

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -45,6 +45,7 @@ from lerobot.robots.taccap_gripper.common import (
     swap_tactile_display_features,
     tactile_camera_output_types,
     tactile_display_key,
+    tactile_serial_for_key,
     validate_robot_id,
     write_hardware_manifest,
 )
@@ -926,6 +927,55 @@ class TestManifestEpochs:
         — which is the failure this whole mechanism exists to prevent."""
         closed = {"epochs": [{"from_episode": 0, "to_episode": 57, "units": self.UNITS_A}]}
         assert epoch_for_episode(closed, 57) is None
+
+
+class TestTactileSerialForKey:
+    """The lookup post-processing actually performs: which sensor fed this video
+    stream in this episode. Getting it wrong is invisible in the output, so the
+    unanswerable cases matter as much as the answerable ones."""
+
+    MANIFEST = {
+        "epochs": [
+            {
+                "from_episode": 0,
+                "to_episode": 40,
+                "units": [
+                    {
+                        "side": "left",
+                        "tactile_sensors": [{"observation_key": "left_tactile_left", "serial": "GSPS01A30Z0015"}],
+                    }
+                ],
+            },
+            {
+                "from_episode": 40,
+                "to_episode": None,
+                "units": [
+                    {
+                        "side": "left",
+                        "tactile_sensors": [{"observation_key": "left_tactile_left", "serial": "GSPS01A30Z0088"}],
+                    }
+                ],
+            },
+        ]
+    }
+
+    def test_the_same_key_resolves_to_different_sensors_across_a_swap(self):
+        assert tactile_serial_for_key(self.MANIFEST, 39, "left_tactile_left") == "GSPS01A30Z0015"
+        assert tactile_serial_for_key(self.MANIFEST, 40, "left_tactile_left") == "GSPS01A30Z0088"
+
+    def test_an_unknown_key_is_none_not_the_first_sensor(self):
+        """Falling back to "some sensor on that rig" is exactly the misattribution
+        this file exists to prevent."""
+        assert tactile_serial_for_key(self.MANIFEST, 0, "right_tactile_left") is None
+
+    def test_an_episode_outside_every_epoch_is_none(self):
+        closed = {"epochs": [{"from_episode": 0, "to_episode": 10, "units": self.MANIFEST["epochs"][0]["units"]}]}
+        assert tactile_serial_for_key(closed, 10, "left_tactile_left") is None
+
+    def test_a_pre_epoch_manifest_still_answers(self):
+        """Those datasets are the majority today; the lookup has to work on them."""
+        legacy = {"robot_type": "taccap_gripper", "units": self.MANIFEST["epochs"][0]["units"]}
+        assert tactile_serial_for_key(legacy, 9999, "left_tactile_left") == "GSPS01A30Z0015"
 
 
 class TestSwapTactileDisplayFeatures:

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -36,7 +36,9 @@ from lerobot.robots.taccap_gripper.common import (
     build_head_camera_configs,
     build_tactile_camera_configs,
     connect_cameras_parallel,
+    epoch_for_episode,
     hardware_manifest_unit,
+    manifest_epochs,
     open_gripper,
     read_head_camera_skew,
     split_camera_read,
@@ -726,34 +728,82 @@ class TestWriteHardwareManifest:
         ],
     )
 
+    def _swapped(self, gripper_sn="TCGU01A24Z0003m"):
+        other = json.loads(json.dumps(self.MANIFEST))
+        other["units"][0]["gripper_sn"] = gripper_sn
+        return other
+
     def test_written_under_meta_not_into_info_json(self, tmp_path):
         """``meta/info.json`` is upstream's schema; a fork-local key there would
         collide on the next v5.x sync."""
         path = write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
         assert path == tmp_path / HARDWARE_MANIFEST_PATH
-        assert json.loads(path.read_text()) == self.MANIFEST
         assert not (tmp_path / "meta" / "info.json").exists()
+
+    def test_a_new_dataset_gets_one_open_epoch(self, tmp_path):
+        """``to_episode`` stays null until something closes it: the episode count
+        is only known once the run ends, and guessing would be worse than saying
+        "still open"."""
+        path = write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        on_disk = json.loads(path.read_text())
+        assert on_disk["robot_type"] == "taccap_gripper"
+        assert on_disk["epochs"] == [{"from_episode": 0, "to_episode": None, "units": self.MANIFEST["units"]}]
 
     def test_rewriting_the_same_hardware_is_a_silent_no_op(self, tmp_path):
         write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        before = (tmp_path / HARDWARE_MANIFEST_PATH).read_text()
+
         logger = FakeLogger()
-        write_hardware_manifest(tmp_path, self.MANIFEST, logger)
+        write_hardware_manifest(tmp_path, self.MANIFEST, logger, episode_index=12)
+
+        assert logger.warnings == []
+        assert (tmp_path / HARDWARE_MANIFEST_PATH).read_text() == before
+
+    def test_resuming_on_other_hardware_appends_an_epoch(self, tmp_path):
+        """Both rigs stay named and every episode keeps pointing at the devices
+        that produced it. Keeping only the first manifest (what this used to do)
+        left the file quietly wrong for everything recorded after the swap."""
+        write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+
+        write_hardware_manifest(tmp_path, self._swapped(), FakeLogger(), episode_index=57)
+
+        epochs = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())["epochs"]
+        assert [(e["from_episode"], e["to_episode"]) for e in epochs] == [(0, 57), (57, None)]
+        assert epochs[0]["units"][0]["gripper_sn"] == "TCGU01A24Z0001m"
+        assert epochs[1]["units"][0]["gripper_sn"] == "TCGU01A24Z0003m"
+
+    def test_a_swap_is_reported_but_is_not_a_warning(self, tmp_path):
+        """It is now recorded rather than lost, so it is news, not a problem."""
+        write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        logger = FakeLogger()
+        write_hardware_manifest(tmp_path, self._swapped(), logger, episode_index=57)
         assert logger.warnings == []
 
-    def test_resuming_on_other_hardware_warns_and_keeps_the_original(self, tmp_path):
-        """The episodes already in the dataset came from the devices named in
-        the file; overwriting would misattribute every one of them."""
+    def test_three_rigs_chain_without_gaps_or_overlap(self, tmp_path):
+        """Bounds are half-open, so each episode belongs to exactly one epoch."""
         write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
-        swapped = json.loads(json.dumps(self.MANIFEST))
-        swapped["units"][0]["gripper_sn"] = "TCGU01A24Z0003m"
+        write_hardware_manifest(tmp_path, self._swapped("TCGU01A24Z0003m"), FakeLogger(), episode_index=57)
+        write_hardware_manifest(tmp_path, self._swapped("TCGU01A24Z0004m"), FakeLogger(), episode_index=90)
+
+        epochs = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())["epochs"]
+        assert [(e["from_episode"], e["to_episode"]) for e in epochs] == [(0, 57), (57, 90), (90, None)]
+
+    def test_a_different_robot_is_kept_apart_not_appended(self, tmp_path):
+        """``robot_type`` / ``robot_id`` / ``role`` identify the station, not the
+        devices on it. A mismatch is not a swap — appending would assert a
+        continuity that is not there."""
+        write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        other_station = json.loads(json.dumps(self.MANIFEST))
+        other_station["robot_id"] = "taccap_9"
 
         logger = FakeLogger()
-        write_hardware_manifest(tmp_path, swapped, logger)
+        write_hardware_manifest(tmp_path, other_station, logger, episode_index=57)
 
         on_disk = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
-        assert on_disk == self.MANIFEST
+        assert on_disk["robot_id"] == "taccap_0"
+        assert len(on_disk["epochs"]) == 1
         assert len(logger.warnings) == 1
-        assert "TCGU01A24Z0003m" in logger.warnings[0]  # names what is connected now
+        assert "taccap_9" in logger.warnings[0]  # names what is connected now
 
     def test_an_unreadable_manifest_is_left_alone(self, tmp_path):
         """A truncated file is someone else's problem to fix; clobbering it would
@@ -767,6 +817,43 @@ class TestWriteHardwareManifest:
 
         assert path.read_text() == "{ truncated"
         assert len(logger.warnings) == 1
+
+
+class TestManifestEpochs:
+    """Reading side. Old files have no epochs at all, so this is where a wrong
+    assumption turns into an episode attributed to the wrong sensor."""
+
+    UNITS_A = [{"side": "left", "gripper_sn": "A", "tactile_sensors": []}]
+    UNITS_B = [{"side": "left", "gripper_sn": "B", "tactile_sensors": []}]
+
+    def test_a_pre_epoch_manifest_reads_as_one_open_epoch(self):
+        """Those datasets are real and mostly single-rig; rejecting them would
+        strand every recording made before epochs existed."""
+        legacy = {"robot_type": "taccap_gripper", "units": self.UNITS_A}
+        assert manifest_epochs(legacy) == [{"from_episode": 0, "to_episode": None, "units": self.UNITS_A}]
+
+    def test_an_open_epoch_claims_every_later_episode(self):
+        legacy = {"units": self.UNITS_A}
+        assert epoch_for_episode(legacy, 0)["units"] == self.UNITS_A
+        assert epoch_for_episode(legacy, 10_000)["units"] == self.UNITS_A
+
+    def test_each_episode_resolves_to_the_rig_that_recorded_it(self):
+        manifest = {
+            "epochs": [
+                {"from_episode": 0, "to_episode": 57, "units": self.UNITS_A},
+                {"from_episode": 57, "to_episode": None, "units": self.UNITS_B},
+            ]
+        }
+        assert epoch_for_episode(manifest, 56)["units"] == self.UNITS_A
+        assert epoch_for_episode(manifest, 57)["units"] == self.UNITS_B  # half-open
+        assert epoch_for_episode(manifest, 1_000)["units"] == self.UNITS_B
+
+    def test_an_episode_no_epoch_claims_is_none_not_the_nearest_rig(self):
+        """Past the last closed epoch nobody recorded that hardware. Falling back
+        to the nearest rig would attribute it to devices that did not produce it
+        — which is the failure this whole mechanism exists to prevent."""
+        closed = {"epochs": [{"from_episode": 0, "to_episode": 57, "units": self.UNITS_A}]}
+        assert epoch_for_episode(closed, 57) is None
 
 
 class TestSwapTactileDisplayFeatures:

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -18,6 +18,7 @@ pinning. Nothing below touches hardware or either vendor SDK.
 
 import functools
 import json
+import re
 import time
 
 import numpy as np
@@ -978,19 +979,55 @@ class TestTactileRuntimes:
         assert (tmp_path / early).read_bytes() == b"bundle-v1"
         assert (tmp_path / late).read_bytes() == b"bundle-v2-after-maintenance"
 
-    def test_an_unchanged_rig_does_not_accumulate_epochs_or_files(self, tmp_path):
-        """Identical bundles are the same content, so re-recording costs nothing."""
-        for episode in (0, 20, 40):
+    def test_resuming_on_the_same_rig_is_not_reported_as_a_hardware_change(self, tmp_path):
+        """Every session exports different bytes even when nothing was touched:
+        the reference image is re-captured at ``Sensor.create()`` and the bundle
+        is freshly AES-GCM encrypted with a random salt and IV. So each resume
+        legitimately gets its own epoch and its own file — but calling that a
+        hardware change would send someone hunting for a swap that never
+        happened.
+
+        Measured on an untouched unit, the two sessions' bundles move ``Depth``
+        by 2.9e-4 and ``ForceResultant`` by 7.3e-3 — the noise floor, and ~1000x
+        smaller than using another *unit's* bundle. Keeping both is still right:
+        the correct one costs 841 KB.
+        """
+        logger = FakeLogger()
+        for episode, blob in ((0, b"session-1"), (20, b"session-2"), (40, b"session-3")):
             write_hardware_manifest(
                 tmp_path,
                 self._manifest(),
-                FakeLogger(),
+                logger,
                 episode_index=episode,
-                runtimes={"GSPS01A25Z0011": b"bundle-v1"},
+                runtimes={"GSPS01A25Z0011": blob},
             )
         manifest = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
-        assert len(manifest["epochs"]) == 1
-        assert len(list((tmp_path / RUNTIME_DIR).iterdir())) == 1
+        assert len(manifest["epochs"]) == 3
+        assert len(list((tmp_path / RUNTIME_DIR).iterdir())) == 3
+        bundles = [tactile_runtime_for_key(manifest, ep, "tactile_left") for ep in (0, 20, 40)]
+        assert len(set(bundles)) == 3
+        assert [(tmp_path / b).read_bytes() for b in bundles] == [b"session-1", b"session-2", b"session-3"]
+        assert not any("Hardware changed" in message for message in logger.infos)
+        assert all("same hardware" in message for message in logger.infos[1:])
+
+    def test_two_bundles_exported_in_the_same_second_do_not_collide(self, tmp_path):
+        """The name carries a whole-second timestamp, so a fast re-export would
+        otherwise land on one file and the second would win — leaving an epoch
+        pointing at a bundle that is not its own."""
+        for episode, blob in ((0, b"first"), (1, b"second")):
+            write_hardware_manifest(
+                tmp_path, self._manifest(), FakeLogger(), episode_index=episode, runtimes={"GSPS01A25Z0011": blob}
+            )
+        manifest = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
+        assert (tmp_path / tactile_runtime_for_key(manifest, 0, "tactile_left")).read_bytes() == b"first"
+        assert (tmp_path / tactile_runtime_for_key(manifest, 1, "tactile_left")).read_bytes() == b"second"
+
+    def test_the_filename_carries_the_serial_and_a_sortable_time(self, tmp_path):
+        """A content hash would never collapse duplicates (random salt) while
+        telling a reader nothing. The time is what the file actually is."""
+        write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), runtimes={"GSPS01A25Z0011": b"b"})
+        (name,) = [p.name for p in (tmp_path / RUNTIME_DIR).iterdir()]
+        assert re.fullmatch(r"GSPS01A25Z0011-\d{8}T\d{6}Z\.bin", name), name
 
     def test_a_sensor_without_a_bundle_is_absent_not_null(self, tmp_path):
         """Absent means "not recorded"; a null would read like "recorded as

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -1032,7 +1032,7 @@ class TestTactileRuntimes:
         the timezone of the bench it was taken at, so it reads without arithmetic.
         """
         write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), runtimes={"GSPS01A25Z0011": b"b"})
-        (name,) = [p.name for p in (tmp_path / RUNTIME_DIR).iterdir()]
+        (name,) = (p.name for p in (tmp_path / RUNTIME_DIR).iterdir())
         assert re.fullmatch(r"GSPS01A25Z0011-\d{8}T\d{6}\.bin", name), name
         stamped = datetime.strptime(name.split("-")[1][: -len(".bin")], "%Y%m%dT%H%M%S")
         assert abs(stamped - datetime.now(CAPTURE_TZ).replace(tzinfo=None)) < timedelta(minutes=1)

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -30,6 +30,7 @@ from lerobot.robots.taccap_gripper.common import (
     HEAD_CAMERA_KEYS,
     HEAD_POSE_KEYS,
     POSE_KEYS,
+    RUNTIME_DIR,
     GripperReadGuard,
     HeadSkewMonitor,
     build_hardware_manifest,
@@ -45,6 +46,7 @@ from lerobot.robots.taccap_gripper.common import (
     swap_tactile_display_features,
     tactile_camera_output_types,
     tactile_display_key,
+    tactile_runtime_for_key,
     tactile_serial_for_key,
     validate_robot_id,
     write_hardware_manifest,
@@ -927,6 +929,81 @@ class TestManifestEpochs:
         — which is the failure this whole mechanism exists to prevent."""
         closed = {"epochs": [{"from_episode": 0, "to_episode": 57, "units": self.UNITS_A}]}
         assert epoch_for_episode(closed, 57) is None
+
+
+class TestTactileRuntimes:
+    """The bundles are what actually rebuild depth / force / difference, so the
+    cases that would hand an episode the wrong one are the ones worth pinning."""
+
+    def _manifest(self, serial="GSPS01A25Z0011"):
+        return build_hardware_manifest(
+            robot_type="taccap_gripper",
+            robot_id="taccap_0",
+            role="leader",
+            units=[
+                hardware_manifest_unit(
+                    "left",
+                    endpoints=FakeEndpoints("TCGU01A24Z0001m"),
+                    tactile_serials={"left": serial},
+                    key_prefix="",
+                )
+            ],
+        )
+
+    def test_the_bundle_lands_in_the_dataset_and_the_epoch_points_at_it(self, tmp_path):
+        write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), runtimes={"GSPS01A25Z0011": b"bundle-v1"})
+        relative = tactile_runtime_for_key(
+            json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text()), 0, "tactile_left"
+        )
+        assert relative.startswith(RUNTIME_DIR)
+        assert (tmp_path / relative).read_bytes() == b"bundle-v1"
+
+    def test_recalibration_keeps_both_bundles_and_splits_the_epoch(self, tmp_path):
+        """Same serial, new reference image. Naming the file by serial alone would
+        have the second run overwrite the first, silently re-deriving the earlier
+        episodes against a calibration they were not recorded with."""
+        write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), runtimes={"GSPS01A25Z0011": b"bundle-v1"})
+        write_hardware_manifest(
+            tmp_path,
+            self._manifest(),
+            FakeLogger(),
+            episode_index=40,
+            runtimes={"GSPS01A25Z0011": b"bundle-v2-after-maintenance"},
+        )
+
+        manifest = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
+        early = tactile_runtime_for_key(manifest, 39, "tactile_left")
+        late = tactile_runtime_for_key(manifest, 40, "tactile_left")
+        assert early != late
+        assert (tmp_path / early).read_bytes() == b"bundle-v1"
+        assert (tmp_path / late).read_bytes() == b"bundle-v2-after-maintenance"
+
+    def test_an_unchanged_rig_does_not_accumulate_epochs_or_files(self, tmp_path):
+        """Identical bundles are the same content, so re-recording costs nothing."""
+        for episode in (0, 20, 40):
+            write_hardware_manifest(
+                tmp_path,
+                self._manifest(),
+                FakeLogger(),
+                episode_index=episode,
+                runtimes={"GSPS01A25Z0011": b"bundle-v1"},
+            )
+        manifest = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
+        assert len(manifest["epochs"]) == 1
+        assert len(list((tmp_path / RUNTIME_DIR).iterdir())) == 1
+
+    def test_a_sensor_without_a_bundle_is_absent_not_null(self, tmp_path):
+        """Absent means "not recorded"; a null would read like "recorded as
+        nothing". Consumers check for the key."""
+        write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), runtimes={})
+        manifest = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
+        sensor = manifest["epochs"][0]["units"][0]["tactile_sensors"][0]
+        assert "runtime" not in sensor
+        assert tactile_runtime_for_key(manifest, 0, "tactile_left") is None
+
+    def test_a_pre_bundle_dataset_reports_none_rather_than_guessing(self):
+        legacy = {"robot_type": "taccap_gripper", "units": self._manifest()["units"]}
+        assert tactile_runtime_for_key(legacy, 0, "tactile_left") is None
 
 
 class TestTactileSerialForKey:


### PR DESCRIPTION
`meta/hardware.json` is dataset-level, but swapping a broken device and `--resume`-ing is unavoidable. On that path the manifest was kept as-is and a warning went to the log — and the log is not the dataset. Afterwards nothing on disk said the rig had changed, while the manifest quietly misattributed every episode recorded after the swap.

## Why this is worse than a loud failure

Solving a tactile stream against another sensor's calibration **does not error**. Measured on two real GSPS01 units, **both untouched**, using the wrong sensor's runtime:

| | own runtime | other unit's | ratio |
|---|---|---|---|
| `Depth` max | 0.000321 | **0.2595** | **808×** |
| `ForceResultant` max | 0.010332 | **10.3454** | **1001×** |

A resting gel reports plausible depth and force, with no signal that anything is wrong. The cause is `img_ref_raw` in the runtime bundle: subtracting sensor A's reference from sensor B's frame leaves the fixed differences between the two units (marker layout, lighting, mirror geometry), which the pipeline reads as deformation.

So "dataset spans two rigs, manifest names only the first" is exactly the case that turns this into silent bad data. The same applies to grippers and wrist cameras; tactile is just where it is least visible.

## What changed

```json
{"epochs": [{"from_episode": 0,  "to_episode": 57,   "units": [...]},
            {"from_episode": 57, "to_episode": null, "units": [...]}]}
```

`units` keeps its exact shape. Bounds are half-open, matching `dataset_from_index` / `dataset_to_index`.

- **Writing** — `write_hardware_manifest` now takes the episode index this run starts at (`dataset.num_episodes`, passed from `lerobot_record`). Same hardware stays a silent no-op; different hardware closes the open epoch at that index and appends a new one.
- **Reading** — `manifest_epochs()` / `epoch_for_episode()`. A pre-epoch file reads as one open-ended epoch, so **every dataset recorded so far keeps working**.
- A mismatch in `robot_type` / `robot_id` / `role` is still kept apart and warned about — that is a different station, not a swap, and epochs do not model it.

`epoch_for_episode` returns `None` past the last closed epoch rather than falling back to the nearest rig: that fallback is precisely the misattribution this exists to prevent.

## Why not a per-episode column in `meta/episodes/*.parquet`

That would be the cleaner data model, and it was the first thing I tried. **Adding a column part-way through makes the dataset unreadable.** Measured:

```
old schema first (= the real order when resuming adds a column)
  → DatasetGenerationError: CastError: Couldn't cast ... because column names don't match
  → the whole dataset fails to load, not just a missing column

new schema first        → loads, old rows get None
pyarrow.dataset path    → silently drops the column
```

`datasets.Dataset.from_parquet` casts every later file to the *first* file's schema. Three layers compound: `_flush_metadata_buffer` accumulates by key (mismatched keys give unequal column lengths), `ParquetWriter` is created with the first table's schema, and then the read-side cast above.

The same reasoning already put this file outside `meta/info.json`, so it applies here too — a fork-local parquet column would also be a v5.x sync hazard.

## Verification

- **195 passed** in `tests/robots/`; `ruff check` and `ruff format` clean
- End-to-end scenario: new → same-hardware resume → swap at ep 57 → **swap back** at ep 90. The last one correctly opens a *third* epoch rather than merging back into the first
- Backward compatibility checked against a real pre-epoch `hardware.json` from a recorded dataset (`taccap-g1-arrange-tabletop-items-0813`)

The swap test previously asserted keep-and-warn, which is the behaviour being replaced; it now asserts both rigs survive with correct bounds. Added reader tests for the legacy shape, half-open boundaries, a three-rig chain, and the unclaimed-episode case.

## One thing left out

The `logger.warn` on a genuinely different robot is still the only signal for that case. I did not touch it — it is a different situation (wrong station, not a swap) and I would rather not widen the change.
