### PR TITLE
docs(claude): 硬件清单那段跟上 epochs 与 runtime bundle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ manifest quietly misattributed every episode recorded after the swap. Only a
 `robot_type` mismatch is still keep-and-warn — single vs bimanual changes the
 observation keys, so it is not the same dataset and epochs do not model it.
 A pre-epoch file reads back as one open epoch (`manifest_epochs`), but an open
-single epoch means *"nothing here says the rig changed"*, **not** *"it didn't"*.
+single epoch means _"nothing here says the rig changed"_, **not** _"it didn't"_.
 
 Each tactile sensor's **runtime bundle** goes in beside it, at
 `meta/runtimes/<serial>-<local time>.bin` (`RUNTIME_DIR`), with the epoch's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,30 @@ after `connect()` from `robot.hardware_manifest`: per unit, the gripper's
 tagged with `side` (which gripper), `finger` (which sensor on it) and the
 `observation_key` it feeds. Keep it a separate file — `meta/info.json` is
 upstream's schema and a fork-local key there collides on the next v5.x sync.
-Helpers live in `taccap_gripper/common.py`; a resume against different hardware
-warns and keeps the original file rather than misattributing recorded episodes.
+Helpers live in `taccap_gripper/common.py`.
+
+The file is a list of **`epochs`**, not one flat `units`: each carries
+`from_episode` / `to_episode` (half-open, matching `dataset_from_index` /
+`dataset_to_index`) and `recorded_at`, so a rig swapped **mid-dataset** closes
+the open epoch at the current episode count and opens the next one. It used to
+warn and keep the original file; that warning went to the log and never reached
+the dataset, so afterwards nothing on disk said the rig had changed while the
+manifest quietly misattributed every episode recorded after the swap. Only a
+`robot_type` mismatch is still keep-and-warn — single vs bimanual changes the
+observation keys, so it is not the same dataset and epochs do not model it.
+A pre-epoch file reads back as one open epoch (`manifest_epochs`), but an open
+single epoch means *"nothing here says the rig changed"*, **not** *"it didn't"*.
+
+Each tactile sensor's **runtime bundle** goes in beside it, at
+`meta/runtimes/<serial>-<local time>.bin` (`RUNTIME_DIR`), with the epoch's
+sensors pointing at their own. Deriving depth / force / difference from the
+recorded `rectify` stream needs the bundle that was current **when the episodes
+were recorded** — it carries the reference image captured at `Sensor.create()`,
+and a sensor that comes back from maintenance keeps its serial but produces a
+different bundle, which is why the name is timestamped and why a new bundle
+opens its own epoch. Solving against the wrong one does not fail: an untouched
+gel returns plausible depth and force. So `tactile_runtime_for_key` returning
+`None` means **skip derivation**, never "use whichever bundle is nearest".
 
 ### On mis-burned / mis-installed hardware
 


### PR DESCRIPTION
`CLAUDE.md` 里这句是 `052eb354` 之前的行为:

> Helpers live in `taccap_gripper/common.py`; a resume against different hardware warns and keeps the original file rather than misattributing recorded episodes.

而且它把结论说反了。那条告警只进日志、从不进数据集——换硬件之后盘上没有任何东西记下这件事,清单却把换后录的每一集都记在旧设备名下。**旧行为不是「避免记错」,它就是记错。**现在的行为是封口开着的 epoch、另起一段。

顺带补上这块笔记里**整个缺失**的两件事(`052eb354` / `dbbdd08e` 当时没更新工作笔记):

- 清单是 **`epochs` 列表**,每段带 `from_episode` / `to_episode`(左闭右开,与 `dataset_from_index` / `dataset_to_index` 一致)和 `recorded_at`;`robot_type` 不匹配仍是保留原文件并告警(单/双夹爪观测键不同,不是换硬件)。老文件读回来是一个开口的 epoch,但开口**不等于**没换过。
- **`meta/runtimes/<serial>-<本地时间>.bin`**(`RUNTIME_DIR`),每枚传感器一份,epoch 里各自指向。写清了为什么必须是「录制当时那一份」(参考图在 `Sensor.create()` 时重拍;维护后装回的传感器 SN 不变但 bundle 变,所以文件名带时间戳、也因此另起一个 epoch),以及 `tactile_runtime_for_key` 返回 `None` 时正确的反应是**跳过重建**——拿错 bundle 不报错,没碰过的胶体照样解出看着合理的 depth 和 force。

只改 `CLAUDE.md`,无代码变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)