### PR TITLE
docs(claude): 记下 torchvision/libjpeg 的导入顺序陷阱

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,35 @@ The same trap has now appeared twice: once in the video concatenation path, and
 once in a proposed `_atomic_write_parquet` that would have moved data parquet
 from `0644` to `0600` (reviewed on PR #19).
 
+### Host gotcha — `import xense.taccap` must precede torchvision
+
+torchvision ships a vendored `libjpeg` that claims the `LIBJPEG_8.0` symbol
+version but carries **none** of the `jpeg12_*` symbols conda's `libtiff` needs.
+Whichever loads first wins the version slot, so once torchvision is in, every
+later `import xense.taccap` — which reaches libtiff via
+`libopencv_videoio` → `libopencv_imgcodecs` → `libtiff` — dies with:
+
+```text
+ImportError: .../libtiff.so.6: undefined symbol: jpeg12_write_raw_data, version LIBJPEG_8.0
+```
+
+`lerobot_record.py`, `lerobot_replay.py` and `lerobot_teleoperate.py` each carry
+a `contextlib.suppress(ImportError)` import of `xense.taccap` **above every
+lerobot import** for exactly this. Moving it below them puts the bug back.
+
+Only those three need it: they are the entry points that both pull torchvision
+(through `lerobot.datasets`) and touch the SDK. `lerobot-calibrate` never loads
+torchvision at all, so it is fine as-is — verify before adding the block
+elsewhere rather than sprinkling it.
+
+The failure is nasty out of proportion to its cause: nothing fails at startup,
+because the SDK import is what breaks and the robots only reach for it later. On
+the sister repo `lerobot-xense`, whose `XenseWristCamera` imports
+`FisheyeUndistorter` lazily inside `connect()`, the same conflict surfaced as a
+recording dying at camera-connect time. `LD_PRELOAD` does not help — torchvision's
+copy is auditwheel-renamed (`libjpeg.4af9affd.so.8`), so it is not competing on
+soname but on the symbol version, and preloading cannot outrank it.
+
 ## Vendored SDK
 
 `third_party/taccap-gripper` is the TacCap-Gripper SDK submodule (has its own


### PR DESCRIPTION
`lerobot_record.py` / `lerobot_replay.py` / `lerobot_teleoperate.py` 顶部那句看似多余的 `import xense.taccap` 是**必需的**,但代码里只有一行注释,没说清机制、后果和边界。

补进 `CLAUDE.md`:

- **冲突机制**:torchvision 自带的 libjpeg 声明 `LIBJPEG_8.0` 符号版本却不含 conda 的 libtiff 需要的 `jpeg12_*`,谁先加载谁占坑
- **依赖链**:`xense.taccap` → `libopencv_videoio` → `libopencv_imgcodecs` → `libtiff`
- **边界**:只有那三个入口需要(它们既拉 torchvision 又用 SDK);`lerobot-calibrate` 根本不加载 torchvision,不必跟着加 —— 明确写了"先验证再加,别到处撒"
- **`LD_PRELOAD` 为什么无效**:torchvision 那份被 auditwheel 改名成 `libjpeg.4af9affd.so.8`,不在 soname 上竞争而在符号版本上

顺带把姊妹仓库的实例写了进来:`lerobot-xense` 上同一个冲突**未修**,而它的 `XenseWristCamera` 在 `connect()` 里才 lazy import,于是表现为**录制到连腕相机那一刻才炸**。这正好是"这几行删掉会怎样"的现成答案。(那边的修复在 Vertax42/lerobot-xense#17)

纯文档,无代码变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)