### PR TITLE
chore(taccap): bump SDK submodule to v0.1.9 (3dac16a)

### DIFF
--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -349,7 +349,7 @@ python third_party/taccap-gripper/python/examples/fisheye_cal.py show --sn TCGU0
 ```
 
 ```
-Firmware 1.2.1  (fisheye needs cmd set >= V2.0, encoder-max >= V2.1: leader >= 1.2.0 / follower >= 1.1.0)
+Firmware 1.2.2  (fisheye needs cmd set >= V2.0, encoder-max >= V2.1: leader >= 1.2.0 / follower >= 1.1.0)
 
 Fisheye camera calibration (Cmd 0x2B)
   not calibrated — firmware returned CalNotSet
@@ -382,7 +382,7 @@ constructor would throw instead.
 
 `Cmd::GetVersion` returns the constant compiled into the running image, not OTA
 bank metadata, so it is proof of what actually landed. Two things it is not:
-`xense.taccap.__version__` is the **SDK** version (`0.1.7`), unrelated to
+`xense.taccap.__version__` is the **SDK** version (`0.1.9`), unrelated to
 firmware; and `ack.data[3]`, the fourth "build" byte, is pinned to 0 and
 meaningless — versions are `MAJOR.MINOR.PATCH` everywhere, so do not write the
 trailing zero into a version comparison.
@@ -448,7 +448,7 @@ python -c "from xense.taccap import scan_grippers
 for g in scan_grippers(): print(g.firmware_sn, '->', 'leader' if g.firmware_sn.endswith('m') else 'follower')"
 
 python third_party/taccap-gripper/python/examples/ota_update.py \
-    tc-gu-01-master.bin --side left --target-version 1.2.1
+    tc-gu-01-master.bin --side left --target-version 1.2.2
 ```
 
 Naming the image is enough — `ota_update.py` finds it in the SDK's own


### PR DESCRIPTION
子模块 `third_party/taccap-gripper` 从 `83314c8` 前进 40 个提交,到 SDK 的 **`v0.1.9`** tag(`3dac16a`)。

## 带过来的东西

- **状态流丢帧的定位与规避**(v0.1.9 的发布主题):传输层写互斥、订阅回调移出 reader 线程、pybind 回调的 GIL-safe holder。
- **固件镜像 leader 1.2.2 / follower 1.1.5**,修掉三条主从共用代码里的缺陷:命令通道活锁、日志阻塞实时任务、上电越界写。两版都过了实机验证 —— 但都是**本地工具链**编译的(非固件团队发布链路),且**刷完必须断电重启**。
- 协议镜像到固件命令集 V2.2;`EncoderConfig` 收缩到固件真实的 5 字节布局;新增 CI 比对协议与固件头文件。
- 相机侧新增 `FisheyeUndistorter` 与 `resolve_fisheye()` 的回退策略。

## 兼容性核查

本仓库对 SDK 的调用面只有:`LeaderGripper(mcu_device, normalize_position=True)`、`FollowerGripper(mcu_device)`、`scan_grippers()` 及其 endpoint 字段、`imu.read_once()`、`is_streaming` / `stop_streaming()`。

- 区间里唯一的破坏性变更是 `fix(follower)!: start_streaming takes only motor_hz` —— **本仓库一处都没调用 `start_streaming`**。
- `xense/taccap/__init__.py` 在这 40 个提交里是**纯新增、零删除**。
- `LeaderGripper` 新增的 `undistort_wrist` / `fisheye_balance` 默认关,腕相机本来也走 LeRobot 相机框架(SDK 只当 MCU 传输),不受影响。

已在本地重编译并验证:`taccap-gripper` dist/module 均为 0.1.9,`lerobot.robots.{taccap_gripper,bi_taccap_gripper}` 的 `TACCAP_SDK_AVAILABLE` 都是 `True`。**未做真机验证** —— 丢帧修复、fisheye 重采样和 1.2.2 镜像都需要上硬件才算数。

## ⚠️ 拉到这个提交之后必须重新编译

SDK 是 editable 安装,换 checkout 之后 Python 层立刻走新代码而 `_taccap_native.so` 还是旧的,`import xense.taccap` 会因缺 `FisheyeUndistorter` 直接失败:

```bash
uv pip install -e third_party/taccap-gripper --no-deps --no-build-isolation
```

## README

三处随基线走的版本号跟着改(示例输出的固件号、`__version__` 的说明、OTA 命令的 `--target-version`)。「Since 0.1.7 ships the released images」这类历史陈述保持原样。

## 配套文档 PR

XenseRobotics/XTac-UMI-G1-Docs#7 —— **本 PR 先合**,那边的「已验证基线」要填这次的 SHA。

🤖 Generated with [Claude Code](https://claude.com/claude-code)