### PR TITLE
docs(bi): 双臂 README 补上腕相机鱼眼矫正

### DIFF
--- a/src/lerobot/robots/bi_taccap_gripper/README.md
+++ b/src/lerobot/robots/bi_taccap_gripper/README.md
@@ -79,8 +79,21 @@ to left/right by its serial's **second-to-last digit** (odd → left, even → r
 missing/duplicate/malformed tracker raises a clear error. Set `--robot.enable_tracker=false`
 to record tactile + gripper only (no PC service needed). Other knobs: `--robot.role`,
 `--robot.{side}_gripper_open_rad` (fallback only — see below), `--robot.tactile_fps`,
-`--robot.wrist_camera_{width,height,fps}`,
+`--robot.wrist_camera_{width,height,fps}`, `--robot.wrist_undistort`,
 `--robot.expected_tactiles_per_side`, `--robot.enable_tactile`.
+
+**Wrist fisheye undistortion.** `--robot.wrist_undistort=true` (off by default)
+rectifies both wrist streams **before the frames are recorded**, with
+`--robot.wrist_undistort_balance` (0..1, default 0) trading field of view against
+black border. The flag is **shared by both arms** like the other
+`wrist_camera_*` settings, but the intrinsics are **per unit**: each gripper is
+asked for its own, so one arm can rectify from its flash while the other falls
+back to the SDK's reference values — and `meta/hardware.json` records which,
+per unit. Only 640x480 is accepted, checked at CLI-parse time. Everything else
+about it — what the reference fallback costs, and why an off-centre picture does
+not mean the calibration is wrong — is in the
+[single-arm README](../taccap_gripper/README.md#wrist-fisheye-undistortion-robotwrist_undistort-off-by-default);
+the behaviour is identical per arm.
 
 **Jaw normalisation.** `{side}_gripper.pos` comes from each leader's own encoder-max
 calibration in MCU flash (firmware ≥ V2.1), so 1.0 is _that_ unit's real full-open rather


### PR DESCRIPTION
`--robot.wrist_undistort` 是单臂双臂都有的([`e5b4445a`](https://github.com/Vertax42/xense-taccap-lerobot/commit/e5b4445a) 一起加的),但当时**只有单臂 README 写了** —— 双臂那份连参数列表里都没提。核查客户文档站时发现的。

补进去,并写清一件**双臂独有**的事:

> 开关是**两臂共享**的(和其它 `wrist_camera_*` 设置一样),**而内参是分侧的** —— 每只夹爪各问各的。

所以完全可能出现一臂用本机标定、另一臂回退到 SDK 参考值的情况,`meta/hardware.json` 也按 unit 分别记录。这一点单臂 README 讲不到,只能在这里说。

其余细节(参考值回退的代价、画面偏心不代表标定错)**不重复一遍**,指向单臂 README 的对应小节 —— 每臂的行为完全相同,写两份只会分叉。跨文件锚点已核对生成正确。

顺带把 `--robot.wrist_undistort` 加进参数列表那一行。

`pytest tests/robots/` 224 passed。纯文档。

## 覆盖情况核查

| 位置 | 状态 |
|---|---|
| 客户文档站 `05-data-collection` / `06-dataset` / `versions`(中英) | ✅ 已有(Docs#8) |
| `taccap_gripper/README.md` | ✅ 已有(#53) |
| `bi_taccap_gripper/README.md` | **本 PR 补上** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)