### PR TITLE
feat(taccap): 腕相机鱼眼矫正,默认关,可用参数开启

### DIFF
--- a/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
@@ -70,9 +70,11 @@ from ..taccap_gripper.common import (
     open_gripper,
     prewarm_tactile_config_cache,
     read_head_pose,
+    resolve_wrist_undistorter,
     split_camera_read,
     swap_tactile_display_features,
     tactile_camera_output_types,
+    wrist_undistort_record,
 )
 from ..taccap_gripper.ee_transform import resolve_tracker_to_ee
 from .config_bi_taccap_gripper import BiTaccapGripperConfig
@@ -82,6 +84,8 @@ _SIDES = ("left", "right")
 # ---- TacCap-Gripper SDK -----------------------------------------------------
 try:
     from xense.taccap import (
+        FISHEYE_FALLBACK_CAL,
+        FisheyeUndistorter,
         FollowerGripper,
         LeaderGripper,
     )
@@ -139,6 +143,11 @@ class BiTaccapGripper(Robot):
         # Per-side hardware handles, populated on connect.
         self._gripper: dict[str, Any] = dict.fromkeys(_SIDES)  # Leader/FollowerGripper
         self._endpoints: dict[str, Any] = dict.fromkeys(_SIDES)  # GripperEndpoints
+        # {observation key: FisheyeUndistorter}, empty unless wrist_undistort is
+        # on. The flag is shared by both arms but the intrinsics are per unit, so
+        # one arm can rectify from its own flash while the other falls back.
+        self._wrist_undistorters: dict[str, Any] = {}
+        self._wrist_undistort_source: dict[str, str | None] = dict.fromkeys(_SIDES)
         self._tracker: dict[str, Pico4TrackerReader | None] = dict.fromkeys(_SIDES)
         # Auto-discover tactile + wrist cameras and build their configs so the
         # observation schema is ready before connect(). Tactiles are paired to a
@@ -281,6 +290,11 @@ class BiTaccapGripper(Robot):
                     endpoints=self._endpoints[side],
                     tactile_serials=self._disc_tactiles.get(side, {}),
                     key_prefix=f"{side}_",
+                    wrist_undistort=wrist_undistort_record(
+                        has_wrist_camera=f"{side}_wrist" in self._camera_configs,
+                        source=self._wrist_undistort_source[side],
+                        balance=self.config.wrist_undistort_balance,
+                    ),
                 )
                 for side in _SIDES
             ],
@@ -448,6 +462,22 @@ class BiTaccapGripper(Robot):
                 )
                 self.logger.info(f"  [{side}] ✅ {gripper_cls.__name__} attached (MCU-only, read-only)")
 
+            if self.config.wrist_undistort and f"{side}_wrist" in self._camera_configs:
+                # Per arm: each gripper is asked for its own intrinsics, so one
+                # side falling back to the SDK reference does not drag the other
+                # onto it. Built before the cameras open so an uncalibrated unit
+                # warns during connect, not mid-recording.
+                undistorter, source = resolve_wrist_undistorter(
+                    self._gripper[side],
+                    undistorter_cls=FisheyeUndistorter,
+                    fallback_cal=FISHEYE_FALLBACK_CAL,
+                    balance=self.config.wrist_undistort_balance,
+                    logger=self.logger,
+                    label=f"[{side}] ",
+                )
+                self._wrist_undistorters[f"{side}_wrist"] = undistorter
+                self._wrist_undistort_source[side] = source
+
             # 2. Pico4 tracker (auto-discovered SN per side, pinned here).
             if side in self._tracker_sn_by_side:
                 # None means "use this side's built-in mount transform"; the
@@ -518,7 +548,9 @@ class BiTaccapGripper(Robot):
                 # Gripper has no explicit close; transport released on GC.
                 self._gripper[side] = None
             self._endpoints[side] = None
+            self._wrist_undistort_source[side] = None
 
+        self._wrist_undistorters = {}
         self._is_connected = False
 
     def calibrate(self) -> None:
@@ -568,10 +600,17 @@ class BiTaccapGripper(Robot):
         # cameras, and the pose comes from the SDK above, not from a frame.
         # Insight bundled the two, which is why this used to be read apart.
         for cam_name, cam in self.cameras.items():
+            frame = self._cam_guard.read(cam_name, cam)
+            # After the guard, not before — see the single-arm robot for why
+            # (the guard spots a frozen stream by frame identity, and apply()
+            # returns a fresh array every call).
+            undistorter = self._wrist_undistorters.get(cam_name)
+            if undistorter is not None:
+                frame = undistorter.apply(frame)
             obs.update(
                 split_camera_read(
                     cam_name,
-                    self._cam_guard.read(cam_name, cam),
+                    frame,
                     self._tactile_display_keys.get(cam_name),
                 )
             )

--- a/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
@@ -38,7 +38,11 @@ auto-discover by rule.
 from dataclasses import dataclass, field
 
 from ..config import RobotConfig
-from ..taccap_gripper.common import build_head_camera_configs, validate_robot_id
+from ..taccap_gripper.common import (
+    build_head_camera_configs,
+    validate_robot_id,
+    validate_wrist_undistort_size,
+)
 
 _SIDES = ("left", "right")
 
@@ -186,6 +190,26 @@ class BiTaccapGripperConfig(RobotConfig):
     wrist_camera_height: int = 480
     wrist_camera_fps: int = 30
 
+    wrist_undistort: bool = False
+    """Rectify both wrist fisheye streams before the frames are recorded.
+
+    Shared by the two arms like the other ``wrist_camera_*`` settings, but the
+    intrinsics are per unit: each gripper is asked for its own, so one arm can be
+    rectified from its flash while the other falls back to the SDK reference.
+
+    **Off by default, and turning it on changes what lands in the dataset**: a
+    rectified ``{side}_wrist`` and a raw fisheye one have identical shape and
+    dtype, so the two are not interchangeable and nothing downstream can tell
+    them apart. Which of the two each arm used is written into
+    ``meta/hardware.json`` for exactly that reason. See the single-arm config for
+    what the reference fallback costs."""
+
+    wrist_undistort_balance: float = 0.0
+    """Output focal length, ``0`` = the calibrated value (also the PC calibration
+    tool's default), ``1`` = 0.70x for the widest field of view at the cost of
+    more black border. Only fx/fy move; the principal point stays put. Clamped to
+    [0, 1] by the SDK."""
+
     wrist_camera_fourcc: str | None = "MJPG"
     """Pixel format to negotiate with both wrist cameras. Defaults to MJPEG
     because the alternative OpenCV would pick on its own (YUYV) reserves enough
@@ -257,6 +281,14 @@ class BiTaccapGripperConfig(RobotConfig):
                 f"got {self.tactile_output_types}. For an extra Rerun-only view use "
                 "--robot.tactile_display_output_types."
             )
+        if self.wrist_undistort:
+            if not any(getattr(self, f"{side}_enable_wrist_camera") for side in _SIDES):
+                raise ValueError(
+                    "wrist_undistort=True but neither arm has a wrist camera enabled — there "
+                    "is no wrist stream to rectify."
+                )
+            validate_wrist_undistort_size(self.wrist_camera_width, self.wrist_camera_height)
+
         for side in _SIDES:
             if getattr(self, f"{side}_enable_gripper") and getattr(self, f"{side}_gripper_open_rad") <= 0:
                 raise ValueError(

--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -660,11 +660,12 @@ Three things worth knowing before turning it on:
   calibration tool's default), 1 shortens it to 0.70x for the widest view. Only
   fx/fy move, so the view does not drift as the knob turns.
 
-Note this is *not* the SDK's own `Config::undistort_wrist`. That one only applies
+Note this is _not_ the SDK's own `Config::undistort_wrist`. That one only applies
 when the SDK owns the wrist UVC device, which it never does here — the cameras
 come from the LeRobot camera framework. `resolve_fisheye()` exists precisely for
 callers in that position, so both paths make the same read-and-fall-back
 decision instead of drifting apart.
+
 - **Head** → obs keys `left_head` / `right_head`, off by default;
   `--robot.enable_head_camera=true` streams the Pico headset's stereo camera as **one key
   per eye**. `--robot.head_camera_width/_height` accept `640x480` (default), `1024x768` or

--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -623,7 +623,48 @@ at connect). Leave it unset (default) to keep auto-discovery.
   comes from the GSPS serial's **last digit** (odd → `left`, even → `right`, 单左双右).
 
 - **Wrist** → obs key `wrist_cam`; `--robot.enable_wrist_camera=false` skips. Tune
-  `--robot.wrist_camera_width/_height/_fps`.
+  `--robot.wrist_camera_width/_height/_fps`. `--robot.wrist_undistort=true` (off by
+  default) rectifies the fisheye **before the frame is recorded** — see below.
+
+### Wrist fisheye undistortion (`--robot.wrist_undistort`, off by default)
+
+The wrist lens is a 190° fisheye and what gets recorded is, by default, the raw
+frame. Turning this on rectifies it with the intrinsics stored in that gripper's
+own flash (`Cmd 0x2B`, command set V2.0+), read through the SDK's
+`Calibration::resolve_fisheye()`.
+
+**It changes what lands in the dataset, and the change is invisible.** A rectified
+`wrist_cam` and a raw one have the same shape and dtype, so datasets recorded with
+and without it are not interchangeable and nothing downstream can tell them apart.
+That is why `meta/hardware.json` records, per unit, whether it was applied and
+which intrinsics were used — and why flipping the flag part-way through a dataset
+opens a new epoch.
+
+Three things worth knowing before turning it on:
+
+- **An uncalibrated unit does not fail.** The SDK's shared reference intrinsics
+  stand in and `connect()` warns: every unit carries the same lens on the same
+  sensor, so reference numbers beat raw fisheye. They are **approximate** — lens
+  placement varies per assembly, so the principal point drifts. Anything that
+  measures in pixels off these frames wants this unit's own calibration:
+  `python third_party/taccap-gripper/python/examples/fisheye_cal.py set-fisheye`.
+  The manifest records `"calibration": "reference"` when this happened, because a
+  warning at connect scrolls past and the dataset is what remains.
+- **640x480 only.** The firmware record holds the 8 intrinsic/distortion floats
+  and no image size, so any other resolution would mean guessing a scale factor
+  and rectifying wrongly with nothing in the frames to show it. Combining
+  `--robot.wrist_undistort=true` with another `--robot.wrist_camera_width/_height`
+  fails at **CLI-parse time**, before any device is touched.
+- **`--robot.wrist_undistort_balance`** (0..1, default 0) trades field of view
+  against black border: 0 keeps the calibrated focal length (also the PC
+  calibration tool's default), 1 shortens it to 0.70x for the widest view. Only
+  fx/fy move, so the view does not drift as the knob turns.
+
+Note this is *not* the SDK's own `Config::undistort_wrist`. That one only applies
+when the SDK owns the wrist UVC device, which it never does here — the cameras
+come from the LeRobot camera framework. `resolve_fisheye()` exists precisely for
+callers in that position, so both paths make the same read-and-fall-back
+decision instead of drifting apart.
 - **Head** → obs keys `left_head` / `right_head`, off by default;
   `--robot.enable_head_camera=true` streams the Pico headset's stereo camera as **one key
   per eye**. `--robot.head_camera_width/_height` accept `640x480` (default), `1024x768` or
@@ -690,28 +731,43 @@ defaults it to `taccap_0`.
 ```json
 {
   "robot_type": "bi_taccap_gripper",
-  "robot_id": "taccap_0",
-  "role": "leader",
-  "units": [
+  "epochs": [
     {
-      "side": "left",
-      "gripper_sn": "TCGU01A24Z0001m",
-      "tactile_sensors": [
+      "from_episode": 0,
+      "to_episode": null,
+      "recorded_at": "2026-08-22T16:03:09+08:00",
+      "robot_id": "taccap_0",
+      "role": "leader",
+      "units": [
         {
-          "finger": "left",
-          "observation_key": "left_tactile_left",
-          "serial": "GSPS01A25Z0011"
-        },
-        {
-          "finger": "right",
-          "observation_key": "left_tactile_right",
-          "serial": "GSPS01A25Z0012"
+          "side": "left",
+          "gripper_sn": "TCGU01A24Z0001m",
+          "tactile_sensors": [
+            {
+              "finger": "left",
+              "observation_key": "left_tactile_left",
+              "serial": "GSPS01A25Z0011",
+              "runtime": "meta/runtimes/GSPS01A25Z0011-20260822T160309.bin"
+            },
+            {
+              "finger": "right",
+              "observation_key": "left_tactile_right",
+              "serial": "GSPS01A25Z0012",
+              "runtime": "meta/runtimes/GSPS01A25Z0012-20260822T160309.bin"
+            }
+          ],
+          "wrist_undistort": { "applied": false }
         }
       ]
     }
   ]
 }
 ```
+
+`epochs` is a list because a rig can be swapped part-way through a dataset: the
+open epoch is closed at the current episode count and a new one starts, so every
+episode keeps pointing at the devices that produced it. `to_episode` is exclusive
+and `null` on the epoch still being recorded.
 
 - `side` is which gripper; `finger` is which sensor on it. Both are called
   left/right and they are **independent** — 单左双右 is applied once to the
@@ -727,15 +783,25 @@ defaults it to `taccap_0`.
   omitted; `enable_tactile=false` gives it an empty `tactile_sensors`.
 - It is a file of its own, **not** a key in `meta/info.json`: that schema is
   upstream's and a fork-local key in it would collide on the next v5.x sync.
-- Resuming a dataset on _different_ hardware keeps the original file and warns.
-  The episodes already recorded came from the devices named there, and
-  overwriting would misattribute every one of them — the warning is the signal
-  that the dataset now spans two rigs.
+- `runtime` points at the tactile runtime bundle under `meta/runtimes/` that was
+  current when those episodes were recorded — what the derived channels have to
+  be rebuilt against.
+- `wrist_undistort` says whether that unit's wrist frames were rectified and from
+  whose intrinsics (`"unit"` or `"reference"`). Present whenever the unit has a
+  wrist camera, including as `{"applied": false}`.
+- Resuming a dataset on _different_ hardware **closes the open epoch and appends a
+  new one**. It used to keep the original file and warn, but that warning only
+  reached the log: nothing on disk said the rig had changed, while the manifest
+  went on attributing post-swap episodes to the old devices. Only a `robot_type`
+  mismatch is still keep-and-warn — single vs bimanual is a different dataset,
+  not a swap.
 
-Trackers and wrist cameras are deliberately not in the manifest: they are
-mounted accessories, while the gripper + its two tactiles are the unit whose
-serials the data is about. `hardware_manifest_unit()` in `common.py` is where
-that would change.
+Trackers are deliberately not in the manifest, and neither is the wrist camera's
+_identity_: they are mounted accessories, while the gripper + its two tactiles are
+the unit whose serials the data is about. `wrist_undistort` is not an exception to
+that — it records how the recorded frames were **processed**, which is invisible in
+the frames themselves. `hardware_manifest_unit()` in `common.py` is where all of
+this is decided.
 
 ## What gets recorded per frame
 

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -617,6 +617,102 @@ def open_gripper(
     return gripper, "firmware"
 
 
+# ------------------------------------------------------- wrist fisheye undistort
+
+#: The wrist lens is calibrated at this size and the firmware record carries the
+#: 8 intrinsic/distortion floats and **no image size**, so serving another
+#: resolution would mean guessing a scale factor and rectifying wrongly without
+#: a trace. ``FisheyeUndistorter`` rejects anything else; the configs check it at
+#: CLI-parse time so it does not wait until ``connect()`` to say so.
+WRIST_CALIB_SIZE = (640, 480)
+
+
+def validate_wrist_undistort_size(width: int, height: int) -> None:
+    """Reject a wrist resolution the fisheye intrinsics do not describe.
+
+    Called from both configs' ``__post_init__`` so the failure lands at
+    CLI-parse time. ``FisheyeUndistorter`` would raise at ``connect()`` anyway —
+    after the grippers, tracker and every other camera are already open — and the
+    error there does not name the flag that caused it.
+    """
+    if (width, height) != WRIST_CALIB_SIZE:
+        w, h = WRIST_CALIB_SIZE
+        raise ValueError(
+            f"wrist_undistort=True requires the wrist camera at {w}x{h}, got {width}x{height}. "
+            f"The firmware's fisheye record holds only the 8 intrinsic/distortion floats and no "
+            f"image size, so another resolution would mean guessing a scale factor and rectifying "
+            f"wrongly with nothing in the frames to show it. Either drop --robot.wrist_undistort "
+            f"or record at {w}x{h}."
+        )
+
+
+def resolve_wrist_undistorter(
+    gripper: Any,
+    *,
+    undistorter_cls: Any,
+    fallback_cal: Any,
+    balance: float,
+    logger: Any,
+    label: str = "",
+) -> tuple[Any, str]:
+    """Build the undistorter for one wrist camera, and say where its numbers came from.
+
+    We own the wrist UVC device (the cameras come from the LeRobot camera
+    framework, and ``open_gripper`` leaves the SDK's ``open_cameras`` at its
+    default ``False``), so the SDK's own ``Config::undistort_wrist`` never
+    applies to us. ``Calibration::resolve_fisheye`` exists precisely for this
+    case: it hands callers that own the device the *identical* read-and-fall-back
+    answer the SDK uses internally, instead of each consumer re-deriving it and
+    drifting from the other.
+
+    Falls back to the SDK's reference intrinsics rather than refusing, matching
+    the SDK: every unit carries the same lens on the same sensor, so the shared
+    numbers beat no rectification at all. It is **approximate** — lens placement
+    varies per assembly so the principal point drifts — hence the warning, and
+    hence ``hardware_manifest_unit`` records which of the two was used. A warning
+    at connect scrolls past; the manifest is what can still be checked afterwards.
+
+    ``gripper`` may be ``None`` (``enable_gripper=False``), which leaves no MCU to
+    ask and therefore no way to read this unit's own calibration.
+
+    ``undistorter_cls`` (``FisheyeUndistorter``) and ``fallback_cal``
+    (``FISHEYE_FALLBACK_CAL``) are injected rather than imported here, for the
+    same reason ``open_gripper`` takes ``gripper_cls``: this module is helper
+    code the robots share, and importing the SDK in it would make every one of
+    these helpers untestable on a machine without the SDK — which includes CI.
+
+    Returns:
+        ``(undistorter, source)`` where ``source`` is ``"unit"`` when the numbers
+        came off this gripper's flash and ``"reference"`` when they did not.
+    """
+    if gripper is None:
+        cal, is_reference, reason = (
+            fallback_cal,
+            True,
+            "the gripper MCU is disabled (--robot.enable_gripper=false), so this unit's own calibration cannot be read",
+        )
+    else:
+        cal, is_reference, reason = gripper.calibration.resolve_fisheye()
+
+    if is_reference:
+        logger.warn(
+            f"  {label}Wrist undistortion is using the SDK's REFERENCE intrinsics because "
+            f"{reason}. Rectification will be approximate — lens placement varies per "
+            f"assembly, so the principal point drifts, and anything measuring in pixels off "
+            f"these frames needs a real calibration. Store this unit's own with: "
+            f"python third_party/taccap-gripper/python/examples/fisheye_cal.py set-fisheye"
+        )
+
+    width, height = WRIST_CALIB_SIZE
+    undistorter = undistorter_cls(cal, width, height, balance)
+    source = "reference" if is_reference else "unit"
+    logger.info(
+        f"  {label}Wrist fisheye undistortion on (balance={undistorter.balance:.2f}, "
+        f"focal_scale={undistorter.focal_scale:.3f}, calibration={source})"
+    )
+    return undistorter, source
+
+
 #: How long the jaw encoder may fail continuously before the gripper counts as
 #: physically lost. Shorter than :data:`camera_health.CAM_FREEZE_TIMEOUT_S`
 #: because an encoder read is one serial round-trip with nothing to buffer, and
@@ -809,6 +905,7 @@ def hardware_manifest_unit(
     endpoints: Any,
     tactile_serials: dict[str, str],
     key_prefix: str,
+    wrist_undistort: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """One TacCap unit's identity: its gripper, and the tactiles on that gripper.
 
@@ -824,8 +921,21 @@ def hardware_manifest_unit(
     carries the ``observation_key`` it feeds (``{key_prefix}tactile_{finger}``),
     letting a dataset column trace back to a physical sensor without re-deriving
     the naming rule.
+
+    ``wrist_undistort`` records whether this unit's wrist frames were rectified
+    and from whose intrinsics — ``{"applied": bool, "calibration": "unit" |
+    "reference", "balance": float}``, or ``None`` when there is no wrist camera,
+    in which case the key is left out entirely.
+
+    That may look like it contradicts leaving trackers and wrist cameras out of
+    the manifest, but it does not: what is excluded is an accessory's *identity*,
+    and this records how the recorded frames were *processed*. A rectified
+    ``wrist_cam`` and a raw fisheye one have the same shape and dtype, so without
+    this nothing downstream — or later — can tell which it is holding. It rides
+    in ``units``, so changing it part-way through a dataset opens a new epoch on
+    its own (see ``write_hardware_manifest``).
     """
-    return {
+    unit: dict[str, Any] = {
         "side": side,
         "gripper_sn": getattr(endpoints, "firmware_sn", None) or None,
         "tactile_sensors": [
@@ -837,6 +947,28 @@ def hardware_manifest_unit(
             for finger, sn in sorted(tactile_serials.items())
         ],
     }
+    if wrist_undistort is not None:
+        unit["wrist_undistort"] = wrist_undistort
+    return unit
+
+
+def wrist_undistort_record(*, has_wrist_camera: bool, source: str | None, balance: float) -> dict[str, Any] | None:
+    """The ``wrist_undistort`` entry for one unit's manifest, or ``None`` to omit it.
+
+    ``None`` — and therefore no key at all — means "this unit has no wrist
+    camera", so there is nothing for the question to be about. A unit that *has*
+    one always records an answer, including ``{"applied": False}``: absent and
+    false would otherwise be indistinguishable, and "we did not rectify" is a
+    fact about the data worth stating rather than inferring from a missing key.
+
+    ``balance`` is left out when nothing was applied — it describes a
+    rectification that did not happen.
+    """
+    if not has_wrist_camera:
+        return None
+    if source is None:
+        return {"applied": False}
+    return {"applied": True, "calibration": source, "balance": float(balance)}
 
 
 def build_hardware_manifest(

--- a/src/lerobot/robots/taccap_gripper/config_taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/config_taccap_gripper.py
@@ -34,7 +34,7 @@ Unity-app launch time.
 from dataclasses import dataclass, field
 
 from ..config import RobotConfig
-from .common import build_head_camera_configs, validate_robot_id
+from .common import build_head_camera_configs, validate_robot_id, validate_wrist_undistort_size
 
 
 @RobotConfig.register_subclass("taccap_gripper")
@@ -186,6 +186,29 @@ class TaccapGripperConfig(RobotConfig):
     wrist_camera_height: int = 480
     wrist_camera_fps: int = 30
 
+    wrist_undistort: bool = False
+    """Rectify the wrist fisheye before the frame is recorded.
+
+    **Off by default, and turning it on changes what lands in the dataset**: a
+    rectified ``wrist_cam`` and a raw fisheye one have identical shape and dtype,
+    so the two are not interchangeable and nothing downstream can tell them
+    apart. Which of the two a recording used is written into
+    ``meta/hardware.json`` for exactly that reason.
+
+    The intrinsics come from this gripper's flash (``Cmd 0x2B``, command set
+    V2.0+) via the SDK's ``resolve_fisheye()``. A unit that has never been
+    calibrated does not fail — the SDK's shared reference intrinsics stand in and
+    connect() warns, since every unit carries the same lens and reference numbers
+    beat raw fisheye. They are approximate: lens placement varies per assembly so
+    the principal point drifts, and anything measuring in pixels off these frames
+    wants a real calibration (``fisheye_cal.py set-fisheye``)."""
+
+    wrist_undistort_balance: float = 0.0
+    """Output focal length, ``0`` = the calibrated value (also the PC calibration
+    tool's default), ``1`` = 0.70x for the widest field of view at the cost of
+    more black border. Only fx/fy move; the principal point stays put so the view
+    does not drift as the knob turns. Clamped to [0, 1] by the SDK."""
+
     wrist_camera_fourcc: str | None = "MJPG"
     """Pixel format to negotiate with the wrist camera. Defaults to MJPEG
     because the alternative OpenCV would pick on its own (YUYV) reserves enough
@@ -244,6 +267,13 @@ class TaccapGripperConfig(RobotConfig):
             # Delegate to the camera config so there is one definition of what
             # a valid mode is, rather than a copy here that can drift from it.
             build_head_camera_configs(self)
+
+        if self.wrist_undistort:
+            if not self.enable_wrist_camera:
+                raise ValueError(
+                    "wrist_undistort=True but enable_wrist_camera=False — there is no wrist stream to rectify."
+                )
+            validate_wrist_undistort_size(self.wrist_camera_width, self.wrist_camera_height)
 
         if self.role.strip().lower() not in ("leader", "master", "follower", "slave"):
             # master/slave are legacy spellings kept for compatibility; see

--- a/src/lerobot/robots/taccap_gripper/taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/taccap_gripper.py
@@ -71,9 +71,11 @@ from .common import (
     open_gripper,
     prewarm_tactile_config_cache,
     read_head_pose,
+    resolve_wrist_undistorter,
     split_camera_read,
     swap_tactile_display_features,
     tactile_camera_output_types,
+    wrist_undistort_record,
 )
 from .config_taccap_gripper import TaccapGripperConfig
 from .ee_transform import resolve_tracker_to_ee
@@ -81,6 +83,8 @@ from .ee_transform import resolve_tracker_to_ee
 # ---- TacCap-Gripper SDK -----------------------------------------------------
 try:
     from xense.taccap import (
+        FISHEYE_FALLBACK_CAL,
+        FisheyeUndistorter,
         FollowerGripper,
         LeaderGripper,
     )
@@ -139,6 +143,13 @@ class TaccapGripper(Robot):
         self._gripper: Any = None  # Leader/FollowerGripper
         self._endpoints: Any = None  # xense.taccap.GripperEndpoints
         self._tracker: Pico4TrackerReader | None = None
+        # {observation key: FisheyeUndistorter} — empty unless wrist_undistort is
+        # on. Keyed by camera name so get_observation can look one up without
+        # knowing which key the wrist camera landed under.
+        self._wrist_undistorters: dict[str, Any] = {}
+        #: Which calibration each undistorter used ("unit" / "reference"), for
+        #: the hardware manifest.
+        self._wrist_undistort_source: str | None = None
 
         # Discover devices → resolve which side this single unit is, then build its
         # tactile + wrist camera configs. Tactiles are paired to a gripper by USB
@@ -292,6 +303,11 @@ class TaccapGripper(Robot):
                     endpoints=self._endpoints,
                     tactile_serials=self._disc_tactiles.get(self._side, {}),
                     key_prefix="",
+                    wrist_undistort=wrist_undistort_record(
+                        has_wrist_camera="wrist_cam" in self._camera_configs,
+                        source=self._wrist_undistort_source,
+                        balance=self.config.wrist_undistort_balance,
+                    ),
                 )
             ],
         )
@@ -453,6 +469,21 @@ class TaccapGripper(Robot):
             )
             self.logger.info(f"  ✅ {gripper_cls.__name__} attached (MCU-only, read-only — motor stays disabled)")
 
+        # 1b. Wrist fisheye undistortion, if asked for. Built here — after the
+        #     gripper, whose MCU holds the intrinsics, and before the cameras open
+        #     — so a unit that cannot supply a calibration warns during connect
+        #     rather than on the first frame of a recording.
+        if self.config.wrist_undistort and "wrist_cam" in self._camera_configs:
+            undistorter, source = resolve_wrist_undistorter(
+                self._gripper,
+                undistorter_cls=FisheyeUndistorter,
+                fallback_cal=FISHEYE_FALLBACK_CAL,
+                balance=self.config.wrist_undistort_balance,
+                logger=self.logger,
+            )
+            self._wrist_undistorters["wrist_cam"] = undistorter
+            self._wrist_undistort_source = source
+
         # 2. Pico4 tracker.
         if self._tracker_sn is not None:
             # None means "use this side's built-in mount transform"; anything
@@ -520,6 +551,8 @@ class TaccapGripper(Robot):
             self._gripper = None
 
         self._endpoints = None
+        self._wrist_undistorters = {}
+        self._wrist_undistort_source = None
         self._is_connected = False
 
     def calibrate(self) -> None:
@@ -574,10 +607,20 @@ class TaccapGripper(Robot):
         # The head cameras need no special case here — they are ordinary
         # cameras, and the pose comes from the SDK above, not from a frame.
         for cam_name, cam in self.cameras.items():
+            frame = self._cam_guard.read(cam_name, cam)
+            # Rectify *after* the guard, deliberately. The guard detects a frozen
+            # stream by frame object identity (camera_health.CameraReadGuard.read),
+            # and FisheyeUndistorter.apply() returns a fresh array every call — so
+            # rectifying upstream of it (by wrapping the camera, say) would make a
+            # frozen wrist camera undetectable. The guard's fallback frame is the
+            # last good *raw* one, which rectifies here like any other.
+            undistorter = self._wrist_undistorters.get(cam_name)
+            if undistorter is not None:
+                frame = undistorter.apply(frame)
             obs.update(
                 split_camera_read(
                     cam_name,
-                    self._cam_guard.read(cam_name, cam),
+                    frame,
                     self._tactile_display_keys.get(cam_name),
                 )
             )

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -27,6 +27,7 @@ import pytest
 
 from lerobot.cameras.pico import SUPPORTED_MODES
 from lerobot.robots.bi_taccap_gripper.config_bi_taccap_gripper import BiTaccapGripperConfig
+from lerobot.robots.taccap_gripper.camera_health import CameraReadGuard
 from lerobot.robots.taccap_gripper.common import (
     CAPTURE_TZ,
     HARDWARE_MANIFEST_PATH,
@@ -45,6 +46,7 @@ from lerobot.robots.taccap_gripper.common import (
     manifest_epochs,
     open_gripper,
     read_head_camera_skew,
+    resolve_wrist_undistorter,
     split_camera_read,
     swap_tactile_display_features,
     tactile_camera_output_types,
@@ -52,6 +54,8 @@ from lerobot.robots.taccap_gripper.common import (
     tactile_runtime_for_key,
     tactile_serial_for_key,
     validate_robot_id,
+    validate_wrist_undistort_size,
+    wrist_undistort_record,
     write_hardware_manifest,
 )
 from lerobot.robots.taccap_gripper.config_taccap_gripper import TaccapGripperConfig
@@ -1282,3 +1286,227 @@ class TestOpenGripper:
         assert source == "config"
         assert gripper.normalize_position is False
         assert any("gripper_open_rad=1.7" in m for m in logger.infos)
+
+
+# --------------------------------------------------------- wrist fisheye undistort
+
+
+class FakeCalibration:
+    """``gripper.calibration``, whose ``resolve_fisheye`` the SDK implements by
+    reading flash. Returns the SDK's own tuple shape."""
+
+    def __init__(self, cal, is_reference, reason):
+        self._answer = (cal, is_reference, reason)
+        self.calls = 0
+
+    def resolve_fisheye(self, *args, **kwargs):
+        self.calls += 1
+        return self._answer
+
+
+class FakeUndistortGripper:
+    def __init__(self, calibration):
+        self.calibration = calibration
+
+
+class FakeUndistorter:
+    """Stand-in for the SDK's ``FisheyeUndistorter``, recording what it was
+    handed. The focal-length maths behind ``balance`` belongs to the SDK and is
+    tested there; what matters here is which calibration and size reach it."""
+
+    def __init__(self, calibration, width, height, balance):
+        self.calibration = calibration
+        self.width = width
+        self.height = height
+        self.balance = balance
+        self.focal_scale = 1.0
+
+
+UNIT_CAL = object()  # this gripper's own, read from flash
+REFERENCE_CAL = object()  # the SDK's FISHEYE_FALLBACK_CAL
+
+
+def _resolve(gripper, **kwargs):
+    kwargs.setdefault("balance", 0.0)
+    kwargs.setdefault("logger", FakeLogger())
+    return resolve_wrist_undistorter(gripper, undistorter_cls=FakeUndistorter, fallback_cal=REFERENCE_CAL, **kwargs)
+
+
+class TestResolveWristUndistorter:
+    """Which intrinsics a recording rectified with is not visible in the frames,
+    so the source this reports is what the manifest — and any later audit — has
+    to go on."""
+
+    def test_this_units_own_calibration_is_used_without_warning(self):
+        cal = FakeCalibration(UNIT_CAL, False, "")
+        logger = FakeLogger()
+        undistorter, source = _resolve(FakeUndistortGripper(cal), logger=logger)
+        assert source == "unit"
+        assert cal.calls == 1
+        assert undistorter.calibration is UNIT_CAL
+        assert logger.warnings == []
+        # The firmware record carries no image size, so this is the only one the
+        # intrinsics describe — see validate_wrist_undistort_size.
+        assert (undistorter.width, undistorter.height) == (640, 480)
+
+    def test_reference_fallback_warns_and_says_why(self):
+        """The fallback is deliberately not an error, so the warning is the only
+        thing standing between an approximate rectification and a whole dataset
+        recorded without anyone noticing."""
+        logger = FakeLogger()
+        undistorter, source = _resolve(
+            FakeUndistortGripper(FakeCalibration(REFERENCE_CAL, True, "the wrist lens has never been calibrated")),
+            logger=logger,
+        )
+        assert source == "reference"
+        assert undistorter.calibration is REFERENCE_CAL
+        assert len(logger.warnings) == 1
+        warning = logger.warnings[0]
+        assert "REFERENCE" in warning
+        assert "never been calibrated" in warning  # the SDK's reason is passed through
+        assert "fisheye_cal.py set-fisheye" in warning  # and how to fix it
+
+    def test_no_gripper_means_no_calibration_to_read(self):
+        """``--robot.enable_gripper=false`` leaves no MCU to ask. That is the
+        reference case too, but for a reason the SDK never sees, so we supply it."""
+        logger = FakeLogger()
+        undistorter, source = _resolve(None, logger=logger)
+        assert source == "reference"
+        assert undistorter.calibration is REFERENCE_CAL
+        assert "enable_gripper" in logger.warnings[0]
+
+    def test_balance_reaches_the_undistorter(self):
+        undistorter, _ = _resolve(FakeUndistortGripper(FakeCalibration(UNIT_CAL, False, "")), balance=1.0)
+        assert undistorter.balance == pytest.approx(1.0)
+
+
+class TestValidateWristUndistortSize:
+    def test_the_calibrated_size_passes(self):
+        validate_wrist_undistort_size(640, 480)
+
+    def test_any_other_size_is_refused_at_parse_time(self):
+        """The firmware record carries no image size, so another resolution means
+        guessing a scale factor and rectifying wrongly with nothing in the frames
+        to show it."""
+        with pytest.raises(ValueError) as excinfo:
+            validate_wrist_undistort_size(1280, 960)
+        assert "640x480" in str(excinfo.value)
+        assert "1280x960" in str(excinfo.value)
+
+
+class TestWristUndistortRecord:
+    def test_no_wrist_camera_omits_the_key_entirely(self):
+        """Absent means the question does not apply, not that the answer is no."""
+        assert wrist_undistort_record(has_wrist_camera=False, source=None, balance=0.0) is None
+
+    def test_a_wrist_camera_always_records_an_answer(self):
+        """Including "we did not rectify" — absent and false would otherwise be
+        indistinguishable in a recorded dataset."""
+        assert wrist_undistort_record(has_wrist_camera=True, source=None, balance=0.0) == {"applied": False}
+
+    def test_applied_records_which_calibration_and_the_balance(self):
+        assert wrist_undistort_record(has_wrist_camera=True, source="reference", balance=0.5) == {
+            "applied": True,
+            "calibration": "reference",
+            "balance": 0.5,
+        }
+
+
+class FrozenCamera:
+    """A stream that keeps handing back the *same* object — how an unplugged
+    Xense sensor behaves, since its read thread survives the error."""
+
+    def __init__(self):
+        self.frame = np.zeros((480, 640, 3), dtype=np.uint8)
+
+    def async_read(self):
+        return self.frame
+
+
+class RectifiedFrozenCamera(FrozenCamera):
+    """The same dead stream, but with rectification applied *before* the guard
+    sees it — a fresh array every call, exactly like ``FisheyeUndistorter.apply``.
+    """
+
+    def async_read(self):
+        return self.frame.copy()
+
+
+class TestFreezeDetectionConstrainsWhereUndistortionGoes:
+    """Why ``get_observation`` rectifies *after* ``CameraReadGuard.read``.
+
+    The guard spots a dead-but-not-raising stream by frame object identity, so
+    anything that hands it a fresh array each call — rectifying upstream by
+    wrapping the camera, say — makes a frozen wrist camera undetectable and the
+    recording silently keeps writing stale frames.
+    """
+
+    def test_a_frozen_stream_is_flagged(self):
+        guard = CameraReadGuard({}, FakeLogger(), freeze_timeout_s=0.0)
+        camera = FrozenCamera()
+        guard.read("wrist_cam", camera)  # first read establishes the baseline
+        guard.read("wrist_cam", camera)
+        assert guard.lost
+
+    def test_a_fresh_array_each_call_hides_the_same_dead_stream(self):
+        """Not a feature — the hazard the ordering avoids. If this ever stops
+        holding, the comment in get_observation can go."""
+        guard = CameraReadGuard({}, FakeLogger(), freeze_timeout_s=0.0)
+        camera = RectifiedFrozenCamera()
+        for _ in range(5):
+            guard.read("wrist_cam", camera)
+        assert not guard.lost
+
+
+class TestWristUndistortOpensItsOwnEpoch:
+    """Rectified and raw frames are indistinguishable in the dataset, so a change
+    of setting part-way through has to be recorded as its own epoch."""
+
+    def _manifest(self, **wrist):
+        return build_hardware_manifest(
+            robot_type="taccap_gripper",
+            robot_id="taccap_0",
+            role="leader",
+            units=[
+                hardware_manifest_unit(
+                    "left",
+                    endpoints=FakeEndpoints("TCGU01A24Z0001m"),
+                    tactile_serials={"left": "GSPS01A25Z0011"},
+                    key_prefix="",
+                    wrist_undistort=wrist_undistort_record(**wrist),
+                )
+            ],
+        )
+
+    def test_turning_it_on_mid_dataset_closes_the_old_epoch(self, tmp_path):
+        off = self._manifest(has_wrist_camera=True, source=None, balance=0.0)
+        on = self._manifest(has_wrist_camera=True, source="unit", balance=0.0)
+
+        write_hardware_manifest(tmp_path, off, FakeLogger())
+        path = write_hardware_manifest(tmp_path, on, FakeLogger(), episode_index=7)
+
+        epochs = json.loads(path.read_text())["epochs"]
+        assert len(epochs) == 2
+        assert epochs[0]["to_episode"] == 7
+        assert epochs[0]["units"][0]["wrist_undistort"]["applied"] is False
+        assert epochs[1]["units"][0]["wrist_undistort"]["applied"] is True
+
+    def test_changing_only_the_balance_also_opens_one(self, tmp_path):
+        """It changes the geometry of every recorded frame, so it is a different
+        configuration even though the hardware is identical."""
+        write_hardware_manifest(
+            tmp_path, self._manifest(has_wrist_camera=True, source="unit", balance=0.0), FakeLogger()
+        )
+        path = write_hardware_manifest(
+            tmp_path,
+            self._manifest(has_wrist_camera=True, source="unit", balance=1.0),
+            FakeLogger(),
+            episode_index=4,
+        )
+        assert len(json.loads(path.read_text())["epochs"]) == 2
+
+    def test_an_unchanged_setting_does_not(self, tmp_path):
+        same = self._manifest(has_wrist_camera=True, source="unit", balance=0.0)
+        write_hardware_manifest(tmp_path, same, FakeLogger())
+        path = write_hardware_manifest(tmp_path, same, FakeLogger(), episode_index=9)
+        assert len(json.loads(path.read_text())["epochs"]) == 1


### PR DESCRIPTION
SDK 0.1.9 带来了 `resolve_fisheye()` 和 `FisheyeUndistorter`,但**我们这条路径一直用不到**:`open_gripper()` 让 SDK 的 `open_cameras` 保持 `False`,腕相机走 LeRobot 相机框架,所以录进数据集的 `wrist_cam` 至今是原始鱼眼。

`--robot.wrist_undistort`(**默认 `False`**)打开后,用那只夹爪 flash 里的内参矫正。

> 这**不是**把 SDK 的 `Config::undistort_wrist` 打开——那个只在 SDK 自己持有 UVC 设备时才有意义。`resolve_fisheye()` 正是为「自己持有设备的调用方」准备的:给出和 SDK 内部一致的「读标定 + 读不到就回退」答案,避免两边各自推导然后漂移。

## 数据集里记了什么,以及为什么必须记

**矫正过的帧和原始帧在数据集里分不出来**——形状、dtype 完全一样。所以 `meta/hardware.json` 的每个 unit 多一条:

```json
"wrist_undistort": { "applied": true, "calibration": "unit", "balance": 0.0 }
```

它落在 `units` 里,于是「录到一半改了设置」**自动另起一个 epoch**,不需要额外代码(`_epoch_payload` 本来就整体比对 `units`)。有腕相机就一定记,包括 `{"applied": false}`:缺键和 `false` 若不可分,事后就说不清了。

## 没标定的单元不硬失败

用 SDK 参考内参并告警,与 SDK 行为一致(同一颗镜头、同一块传感器,参考值比不矫正强)。但它**是近似的**——装配差异导致主点漂移——而 connect 时的告警会滚过去。所以清单里那条 `"calibration": "reference"` 才是事后唯一能查的凭据。这两个决定是配套的。

## 三个实现要点

**① 矫正必须在 `CameraReadGuard` 之后,这不是风格问题。** guard 靠**帧对象身份**识别「卡住但不报错」的流(`camera_health.py:135`),而 `apply()` 每次返回新数组——放在 guard 上游(比如包一层相机)会让腕相机的冻结检测**永远不触发**,录制继续写陈旧帧而毫无提示。加了两个测试把这条约束钉住,其中一个专门演示这个危险。

**② 只接受 640x480,在解析命令行时就拒绝。** 固件记录里只有 8 个内参/畸变浮点数、**不带图像尺寸**,换分辨率等于猜缩放系数。留到 connect 才抛的话,那时夹爪、追踪器和其它相机都已经开了,而且 SDK 的报错不会提到是哪个参数导致的。

**③ SDK 类型由机器人注入**,helper 自己不 `import xense.taccap`。理由和 `open_gripper` 收 `gripper_cls` 一样:`common.py` 是两个机器人共用的辅助代码,在里面 import SDK 会让这些 helper 在没装 SDK 的机器上(**包括 CI**)全都不可测。第一版我写成内部 import,测试立刻就跑不起来。

## 顺带修的两处 README 陈旧描述

我在往清单里加字段,而这一节本身已经不准了:

- 清单示例还是 **epochs 之前的扁平结构**,也没有 `runtime`
- 「续录遇到硬件不同会保留原文件并告警」——那是 `052eb354` 之前的行为(和刚在 #52 修掉的 CLAUDE.md 同源)

## 验证

- `pytest tests/robots/ -q` → **224 passed**(新增 14 个)
- 配置校验:非 640x480、腕相机全关 → 均在构造 config 时抛 `ValueError`
- 真 SDK 端到端跑通(测试用的是假件):`resolve_wrist_undistorter` → `FisheyeUndistorter` → `apply()`,告警文案、manifest 记录都对
- **开销实测 1.5 ms/帧**(640x480)。在录制循环里和 4 路触觉共享预算,值得真机上看一眼 `[slow_frame]` 频率

**尚未真机验证**:需要在实机上比对开关前后的画面、确认未标定单元的告警路径、以及检查产出的 `meta/hardware.json`。

## 客户文档

此前搁置的那条现在可以写了——之前不能写,是因为「SDK 会自动兜底矫正」在我们这条路径上是**假的**。等这个合了我再去 XTac-UMI-G1-Docs 补,要写明默认关、开启后 `wrist_cam` 变成矫正帧、以及**新老数据集不可直接混用**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)