### PR TITLE
feat: 8→6 相机转换与格式检查(cherry-pick #47)+ 保留 TacCap 自有 meta

### DIFF
--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -54,7 +54,12 @@ from lerobot.datasets.utils import (
     write_tasks,
 )
 from lerobot.datasets.video_utils import encode_video_frames, get_video_info
-from lerobot.utils.constants import HF_LEROBOT_HOME, OBS_IMAGE
+from lerobot.utils.constants import (
+    HF_LEROBOT_HOME,
+    OBS_IMAGE,
+    TACCAP_HARDWARE_MANIFEST_PATH,
+    TACCAP_RUNTIME_DIR,
+)
 
 TACCAP_6_CAMERA_FEATURE_KEYS = frozenset(
     {
@@ -152,6 +157,7 @@ def delete_episodes(
 
     _copy_and_reindex_episodes_metadata(dataset, new_meta, episode_mapping, data_metadata, video_metadata)
 
+    _copy_taccap_local_metadata(dataset.meta.root, output_dir)
     new_dataset = LeRobotDataset(
         repo_id=repo_id,
         root=output_dir,
@@ -240,6 +246,7 @@ def split_dataset(
 
         _copy_and_reindex_episodes_metadata(dataset, new_meta, episode_mapping, data_metadata, video_metadata)
 
+        _copy_taccap_local_metadata(dataset.meta.root, split_output_dir)
         new_dataset = LeRobotDataset(
             repo_id=split_repo_id,
             root=split_output_dir,
@@ -269,6 +276,8 @@ def merge_datasets(
     """
     if not datasets:
         raise ValueError("No datasets to merge")
+
+    _reject_merge_of_taccap_hardware_metadata(datasets)
 
     output_dir = Path(output_dir) if output_dir is not None else HF_LEROBOT_HOME / output_repo_id
 
@@ -386,6 +395,7 @@ def modify_features(
     if new_meta.video_keys:
         _copy_videos(dataset, new_meta, exclude_keys=video_keys_to_remove if video_keys_to_remove else None)
 
+    _copy_taccap_local_metadata(dataset.meta.root, output_dir)
     new_dataset = LeRobotDataset(
         repo_id=repo_id,
         root=output_dir,
@@ -579,6 +589,7 @@ def convert_8_to_6_cameras(
         vector_keep_indices=vector_keep_indices,
     )
     _update_stats_after_camera_conversion(dataset, new_meta, vector_keep_indices)
+    _copy_taccap_local_metadata(dataset.meta.root, output_dir)
 
     return LeRobotDataset(
         repo_id=repo_id,
@@ -587,6 +598,78 @@ def convert_8_to_6_cameras(
         delta_timestamps=dataset.delta_timestamps,
         tolerance_s=dataset.tolerance_s,
     )
+
+
+def _reject_merge_of_taccap_hardware_metadata(datasets: list[LeRobotDataset]) -> None:
+    """Refuse to merge datasets that carry a TacCap hardware manifest.
+
+    The other dataset operations derive one output from one input, so their
+    manifest carries over unchanged. Merging cannot: each input names its own
+    grippers and tactile serials for the same `observation_key`, and the merged
+    episodes interleave them. There is no single manifest that describes the
+    result.
+
+    Silently dropping it would be the worst outcome. The merged dataset would look
+    complete, and deriving tactile depth / force from it later would pick whatever
+    sensor happened to be guessed — which does not fail loudly, it reports
+    plausible values from the wrong calibration. Erroring costs the caller one
+    decision; the alternative costs data nobody can tell is wrong.
+
+    Merging these properly means expressing the result as an epoch sequence
+    (`epochs` in the manifest, one per input, remapped onto the merged episode
+    indices). That is a real feature, not a copy step, so it is left undone rather
+    than approximated.
+    """
+    with_manifest = [ds.repo_id for ds in datasets if (Path(ds.root) / TACCAP_HARDWARE_MANIFEST_PATH).is_file()]
+    if not with_manifest:
+        return
+    raise NotImplementedError(
+        f"Cannot merge datasets that carry {TACCAP_HARDWARE_MANIFEST_PATH}: {with_manifest}. "
+        "Each input maps the same observation keys to different physical sensors, and the merged "
+        "episodes interleave them, so no single manifest describes the result. Deriving tactile "
+        "channels against the wrong sensor's calibration does not fail loudly. Merge the datasets "
+        "manually, or extend the manifest to an epoch sequence covering the merged episode ranges."
+    )
+
+
+def _copy_taccap_local_metadata(src_root: Path, dst_root: Path) -> None:
+    """Carry TacCap's fork-local metadata into a derived dataset.
+
+    `LeRobotDatasetMetadata.create` builds a fresh standard metadata set
+    (`info.json`, `tasks.parquet`, `stats.json`, `episodes/*`), and the copy
+    helpers above move only data, videos and episode metadata. Anything this fork
+    adds under `meta/` is therefore dropped unless copied here.
+
+    Two things live there and both matter:
+
+    * `meta/hardware.json` maps each tactile `observation_key` to the **physical
+      sensor serial** that produced it.
+    * `meta/runtimes/*.bin` holds those sensors' calibration bundles.
+
+    Losing them is not a cosmetic regression. Deriving depth / force / difference
+    from a tactile stream needs that sensor's own calibration, and solving a
+    stream against **another** unit's bundle does not fail loudly — measured on
+    untouched gels it inflates `Depth` by ~800x and `ForceResultant` by ~1000x
+    while reporting no error at all. A converted dataset that lost its manifest
+    cannot be reconstructed from the dataset alone; the mapping only exists in
+    whatever record the capture side kept.
+
+    Copies verbatim. The 8-to-6 conversion only removes headset cameras, and the
+    manifest names no cameras — only grippers and tactile sensors — so there is
+    nothing in it to prune.
+    """
+    src_root, dst_root = Path(src_root), Path(dst_root)
+    for relative in (TACCAP_HARDWARE_MANIFEST_PATH, TACCAP_RUNTIME_DIR):
+        src = src_root / relative
+        if not src.exists():
+            continue
+        dst = dst_root / relative
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if src.is_dir():
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+        else:
+            shutil.copy2(src, dst)
+        logging.info(f"Carried {relative} into {dst_root}")
 
 
 def _copy_data_with_feature_changes_and_vector_indices(
@@ -2007,6 +2090,8 @@ def convert_image_to_video_dataset(
 
     logging.info(f"Completed converting {dataset.repo_id} to video format")
     logging.info(f"New dataset saved to: {output_dir}")
+
+    _copy_taccap_local_metadata(dataset.meta.root, output_dir)
 
     # Return new dataset
     return LeRobotDataset(repo_id=repo_id, root=output_dir)

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -23,6 +23,7 @@ This module provides utilities for:
 - Merging datasets (wrapper around aggregate functionality)
 """
 
+import copy
 import logging
 import shutil
 from collections.abc import Callable
@@ -54,6 +55,28 @@ from lerobot.datasets.utils import (
 )
 from lerobot.datasets.video_utils import encode_video_frames, get_video_info
 from lerobot.utils.constants import HF_LEROBOT_HOME, OBS_IMAGE
+
+TACCAP_6_CAMERA_FEATURE_KEYS = frozenset(
+    {
+        "observation.images.left_tactile_left",
+        "observation.images.left_tactile_right",
+        "observation.images.right_tactile_left",
+        "observation.images.right_tactile_right",
+        "observation.images.left_wrist",
+        "observation.images.right_wrist",
+    }
+)
+
+TACCAP_HEAD_CAMERA_FEATURE_KEYS = frozenset(
+    {
+        "observation.images.left_head",
+        "observation.images.right_head",
+    }
+)
+
+TACCAP_8_CAMERA_FEATURE_KEYS = TACCAP_6_CAMERA_FEATURE_KEYS | TACCAP_HEAD_CAMERA_FEATURE_KEYS
+
+HEAD_CAMERA_STATE_NAME_PREFIX = "head_camera."
 
 
 def _load_episode_with_stats(src_dataset: LeRobotDataset, episode_idx: int) -> dict:
@@ -438,6 +461,233 @@ def remove_feature(
         output_dir=output_dir,
         repo_id=repo_id,
     )
+
+
+def convert_8_to_6_cameras(
+    dataset: LeRobotDataset,
+    output_dir: str | Path | None = None,
+    repo_id: str | None = None,
+) -> LeRobotDataset:
+    """Convert a bimanual TacCap 8-camera dataset to the 6-camera format.
+
+    The 8-camera format consists of the six bimanual cameras (four tactile pads
+    and two wrist cameras) plus the two Pico headset eyes. This conversion drops
+    the headset image keys and the ``head_camera.*`` dimensions from
+    ``action``/``observation.state``, so downstream training sees the same schema
+    as a bimanual recording made with ``enable_head_camera=false``.
+
+    Args:
+        dataset: The source LeRobotDataset.
+        output_dir: Root directory where the edited dataset will be stored. If
+            not specified, defaults to $HF_LEROBOT_HOME/repo_id.
+        repo_id: Edited dataset identifier. If not specified, defaults to
+            ``{dataset.repo_id}_6cameras``.
+
+    Returns:
+        New dataset with the 6-camera format.
+    """
+    camera_keys = set(dataset.meta.camera_keys)
+    missing_six_camera_keys = TACCAP_6_CAMERA_FEATURE_KEYS - camera_keys
+    missing_head_camera_keys = TACCAP_HEAD_CAMERA_FEATURE_KEYS - camera_keys
+    extra_camera_keys = camera_keys - TACCAP_8_CAMERA_FEATURE_KEYS
+
+    if missing_six_camera_keys:
+        raise ValueError(
+            "Source dataset is missing required 6-camera keys: "
+            f"{sorted(missing_six_camera_keys)}. Camera keys: {sorted(camera_keys)}"
+        )
+    if missing_head_camera_keys:
+        raise ValueError(
+            "Source dataset is already in 6-camera format or does not contain the expected head cameras: "
+            f"missing {sorted(missing_head_camera_keys)}. Camera keys: {sorted(camera_keys)}"
+        )
+    if extra_camera_keys:
+        raise ValueError(
+            "Source dataset contains unexpected camera keys; refusing to convert to avoid schema confusion: "
+            f"{sorted(extra_camera_keys)}"
+        )
+
+    new_features = copy.deepcopy(dataset.meta.features)
+    for key in TACCAP_HEAD_CAMERA_FEATURE_KEYS:
+        new_features.pop(key, None)
+
+    vector_keep_indices: dict[str, list[int]] = {}
+    for feature_key in ("action", "observation.state"):
+        ft = new_features.get(feature_key)
+        if not isinstance(ft, dict) or ft.get("names") is None:
+            continue
+
+        names = list(ft["names"])
+        keep_indices = [
+            i for i, name in enumerate(names) if not str(name).startswith(HEAD_CAMERA_STATE_NAME_PREFIX)
+        ]
+        if len(keep_indices) == len(names):
+            continue
+        if not keep_indices:
+            raise ValueError(
+                f"Cannot convert {feature_key}: every dimension is a head_camera dimension. "
+                "Leaving no state/action dimensions would invalidate the dataset."
+            )
+
+        vector_keep_indices[feature_key] = keep_indices
+        new_features[feature_key] = {
+            **ft,
+            "shape": (len(keep_indices),),
+            "names": [names[i] for i in keep_indices],
+        }
+
+    missing_vector_names = [
+        feature_key
+        for feature_key in ("action", "observation.state")
+        if feature_key in new_features and new_features[feature_key].get("names") is None
+    ]
+    if missing_vector_names:
+        raise ValueError(
+            "Cannot safely convert head cameras from datasets without vector feature names: "
+            f"{missing_vector_names}. TacCap datasets store the raw state/action names in "
+            "`action`/`observation.state` feature metadata."
+        )
+
+    if repo_id is None:
+        repo_id = f"{dataset.repo_id}_6cameras"
+    output_dir = Path(output_dir) if output_dir is not None else HF_LEROBOT_HOME / repo_id
+
+    remaining_video_keys = [key for key, ft in new_features.items() if ft["dtype"] == "video"]
+    new_meta = LeRobotDatasetMetadata.create(
+        repo_id=repo_id,
+        fps=dataset.meta.fps,
+        features=new_features,
+        robot_type=dataset.meta.robot_type,
+        root=output_dir,
+        use_videos=len(remaining_video_keys) > 0,
+        chunks_size=dataset.meta.chunks_size,
+        data_files_size_in_mb=dataset.meta.data_files_size_in_mb,
+        video_files_size_in_mb=dataset.meta.video_files_size_in_mb,
+    )
+
+    _copy_data_with_feature_changes_and_vector_indices(
+        dataset=dataset,
+        new_meta=new_meta,
+        remove_features=list(TACCAP_HEAD_CAMERA_FEATURE_KEYS),
+        vector_keep_indices=vector_keep_indices,
+    )
+    if dataset.meta.episodes is None:
+        dataset.meta.episodes = load_episodes(dataset.meta.root)
+    _copy_videos(dataset, new_meta, exclude_keys=list(TACCAP_HEAD_CAMERA_FEATURE_KEYS))
+    _copy_episodes_metadata_and_stats(dataset, new_meta)
+    _update_episodes_metadata_after_camera_conversion(
+        dst_meta=new_meta,
+        remove_feature_keys=list(TACCAP_HEAD_CAMERA_FEATURE_KEYS),
+        vector_keep_indices=vector_keep_indices,
+    )
+    _update_stats_after_camera_conversion(dataset, new_meta, vector_keep_indices)
+
+    return LeRobotDataset(
+        repo_id=repo_id,
+        root=output_dir,
+        image_transforms=dataset.image_transforms,
+        delta_timestamps=dataset.delta_timestamps,
+        tolerance_s=dataset.tolerance_s,
+    )
+
+
+def _copy_data_with_feature_changes_and_vector_indices(
+    dataset: LeRobotDataset,
+    new_meta: LeRobotDatasetMetadata,
+    remove_features: list[str] | None = None,
+    vector_keep_indices: dict[str, list[int]] | None = None,
+) -> None:
+    """Copy data files, dropping features and narrowing named vector columns."""
+    remove_features = remove_features or []
+    vector_keep_indices = vector_keep_indices or {}
+
+    data_dir = dataset.root / DATA_DIR
+    parquet_files = sorted(data_dir.glob("*/*.parquet"))
+    if not parquet_files:
+        raise ValueError(f"No parquet files found in {data_dir}")
+
+    for src_path in tqdm(parquet_files, desc="Processing data files"):
+        df = pd.read_parquet(src_path).reset_index(drop=True)
+
+        if remove_features:
+            df = df.drop(columns=remove_features, errors="ignore")
+
+        for feature_key, keep_indices in vector_keep_indices.items():
+            if feature_key not in df.columns:
+                continue
+            sliced_values = []
+            for value in df[feature_key]:
+                arr = np.asarray(value, dtype=np.float32)
+                if arr.ndim == 0:
+                    arr = arr.reshape(1)
+                sliced_values.append(arr[keep_indices])
+            df[feature_key] = sliced_values
+
+        relative_path = src_path.relative_to(dataset.root)
+        chunk_dir = relative_path.parts[1]
+        file_name = relative_path.parts[2]
+        chunk_idx = int(chunk_dir.split("-")[1])
+        file_idx = int(file_name.split("-")[1].split(".")[0])
+
+        dst_path = new_meta.root / DEFAULT_DATA_PATH.format(chunk_index=chunk_idx, file_index=file_idx)
+        dst_path.parent.mkdir(parents=True, exist_ok=True)
+        _write_parquet(df, dst_path, new_meta)
+
+
+def _update_episodes_metadata_after_camera_conversion(
+    dst_meta: LeRobotDatasetMetadata,
+    remove_feature_keys: list[str],
+    vector_keep_indices: dict[str, list[int]],
+) -> None:
+    """Drop removed camera columns and narrow vector stats in episode metadata."""
+    episodes_dir = dst_meta.root / "meta/episodes"
+    parquet_files = sorted(episodes_dir.glob("*/*.parquet")) if episodes_dir.exists() else []
+
+    for path in parquet_files:
+        df = pd.read_parquet(path)
+        columns_to_drop = []
+        for feature_key in remove_feature_keys:
+            columns_to_drop.extend(
+                col
+                for col in df.columns
+                if col.startswith(f"videos/{feature_key}/") or col.startswith(f"stats/{feature_key}/")
+            )
+        if columns_to_drop:
+            df = df.drop(columns=columns_to_drop, errors="ignore")
+
+        for feature_key, keep_indices in vector_keep_indices.items():
+            prefix = f"stats/{feature_key}/"
+            for col in df.columns:
+                if not col.startswith(prefix) or col.rsplit("/", 1)[-1] == "count":
+                    continue
+                df[col] = df[col].map(lambda value: np.asarray(value)[keep_indices])
+
+        df.to_parquet(path)
+
+
+def _update_stats_after_camera_conversion(
+    dataset: LeRobotDataset,
+    dst_meta: LeRobotDatasetMetadata,
+    vector_keep_indices: dict[str, list[int]],
+) -> None:
+    """Write top-level stats after dropping head cameras and state dimensions."""
+    source_stats = dataset.meta.stats or {}
+    new_stats = {}
+
+    for feature_key in dst_meta.features:
+        stats = source_stats.get(feature_key)
+        if stats is None:
+            continue
+        if feature_key in vector_keep_indices:
+            keep_indices = vector_keep_indices[feature_key]
+            stats = {
+                stat: value if stat == "count" else np.asarray(value)[keep_indices]
+                for stat, value in stats.items()
+            }
+        new_stats[feature_key] = stats
+
+    dst_meta.stats = new_stats
+    write_stats(new_stats, dst_meta.root)
 
 
 def _fractions_to_episode_indices(

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -518,9 +518,7 @@ def convert_8_to_6_cameras(
             continue
 
         names = list(ft["names"])
-        keep_indices = [
-            i for i, name in enumerate(names) if not str(name).startswith(HEAD_CAMERA_STATE_NAME_PREFIX)
-        ]
+        keep_indices = [i for i, name in enumerate(names) if not str(name).startswith(HEAD_CAMERA_STATE_NAME_PREFIX)]
         if len(keep_indices) == len(names):
             continue
         if not keep_indices:
@@ -660,7 +658,7 @@ def _update_episodes_metadata_after_camera_conversion(
             for col in df.columns:
                 if not col.startswith(prefix) or col.rsplit("/", 1)[-1] == "count":
                     continue
-                df[col] = df[col].map(lambda value: np.asarray(value)[keep_indices])
+                df[col] = df[col].map(lambda value, keep_indices=keep_indices: np.asarray(value)[keep_indices])
 
         df.to_parquet(path)
 
@@ -681,8 +679,7 @@ def _update_stats_after_camera_conversion(
         if feature_key in vector_keep_indices:
             keep_indices = vector_keep_indices[feature_key]
             stats = {
-                stat: value if stat == "count" else np.asarray(value)[keep_indices]
-                for stat, value in stats.items()
+                stat: value if stat == "count" else np.asarray(value)[keep_indices] for stat, value in stats.items()
             }
         new_stats[feature_key] = stats
 

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -40,6 +40,7 @@ import numpy as np
 
 from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
 from lerobot.cameras.xense.configuration_xense import XenseTactileCameraConfig
+from lerobot.utils.constants import TACCAP_HARDWARE_MANIFEST_PATH, TACCAP_RUNTIME_DIR
 
 # 6D rotation convention (matches ``vive_tracker``): r1..r3 is the first column
 # of the rotation matrix, r4..r6 the second. Position first, so the tuple is the
@@ -783,7 +784,7 @@ def validate_robot_id(robot_id: str | None, robot_type: str) -> str:
 
 # ------------------------------------------------------------ hardware manifest
 
-HARDWARE_MANIFEST_PATH = "meta/hardware.json"
+HARDWARE_MANIFEST_PATH = TACCAP_HARDWARE_MANIFEST_PATH
 """Where a recorded dataset keeps its TacCap hardware manifest, relative to the
 dataset root.
 
@@ -914,7 +915,7 @@ def epoch_for_episode(manifest: dict[str, Any], episode_index: int) -> dict[str,
     return None
 
 
-RUNTIME_DIR = "meta/runtimes"
+RUNTIME_DIR = TACCAP_RUNTIME_DIR
 """Where a dataset keeps the tactile runtime bundles its episodes need.
 
 Rebuilding depth / force / difference from the recorded ``rectify`` stream needs

--- a/src/lerobot/scripts/lerobot_check_dataset.py
+++ b/src/lerobot/scripts/lerobot_check_dataset.py
@@ -520,23 +520,14 @@ def classify_camera_format(info: dict) -> tuple[str | None, list[str], list[str]
         ft = features.get(feature_key)
         names = ft.get("names") if isinstance(ft, dict) else None
         if names is None:
-            warnings.append(
-                f"{feature_key} has no feature names; cannot verify head_camera dimensions"
-            )
+            warnings.append(f"{feature_key} has no feature names; cannot verify head_camera dimensions")
             continue
 
-        head_camera_dims = [
-            name for name in names if str(name).startswith(HEAD_CAMERA_STATE_NAME_PREFIX)
-        ]
+        head_camera_dims = [name for name in names if str(name).startswith(HEAD_CAMERA_STATE_NAME_PREFIX)]
         if camera_format == "6" and head_camera_dims:
-            errors.append(
-                f"6-camera dataset must not contain {feature_key} head_camera dims: "
-                f"{head_camera_dims}"
-            )
+            errors.append(f"6-camera dataset must not contain {feature_key} head_camera dims: {head_camera_dims}")
         if camera_format == "8" and not head_camera_dims:
-            errors.append(
-                f"8-camera dataset must contain {feature_key} head_camera dims"
-            )
+            errors.append(f"8-camera dataset must contain {feature_key} head_camera dims")
 
     return camera_format, errors, warnings
 

--- a/src/lerobot/scripts/lerobot_check_dataset.py
+++ b/src/lerobot/scripts/lerobot_check_dataset.py
@@ -23,6 +23,7 @@ Verifies:
   - episodes metadata matches info.json episode count
   - data parquet files: row count, index continuity, frame_index continuity, NaN check
   - video files: existence, frame count alignment with parquet, fps, resolution
+  - camera format: TacCap 6-camera (no headset) vs 8-camera (headset)
 
 Examples:
 
@@ -46,6 +47,11 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from lerobot.datasets.dataset_tools import (
+    HEAD_CAMERA_STATE_NAME_PREFIX,
+    TACCAP_6_CAMERA_FEATURE_KEYS,
+    TACCAP_8_CAMERA_FEATURE_KEYS,
+)
 from lerobot.utils.constants import HF_LEROBOT_HOME
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -479,6 +485,82 @@ def check_videos(
             )
 
 
+def classify_camera_format(info: dict) -> tuple[str | None, list[str], list[str]]:
+    """Classify a dataset as TacCap 6-camera or 8-camera format.
+
+    Returns:
+        Tuple of (camera format, errors, warnings). ``camera format`` is
+        ``"6"``, ``"8"``, or ``None`` when the camera keys do not match either
+        known TacCap schema.
+    """
+    features = info.get("features", {})
+    camera_keys = {key for key, ft in features.items() if ft.get("dtype") in ("video", "image")}
+
+    if camera_keys == TACCAP_6_CAMERA_FEATURE_KEYS:
+        camera_format = "6"
+    elif camera_keys == TACCAP_8_CAMERA_FEATURE_KEYS:
+        camera_format = "8"
+    else:
+        missing_six = sorted(TACCAP_6_CAMERA_FEATURE_KEYS - camera_keys)
+        missing_head = sorted(TACCAP_8_CAMERA_FEATURE_KEYS - camera_keys)
+        extra = sorted(camera_keys - TACCAP_8_CAMERA_FEATURE_KEYS)
+        return (
+            None,
+            [],
+            [
+                "Camera keys do not match the TacCap 6-camera or 8-camera format "
+                f"(missing 6-camera keys: {missing_six}, missing 8-camera keys: {missing_head}, "
+                f"unexpected keys: {extra})"
+            ],
+        )
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    for feature_key in ("action", "observation.state"):
+        ft = features.get(feature_key)
+        names = ft.get("names") if isinstance(ft, dict) else None
+        if names is None:
+            warnings.append(
+                f"{feature_key} has no feature names; cannot verify head_camera dimensions"
+            )
+            continue
+
+        head_camera_dims = [
+            name for name in names if str(name).startswith(HEAD_CAMERA_STATE_NAME_PREFIX)
+        ]
+        if camera_format == "6" and head_camera_dims:
+            errors.append(
+                f"6-camera dataset must not contain {feature_key} head_camera dims: "
+                f"{head_camera_dims}"
+            )
+        if camera_format == "8" and not head_camera_dims:
+            errors.append(
+                f"8-camera dataset must contain {feature_key} head_camera dims"
+            )
+
+    return camera_format, errors, warnings
+
+
+def check_camera_format(info: dict, errors: list, warnings: list) -> str | None:
+    """Log the TacCap camera format and add any schema consistency issues."""
+    logger.info("\n[camera format]")
+    camera_format, format_errors, format_warnings = classify_camera_format(info)
+
+    if camera_format == "6":
+        logger.info("  %s Camera format: 6-camera (no headset)", PASS)
+    elif camera_format == "8":
+        logger.info("  %s Camera format: 8-camera (headset)", PASS)
+
+    errors.extend(format_errors)
+    warnings.extend(format_warnings)
+    for issue in format_errors:
+        logger.warning("  %s %s", FAIL, issue)
+    for issue in format_warnings:
+        logger.warning("  %s %s", WARN, issue)
+
+    return camera_format
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -544,10 +626,20 @@ def main() -> None:
     data_df = check_data(dataset_root, info, episode_indices, errors, warnings)
     if not data_df.empty:
         check_videos(dataset_root, info, data_df, episode_indices, errors, warnings)
+    camera_format = check_camera_format(info, errors, warnings)
 
     # Summary
+    camera_format_label = {
+        "6": "6-camera (no headset)",
+        "8": "8-camera (headset)",
+    }.get(camera_format, "not recognized")
     logger.info("\n" + "=" * 60)
-    logger.info("Summary: %d error(s), %d warning(s)", len(errors), len(warnings))
+    logger.info(
+        "Summary: %d error(s), %d warning(s) | Camera format: %s",
+        len(errors),
+        len(warnings),
+        camera_format_label,
+    )
     if errors:
         logger.info("\nErrors:")
         for e in errors:

--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -98,6 +98,12 @@ Remove camera feature:
         --operation.type remove_feature \
         --operation.feature_names "['observation.image']"
 
+Convert a bimanual TacCap 8-camera dataset to the 6-camera format:
+    lerobot-edit-dataset \
+        --repo_id Xense/taccap_8cam \
+        --new_repo_id Xense/taccap_6cam \
+        --operation.type convert_8_to_6_cameras
+
 Modify tasks - set a single task for all episodes (WARNING: modifies in-place):
     lerobot-edit-dataset \
         --repo_id lerobot/pusht \
@@ -165,6 +171,7 @@ import draccus
 from lerobot.configs import parser
 from lerobot.datasets.dataset_tools import (
     convert_image_to_video_dataset,
+    convert_8_to_6_cameras,
     delete_episodes,
     merge_datasets,
     modify_tasks,
@@ -206,6 +213,12 @@ class MergeConfig(OperationConfig):
 @dataclass
 class RemoveFeatureConfig(OperationConfig):
     feature_names: list[str] | None = None
+
+
+@OperationConfig.register_subclass("convert_8_to_6_cameras")
+@dataclass
+class Convert8To6CamerasConfig(OperationConfig):
+    pass
 
 
 @OperationConfig.register_subclass("modify_tasks")
@@ -415,6 +428,38 @@ def handle_remove_feature(cfg: EditDatasetConfig) -> None:
         LeRobotDataset(output_repo_id, root=output_dir).push_to_hub()
 
 
+def handle_convert_8_to_6_cameras(cfg: EditDatasetConfig) -> None:
+    if not isinstance(cfg.operation, Convert8To6CamerasConfig):
+        raise ValueError("Operation config must be Convert8To6CamerasConfig")
+
+    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
+    output_repo_id, output_dir = get_output_path(
+        cfg.repo_id,
+        new_repo_id=cfg.new_repo_id,
+        root=cfg.root,
+        new_root=cfg.new_root,
+    )
+
+    # In case of in-place modification, make the dataset point to the backup directory
+    if output_dir == dataset.root:
+        dataset.root = dataset.root.with_name(dataset.root.name + "_old")
+
+    logging.info(f"Converting {cfg.repo_id} from 8 cameras to 6 cameras")
+    new_dataset = convert_8_to_6_cameras(
+        dataset,
+        output_dir=output_dir,
+        repo_id=output_repo_id,
+    )
+
+    logging.info(f"Dataset saved to {output_dir}")
+    logging.info(f"Episodes: {new_dataset.meta.total_episodes}, Frames: {new_dataset.meta.total_frames}")
+    logging.info(f"Camera keys: {new_dataset.meta.camera_keys}")
+
+    if cfg.push_to_hub:
+        logging.info(f"Pushing to hub as {output_repo_id}")
+        LeRobotDataset(output_repo_id, root=output_dir).push_to_hub()
+
+
 def handle_modify_tasks(cfg: EditDatasetConfig) -> None:
     if not isinstance(cfg.operation, ModifyTasksConfig):
         raise ValueError("Operation config must be ModifyTasksConfig")
@@ -582,6 +627,8 @@ def edit_dataset(cfg: EditDatasetConfig) -> None:
         handle_merge(cfg)
     elif operation_type == "remove_feature":
         handle_remove_feature(cfg)
+    elif operation_type == "convert_8_to_6_cameras":
+        handle_convert_8_to_6_cameras(cfg)
     elif operation_type == "modify_tasks":
         handle_modify_tasks(cfg)
     elif operation_type == "convert_image_to_video":

--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -170,8 +170,8 @@ import draccus
 
 from lerobot.configs import parser
 from lerobot.datasets.dataset_tools import (
-    convert_image_to_video_dataset,
     convert_8_to_6_cameras,
+    convert_image_to_video_dataset,
     delete_episodes,
     merge_datasets,
     modify_tasks,

--- a/src/lerobot/utils/constants.py
+++ b/src/lerobot/utils/constants.py
@@ -89,3 +89,14 @@ LIBERO_KEY_JOINTS_POS = "robot_state/joints/pos"
 LIBERO_KEY_JOINTS_VEL = "robot_state/joints/vel"
 LIBERO_KEY_PIXELS_AGENTVIEW = "pixels/agentview_image"
 LIBERO_KEY_PIXELS_EYE_IN_HAND = "pixels/robot0_eye_in_hand_image"
+
+# TacCap fork-local dataset metadata. `LeRobotDatasetMetadata.create` does not
+# produce these and no upstream copy step carries them over, so **every operation
+# that derives a new dataset must copy them explicitly** — see
+# `lerobot.datasets.dataset_tools._copy_taccap_local_metadata`.
+#
+# They live here rather than in `robots/taccap_gripper/common.py` so that
+# `datasets/` can name them without importing `robots/` (which would invert the
+# dependency direction). `common.py` re-exports them for its existing callers.
+TACCAP_HARDWARE_MANIFEST_PATH = "meta/hardware.json"
+TACCAP_RUNTIME_DIR = "meta/runtimes"

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 """Tests for dataset tools utilities."""
 
+import json
+from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
@@ -32,6 +34,7 @@ from lerobot.datasets.dataset_tools import (
     split_dataset,
 )
 from lerobot.scripts.lerobot_edit_dataset import convert_image_to_video_dataset
+from lerobot.utils.constants import TACCAP_HARDWARE_MANIFEST_PATH, TACCAP_RUNTIME_DIR
 
 
 def _taccap_8_camera_features() -> dict:
@@ -670,6 +673,61 @@ def test_convert_8_to_6_cameras(empty_lerobot_dataset_factory, tmp_path):
     assert converted.meta.stats["observation.state"]["mean"].shape == (20,)
     assert not any("left_head" in key or "right_head" in key for key in converted.meta.episodes.features)
     assert converted.meta.total_episodes == 2
+
+
+def test_convert_8_to_6_cameras_keeps_the_taccap_hardware_metadata(empty_lerobot_dataset_factory, tmp_path):
+    """End-to-end: the sensor manifest and runtime bundles survive a real conversion.
+
+    Checked here rather than only on the copy helper because the loss was never in
+    the helper — it was that no one called it. `LeRobotDatasetMetadata.create`
+    builds a fresh standard metadata set, so this fork's `meta/` additions vanish
+    unless the conversion carries them, and nothing about the converted dataset
+    looks wrong afterwards. Re-deriving tactile depth/force against another unit's
+    calibration reports plausible values instead of failing.
+    """
+    features = _taccap_8_camera_features()
+    all_camera_keys = [key for key, ft in features.items() if ft["dtype"] == "image"]
+
+    dataset = empty_lerobot_dataset_factory(root=tmp_path / "source_8cam", features=features, use_videos=False)
+    for ep_idx in range(2):
+        for _ in range(3):
+            state = np.arange(features["action"]["shape"][0], dtype=np.float32) + ep_idx * 10
+            dataset.add_frame(
+                {
+                    "action": state + 0.5,
+                    "observation.state": state,
+                    "task": "pick",
+                    **{k: np.zeros((4, 6, 3), dtype=np.uint8) for k in all_camera_keys},
+                }
+            )
+        dataset.save_episode()
+    dataset.finalize()
+
+    manifest = json.dumps(
+        {
+            "robot_type": "bi_taccap_gripper",
+            "units": [
+                {
+                    "side": "left",
+                    "gripper_sn": "TCGU01A28Z0033m",
+                    "tactile_sensors": [{"observation_key": "left_tactile_left", "serial": "GSPS01A29Z0017"}],
+                }
+            ],
+        }
+    )
+    (dataset.meta.root / TACCAP_HARDWARE_MANIFEST_PATH).write_text(manifest)
+    bundle = dataset.meta.root / TACCAP_RUNTIME_DIR / "GSPS01A29Z0017-20260824T101500.bin"
+    bundle.parent.mkdir(parents=True, exist_ok=True)
+    bundle.write_bytes(b"encrypted-runtime-bundle")
+
+    converted = convert_8_to_6_cameras(dataset, output_dir=tmp_path / "converted_6cam", repo_id="test/6cam_hw")
+
+    out = Path(converted.meta.root)
+    assert (out / TACCAP_HARDWARE_MANIFEST_PATH).read_text() == manifest
+    assert (out / TACCAP_RUNTIME_DIR / bundle.name).read_bytes() == b"encrypted-runtime-bundle"
+    # The manifest names sensors, not cameras — a head-camera removal must not
+    # rewrite it, so it has to come through byte-identical.
+    assert "GSPS01A29Z0017" in (out / TACCAP_HARDWARE_MANIFEST_PATH).read_text()
     assert converted.meta.total_frames == 6
 
 

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -23,6 +23,7 @@ import torch
 
 from lerobot.datasets.dataset_tools import (
     add_features,
+    convert_8_to_6_cameras,
     delete_episodes,
     merge_datasets,
     modify_features,
@@ -31,6 +32,39 @@ from lerobot.datasets.dataset_tools import (
     split_dataset,
 )
 from lerobot.scripts.lerobot_edit_dataset import convert_image_to_video_dataset
+
+
+def _taccap_8_camera_features() -> dict:
+    six_camera_keys = [
+        "observation.images.left_tactile_left",
+        "observation.images.left_tactile_right",
+        "observation.images.right_tactile_left",
+        "observation.images.right_tactile_right",
+        "observation.images.left_wrist",
+        "observation.images.right_wrist",
+    ]
+    head_camera_keys = [
+        "observation.images.left_head",
+        "observation.images.right_head",
+    ]
+
+    state_names = []
+    for side in ("left", "right"):
+        state_names.extend(
+            f"{side}_tcp.{key}" for key in ("x", "y", "z", "r1", "r2", "r3", "r4", "r5", "r6")
+        )
+    state_names.extend(["left_gripper.pos", "right_gripper.pos"])
+    state_names.extend(f"head_camera.{key}" for key in ("x", "y", "z", "r1", "r2", "r3", "r4", "r5", "r6"))
+
+    features = {
+        "action": {"dtype": "float32", "shape": (len(state_names),), "names": state_names},
+        "observation.state": {"dtype": "float32", "shape": (len(state_names),), "names": state_names},
+        **{
+            key: {"dtype": "image", "shape": (4, 6, 3), "names": ["height", "width", "channels"]}
+            for key in six_camera_keys + head_camera_keys
+        },
+    }
+    return features
 
 
 @pytest.fixture
@@ -591,6 +625,59 @@ def test_remove_camera_feature(sample_dataset, tmp_path):
 
     sample_item = dataset_without_camera[0]
     assert camera_to_remove not in sample_item
+
+
+def test_convert_8_to_6_cameras(empty_lerobot_dataset_factory, tmp_path):
+    """Test converting an 8-camera bimanual TacCap dataset to 6-camera format."""
+    features = _taccap_8_camera_features()
+    all_camera_keys = [
+        key for key, ft in features.items() if ft["dtype"] == "image"
+    ]
+
+    dataset = empty_lerobot_dataset_factory(
+        root=tmp_path / "source_8cam",
+        features=features,
+        use_videos=False,
+    )
+    for ep_idx in range(2):
+        for frame_idx in range(3):
+            state = np.arange(features["action"]["shape"][0], dtype=np.float32) + ep_idx * 10
+            frame = {
+                "action": state + 0.5,
+                "observation.state": state,
+                "task": "pick",
+                **{
+                    key: np.zeros((4, 6, 3), dtype=np.uint8) + ep_idx + frame_idx
+                    for key in all_camera_keys
+                },
+            }
+            dataset.add_frame(frame)
+        dataset.save_episode()
+    dataset.finalize()
+
+    converted = convert_8_to_6_cameras(
+        dataset,
+        output_dir=tmp_path / "converted_6cam",
+        repo_id="test/6cam",
+    )
+
+    expected_camera_keys = {
+        "observation.images.left_tactile_left",
+        "observation.images.left_tactile_right",
+        "observation.images.right_tactile_left",
+        "observation.images.right_tactile_right",
+        "observation.images.left_wrist",
+        "observation.images.right_wrist",
+    }
+    assert set(converted.meta.camera_keys) == expected_camera_keys
+    assert converted.meta.features["action"]["shape"] == (20,)
+    assert converted.meta.features["observation.state"]["shape"] == (20,)
+    assert not any(name.startswith("head_camera.") for name in converted.meta.features["action"]["names"])
+    assert converted.meta.stats["action"]["mean"].shape == (20,)
+    assert converted.meta.stats["observation.state"]["mean"].shape == (20,)
+    assert not any("left_head" in key or "right_head" in key for key in converted.meta.episodes.features)
+    assert converted.meta.total_episodes == 2
+    assert converted.meta.total_frames == 6
 
 
 def test_complex_workflow_integration(sample_dataset, tmp_path):

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -50,9 +50,7 @@ def _taccap_8_camera_features() -> dict:
 
     state_names = []
     for side in ("left", "right"):
-        state_names.extend(
-            f"{side}_tcp.{key}" for key in ("x", "y", "z", "r1", "r2", "r3", "r4", "r5", "r6")
-        )
+        state_names.extend(f"{side}_tcp.{key}" for key in ("x", "y", "z", "r1", "r2", "r3", "r4", "r5", "r6"))
     state_names.extend(["left_gripper.pos", "right_gripper.pos"])
     state_names.extend(f"head_camera.{key}" for key in ("x", "y", "z", "r1", "r2", "r3", "r4", "r5", "r6"))
 
@@ -630,9 +628,7 @@ def test_remove_camera_feature(sample_dataset, tmp_path):
 def test_convert_8_to_6_cameras(empty_lerobot_dataset_factory, tmp_path):
     """Test converting an 8-camera bimanual TacCap dataset to 6-camera format."""
     features = _taccap_8_camera_features()
-    all_camera_keys = [
-        key for key, ft in features.items() if ft["dtype"] == "image"
-    ]
+    all_camera_keys = [key for key, ft in features.items() if ft["dtype"] == "image"]
 
     dataset = empty_lerobot_dataset_factory(
         root=tmp_path / "source_8cam",
@@ -646,10 +642,7 @@ def test_convert_8_to_6_cameras(empty_lerobot_dataset_factory, tmp_path):
                 "action": state + 0.5,
                 "observation.state": state,
                 "task": "pick",
-                **{
-                    key: np.zeros((4, 6, 3), dtype=np.uint8) + ep_idx + frame_idx
-                    for key in all_camera_keys
-                },
+                **{key: np.zeros((4, 6, 3), dtype=np.uint8) + ep_idx + frame_idx for key in all_camera_keys},
             }
             dataset.add_frame(frame)
         dataset.save_episode()

--- a/tests/datasets/test_taccap_local_metadata.py
+++ b/tests/datasets/test_taccap_local_metadata.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TacCap's fork-local `meta/` survives the operations that derive a dataset.
+
+`LeRobotDatasetMetadata.create` builds a fresh standard metadata set, so anything
+this fork adds under `meta/` is dropped unless a copy step carries it. That is not
+a cosmetic loss: `hardware.json` is the only record of which physical sensor fed
+which tactile stream, and solving a stream against another unit's calibration
+reports plausible depth and force rather than failing.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from lerobot.datasets.dataset_tools import (
+    _copy_taccap_local_metadata,
+    _reject_merge_of_taccap_hardware_metadata,
+)
+from lerobot.utils.constants import TACCAP_HARDWARE_MANIFEST_PATH, TACCAP_RUNTIME_DIR
+
+
+def make_source(root: Path, *, manifest: bool = True, runtimes: int = 0) -> Path:
+    (root / "meta").mkdir(parents=True, exist_ok=True)
+    if manifest:
+        (root / TACCAP_HARDWARE_MANIFEST_PATH).write_text('{"robot_type": "bi_taccap_gripper"}')
+    for i in range(runtimes):
+        bundle = root / TACCAP_RUNTIME_DIR / f"GSPS01A29Z{i:04d}-20260824T101500.bin"
+        bundle.parent.mkdir(parents=True, exist_ok=True)
+        bundle.write_bytes(b"runtime-%d" % i)
+    return root
+
+
+class TestCopy:
+    def test_the_manifest_survives(self, tmp_path):
+        src = make_source(tmp_path / "src")
+        dst = tmp_path / "dst"
+        _copy_taccap_local_metadata(src, dst)
+        assert (dst / TACCAP_HARDWARE_MANIFEST_PATH).read_text() == (src / TACCAP_HARDWARE_MANIFEST_PATH).read_text()
+
+    def test_the_runtime_bundles_survive(self, tmp_path):
+        """The manifest names the sensors; the bundles are what actually lets a
+        stream be re-solved. Carrying one without the other is half a record."""
+        src = make_source(tmp_path / "src", runtimes=3)
+        dst = tmp_path / "dst"
+        _copy_taccap_local_metadata(src, dst)
+        assert sorted(p.name for p in (dst / TACCAP_RUNTIME_DIR).iterdir()) == sorted(
+            p.name for p in (src / TACCAP_RUNTIME_DIR).iterdir()
+        )
+
+    def test_a_source_without_them_is_not_an_error(self, tmp_path):
+        """Upstream datasets have neither. The copy is additive, never required."""
+        src = make_source(tmp_path / "src", manifest=False)
+        dst = tmp_path / "dst"
+        _copy_taccap_local_metadata(src, dst)
+        assert not (dst / TACCAP_HARDWARE_MANIFEST_PATH).exists()
+
+    def test_it_does_not_clobber_unrelated_destination_files(self, tmp_path):
+        src = make_source(tmp_path / "src")
+        dst = tmp_path / "dst"
+        (dst / "meta").mkdir(parents=True)
+        (dst / "meta" / "info.json").write_text("{}")
+        _copy_taccap_local_metadata(src, dst)
+        assert (dst / "meta" / "info.json").read_text() == "{}"
+
+
+class TestMergeRefuses:
+    def fake(self, root: Path, repo_id: str, *, manifest: bool):
+        make_source(root, manifest=manifest)
+        return SimpleNamespace(root=root, repo_id=repo_id)
+
+    def test_merging_manifest_carrying_datasets_raises(self, tmp_path):
+        """Each input maps the same observation keys to different physical sensors
+        and the merged episodes interleave them, so no single manifest describes
+        the result. Dropping it silently would leave a dataset that looks complete
+        and derives tactile channels from the wrong calibration."""
+        datasets = [
+            self.fake(tmp_path / "a", "org/a", manifest=True),
+            self.fake(tmp_path / "b", "org/b", manifest=True),
+        ]
+        with pytest.raises(NotImplementedError) as e:
+            _reject_merge_of_taccap_hardware_metadata(datasets)
+        assert "org/a" in str(e.value) and "org/b" in str(e.value)
+
+    def test_one_carrier_is_enough_to_refuse(self, tmp_path):
+        """Merging a manifest-carrying dataset with one that has none is *more*
+        ambiguous, not less: the result would silently claim every episode came
+        from the sensors named in the only manifest present."""
+        datasets = [
+            self.fake(tmp_path / "a", "org/a", manifest=True),
+            self.fake(tmp_path / "b", "org/b", manifest=False),
+        ]
+        with pytest.raises(NotImplementedError):
+            _reject_merge_of_taccap_hardware_metadata(datasets)
+
+    def test_plain_upstream_datasets_still_merge(self, tmp_path):
+        datasets = [
+            self.fake(tmp_path / "a", "org/a", manifest=False),
+            self.fake(tmp_path / "b", "org/b", manifest=False),
+        ]
+        _reject_merge_of_taccap_hardware_metadata(datasets)  # 不抛即通过
+
+
+def test_every_derived_dataset_path_carries_the_metadata():
+    """A new operation that derives a dataset must call the copy helper. Without
+    this, adding one silently reintroduces the loss — which is invisible until
+    someone tries to re-derive tactile channels months later.
+    """
+    import inspect
+
+    from lerobot.datasets import dataset_tools
+
+    derives = [
+        "delete_episodes",
+        "split_dataset",
+        "modify_features",
+        "convert_8_to_6_cameras",
+        "convert_image_to_video_dataset",
+    ]
+    for name in derives:
+        source = inspect.getsource(getattr(dataset_tools, name))
+        assert "_copy_taccap_local_metadata" in source, f"{name} drops meta/hardware.json"
+
+    merge_source = inspect.getsource(dataset_tools.merge_datasets)
+    assert "_reject_merge_of_taccap_hardware_metadata" in merge_source

--- a/tests/scripts/test_check_dataset.py
+++ b/tests/scripts/test_check_dataset.py
@@ -24,9 +24,7 @@ from lerobot.scripts.lerobot_check_dataset import classify_camera_format
 def _state_names(head_camera_dims: bool) -> list[str]:
     names = []
     for side in ("left", "right"):
-        names.extend(
-            f"{side}_tcp.{key}" for key in ("x", "y", "z", "r1", "r2", "r3", "r4", "r5", "r6")
-        )
+        names.extend(f"{side}_tcp.{key}" for key in ("x", "y", "z", "r1", "r2", "r3", "r4", "r5", "r6"))
     names.extend(["left_gripper.pos", "right_gripper.pos"])
     if head_camera_dims:
         names.extend(f"head_camera.{key}" for key in ("x", "y", "z", "r1", "r2", "r3", "r4", "r5", "r6"))
@@ -62,9 +60,7 @@ def test_classify_6_camera_format():
 
 
 def test_classify_8_camera_format():
-    camera_format, errors, warnings = classify_camera_format(
-        _info(TACCAP_8_CAMERA_FEATURE_KEYS, head_camera_dims=True)
-    )
+    camera_format, errors, warnings = classify_camera_format(_info(TACCAP_8_CAMERA_FEATURE_KEYS, head_camera_dims=True))
     assert camera_format == "8"
     assert errors == []
     assert warnings == []
@@ -80,9 +76,7 @@ def test_classify_8_camera_missing_head_dims():
 
 
 def test_classify_6_camera_with_head_dims():
-    camera_format, errors, warnings = classify_camera_format(
-        _info(TACCAP_6_CAMERA_FEATURE_KEYS, head_camera_dims=True)
-    )
+    camera_format, errors, warnings = classify_camera_format(_info(TACCAP_6_CAMERA_FEATURE_KEYS, head_camera_dims=True))
     assert camera_format == "6"
     assert len(errors) == 2
     assert warnings == []
@@ -90,9 +84,7 @@ def test_classify_6_camera_with_head_dims():
 
 def test_classify_unknown_camera_format():
     camera_keys = TACCAP_6_CAMERA_FEATURE_KEYS | {"observation.images.extra"}
-    camera_format, errors, warnings = classify_camera_format(
-        _info(camera_keys, head_camera_dims=False)
-    )
+    camera_format, errors, warnings = classify_camera_format(_info(camera_keys, head_camera_dims=False))
     assert camera_format is None
     assert errors == []
     assert len(warnings) == 1

--- a/tests/scripts/test_check_dataset.py
+++ b/tests/scripts/test_check_dataset.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lerobot.datasets.dataset_tools import (
+    TACCAP_6_CAMERA_FEATURE_KEYS,
+    TACCAP_8_CAMERA_FEATURE_KEYS,
+)
+from lerobot.scripts.lerobot_check_dataset import classify_camera_format
+
+
+def _state_names(head_camera_dims: bool) -> list[str]:
+    names = []
+    for side in ("left", "right"):
+        names.extend(
+            f"{side}_tcp.{key}" for key in ("x", "y", "z", "r1", "r2", "r3", "r4", "r5", "r6")
+        )
+    names.extend(["left_gripper.pos", "right_gripper.pos"])
+    if head_camera_dims:
+        names.extend(f"head_camera.{key}" for key in ("x", "y", "z", "r1", "r2", "r3", "r4", "r5", "r6"))
+    return names
+
+
+def _info(camera_keys, head_camera_dims: bool) -> dict:
+    names = _state_names(head_camera_dims)
+    camera_features = {
+        key: {
+            "dtype": "video",
+            "shape": (4, 6, 3),
+            "names": ["height", "width", "channels"],
+        }
+        for key in camera_keys
+    }
+    return {
+        "features": {
+            "action": {"dtype": "float32", "shape": (len(names),), "names": names},
+            "observation.state": {"dtype": "float32", "shape": (len(names),), "names": names},
+            **camera_features,
+        }
+    }
+
+
+def test_classify_6_camera_format():
+    camera_format, errors, warnings = classify_camera_format(
+        _info(TACCAP_6_CAMERA_FEATURE_KEYS, head_camera_dims=False)
+    )
+    assert camera_format == "6"
+    assert errors == []
+    assert warnings == []
+
+
+def test_classify_8_camera_format():
+    camera_format, errors, warnings = classify_camera_format(
+        _info(TACCAP_8_CAMERA_FEATURE_KEYS, head_camera_dims=True)
+    )
+    assert camera_format == "8"
+    assert errors == []
+    assert warnings == []
+
+
+def test_classify_8_camera_missing_head_dims():
+    camera_format, errors, warnings = classify_camera_format(
+        _info(TACCAP_8_CAMERA_FEATURE_KEYS, head_camera_dims=False)
+    )
+    assert camera_format == "8"
+    assert len(errors) == 2
+    assert warnings == []
+
+
+def test_classify_6_camera_with_head_dims():
+    camera_format, errors, warnings = classify_camera_format(
+        _info(TACCAP_6_CAMERA_FEATURE_KEYS, head_camera_dims=True)
+    )
+    assert camera_format == "6"
+    assert len(errors) == 2
+    assert warnings == []
+
+
+def test_classify_unknown_camera_format():
+    camera_keys = TACCAP_6_CAMERA_FEATURE_KEYS | {"observation.images.extra"}
+    camera_format, errors, warnings = classify_camera_format(
+        _info(camera_keys, head_camera_dims=False)
+    )
+    assert camera_format is None
+    assert errors == []
+    assert len(warnings) == 1
+
+
+def test_classify_missing_vector_names():
+    info = _info(TACCAP_6_CAMERA_FEATURE_KEYS, head_camera_dims=False)
+    info["features"]["action"]["names"] = None
+    info["features"]["observation.state"]["names"] = None
+
+    camera_format, errors, warnings = classify_camera_format(info)
+    assert camera_format == "6"
+    assert errors == []
+    assert len(warnings) == 2

--- a/tests/scripts/test_edit_dataset_parsing.py
+++ b/tests/scripts/test_edit_dataset_parsing.py
@@ -18,6 +18,7 @@ import draccus
 import pytest
 
 from lerobot.scripts.lerobot_edit_dataset import (
+    Convert8To6CamerasConfig,
     ConvertImageToVideoConfig,
     DeleteEpisodesConfig,
     EditDatasetConfig,
@@ -46,6 +47,7 @@ class TestOperationTypeParsing:
             ("split", SplitConfig),
             ("merge", MergeConfig),
             ("remove_feature", RemoveFeatureConfig),
+            ("convert_8_to_6_cameras", Convert8To6CamerasConfig),
             ("modify_tasks", ModifyTasksConfig),
             ("convert_image_to_video", ConvertImageToVideoConfig),
             ("info", InfoConfig),
@@ -74,6 +76,7 @@ class TestOperationTypeParsing:
             ("split", SplitConfig),
             ("merge", MergeConfig),
             ("remove_feature", RemoveFeatureConfig),
+            ("convert_8_to_6_cameras", Convert8To6CamerasConfig),
             ("modify_tasks", ModifyTasksConfig),
             ("convert_image_to_video", ConvertImageToVideoConfig),
             ("info", InfoConfig),


### PR DESCRIPTION
把 [#47](https://github.com/Vertax42/xense-taccap-lerobot/pull/47) 的两个实质提交 cherry-pick 过来(跳过其中一对 `local_files_only` 的 add + revert —— 那是 #48 的内容混进来又撤掉的,净效果为零),并补上它开发时还不存在的一块。

## 前两个提交(来自 #47,作者 @dctx479)

- `lerobot-edit-dataset --operation.type convert_8_to_6_cameras`:把 8 相机数据集(4 触觉 + 2 wrist + **2 个 headset 眼**)转成 6 相机,同时从 `action` / `observation.state` 去掉 `head_camera.*` 维度。
- `lerobot-check-dataset` 增加格式分类(`6-camera` / `8-camera`)并校验 head 维度与相机键一致。

## 第三个提交:保留 TacCap 自有的 `meta/`

转换用 `LeRobotDatasetMetadata.create` 新建元数据,而上游的 copy 步骤只搬 data / videos / episodes / stats。于是这个 fork 加在 `meta/` 下的东西会被**静默丢掉**:

| | 作用 |
|---|---|
| `meta/hardware.json` | 每路触觉 `observation_key` → **物理传感器序列号** |
| `meta/runtimes/*.bin` | 那些传感器的标定 bundle |

**丢了不是外观问题。** 重建触觉的 depth / force / difference 需要该传感器**自己**的标定,而拿另一台的 bundle 去解**不会报错** —— 实测两台都无接触时,`Depth` 放大约 **800×**、`ForceResultant` 约 **1000×**,输出看着像真实接触。转换后的数据集丢了 manifest 就无法从数据集本身重建。

这两个文件是**后来才加进上游的**(`hardware.json` 2026-08-10、`runtimes/` 08-23),写转换时它们还不存在 —— 不是转换的疏忽,是时间差。

### 改法

- **常量移到 `lerobot/utils/constants.py`**,`common.py` 改为 re-export。放这里是为了让 `datasets/` 能引用而不必 import `robots/`(那会把依赖方向反过来),同时避免两处真源。
- **`_copy_taccap_local_metadata` 接在全部「一进一出」的派生路径上**:`delete_episodes` / `split_dataset` / `modify_features` / `convert_8_to_6_cameras` / `convert_image_to_video_dataset`。原样复制 —— manifest 里只有夹爪与触觉传感器,**不含任何相机引用**,8→6 只动 head,没有要裁剪的东西。
- **`merge_datasets` 明确 `raise NotImplementedError`。** 多进一出没法复制:每个输入把同样的 `observation_key` 映射到**不同的物理传感器**,而合并后的 episode 是交错的,不存在一份 manifest 能描述结果。静默丢弃是最坏的 —— 合出来的数据集看着完整,事后按错的标定解算又不报错。正解是把 manifest 扩成 **epoch 序列**(每个输入一段,重映射到合并后的 episode 区间),那是一个真功能而不是复制步骤,所以宁可不做也不糊弄。

## 测试

新增 8 条,其中一条是防回归的:用 `inspect` 检查每个派生函数的源码里确实调了 copy helper —— **将来新增一个操作却忘了接,会当场失败**,而不是等几个月后有人想重建触觉通道时才发现。

`tests/robots/ tests/datasets/ tests/scripts/` → **479 passed / 1 skipped**(main 基线 462),ruff + pyupgrade 干净。

## 关于 #47

建议 cherry-pick 后关闭 #47,并在那条 PR 下说明原因(内容已并入本 PR + 补了 `hardware.json` 那块)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)