### PR TITLE
feat(taccap)+perf(record): 数据集与工位绑定;Rerun 日志移出录制循环

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,34 @@ something different) plus `head_camera.*`, the headset pose.
   errors, deliberately — silent rescaling would change the recorded field of
   view without trace. Do not "fix" this with a resize.
 
+## Rerun logging is off the record loop — keep it there
+
+`log_rerun_data` runs on a worker thread owned by `RerunLogSink`
+(`utils/visualization_utils.py`); `lerobot_record` and `lerobot_teleoperate` call
+`submit()` and return. Inline it measured **27.2 ms/frame against a 24.1 ms
+viewer-off baseline** on a bimanual rig with the head camera (eight images), i.e.
+the ~3 ms that turned frames into `[slow_frame] ... overrun=` inside a 33.3 ms
+budget at 30 fps — which is how the data team ended up recording with
+`--display_data=false`. Off-loop it measures 24.1 ms, the baseline exactly.
+
+It works because rerun's Rust bindings **release the GIL** for the heavy part of
+`rr.log`, and on Linux `busy_wait` is `time.sleep`, so the worker runs inside the
+window the loop is idle anyway. Both halves matter: a pure-Python sink, or a
+spinning `busy_wait` (which is what macOS/Windows get), would not buy this.
+
+The hand-off is **one frame deep and latest-wins** — a slow viewer drops display
+frames instead of blocking capture, counted and reported once at `close()`.
+Consequences, both display-only and deliberate: `log_time` lags capture by up to a
+loop period, and the worker holds the images the loop just read (the same arrays
+`dataset.add_frame` owns), so a camera recycling its buffer could tear a
+_displayed_ frame — never a recorded one.
+
+Do not move either call back inline "for ordering", and do not give the sink a
+deeper queue: depth is latency, and a viewer that has fallen a second behind is
+showing the operator the wrong thing more usefully than it is showing it late.
+`traj_viz` belongs to the sink now — `reset_trajectory()` between episodes, not
+`traj_viz.reset()`.
+
 ## `xrt.init()` is a process singleton — go through `xrt_session`
 
 `teleoperators/pico4/xrt_session.py` owns it, with a hold count and an atexit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,18 @@ observation keys, so it is not the same dataset and epochs do not model it.
 A pre-epoch file reads back as one open epoch (`manifest_epochs`), but an open
 single epoch means _"nothing here says the rig changed"_, **not** _"it didn't"_.
 
+**`robot_id` is the exception: a wall, not an epoch boundary.** One dataset is
+one station, so `--resume` with a `--robot.id` the manifest disagrees with
+raises (`check_dataset_station`) — identical `units` do not make it one rig,
+because the label names the seat, not the hardware in it. Checked twice: in
+`lerobot-record` **before `connect()`** (the id comes from the config, so no
+device has to spin up to be turned away) and again inside
+`write_hardware_manifest`, the choke point every writer goes through. Being a
+dataset-level invariant it is written at the top level beside `robot_type` and
+repeated per epoch so readers of older files keep working; `manifest_robot_ids`
+reads both. An unlabelled dataset (recorded before `--robot.id` was required) is
+not a mismatch — same reading as the open epoch above.
+
 Each tactile sensor's **runtime bundle** goes in beside it, at
 `meta/runtimes/<serial>-<local time>.bin` (`RUNTIME_DIR`), with the epoch's
 sensors pointing at their own. Deriving depth / force / difference from the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,11 @@ something different) plus `head_camera.*`, the headset pose.
 - **Do not read the SDK frame cache from the record loop.** The eyes arrive as
   separate messages, left first, so sampling at loop rate catches one updated
   and not the other (measured 7% of frames). `cameras/pico/stereo_poller.py`
-  polls at 120 Hz and publishes only pairs whose `frame_sequence` agrees.
+  polls at 60 Hz and publishes only pairs whose `frame_sequence` agrees. The
+  poll rate is margin, not throughput: the SDK holds one slot per eye, so a
+  frame not collected before the next lands is lost, and its counterpart then
+  ages out unpaired. 60 Hz against a ~30 fps stream is 2x — `StereoPoller.stop`
+  reports `dropped_unpaired`, which is the tell if that margin is too thin.
 - **Resolution is a whitelist**, `640x480` / `1024x768` / `1280x960`, all 4:3
   like the sensor and all three offered by the headset app's Resolution setting.
   The default is `640x480` because that is the app's default, so the two line up

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,11 +360,18 @@ left arrow ends the loop _and_ leaves `rerecord_episode` standing for the caller
 which is the whole point of an intent flag.
 
 Checking the intent flags as well is not merely redundant, it is how the bug got
-in. Nothing ever sets `stop_recording` on its own either — ESC sets both, the
-teleop refresh (`control_utils.refresh_events_from_teleop`) writes only
-`go_start`, and the `device_lost` path sets it and breaks on the next line — so a
-`stop_recording` branch here is dead code whose only effect is which line gets
-logged. Do not add one back.
+in. Nothing ever sets `stop_recording` on its own either — ESC sets both, and the
+`device_lost` path sets it and breaks on the next line — so a `stop_recording`
+branch here is dead code whose only effect is which line gets logged. Do not add
+one back.
+
+There used to be a third writer, and it is worth knowing it is gone: the teleop
+refresh (`control_utils.refresh_events_from_teleop`, called per iteration through
+`refresh_listener_events`) polled the Pico4 reset button into a `go_start` flag
+**nothing ever read**. The whole path — flag, refresh, and the Space key that
+also set it — was removed; `poll_buttons` / `get_reset_button` remain on the
+teleoperators, just not wired into any loop. So the event table above is the
+complete list of flags, not a summary of a longer one.
 
 Breaking on `rerecord_episode` instead is what put reset activity _inside_
 episodes. That break left `exit_early` unconsumed; the reset phase is this same

--- a/src/lerobot/cameras/pico/stereo_poller.py
+++ b/src/lerobot/cameras/pico/stereo_poller.py
@@ -29,8 +29,8 @@ stream lands in the gap between them often enough to matter — measured at 7%
 of frames, left ahead by one or two, never behind. The frames themselves were
 fine; the moment we looked at them was not.
 
-Polling well above the stream rate closes that gap: every sequence number is
-seen as it arrives, so a pair can be held back until both halves are in.
+Polling above the stream rate closes that gap: every sequence number is seen as
+it arrives, so a pair can be held back until both halves are in.
 Nothing is published until then, and what a camera reads is always two views
 of the same instant.
 
@@ -51,11 +51,20 @@ from lerobot.utils.robot_utils import get_logger
 
 _EYE_INDEX = {"left": 0, "right": 1}
 
-# Poll period. The stream measured 29.9 fps (~33 ms), so this samples each
-# frame about four times — enough to see both halves of a pair land without
-# spinning hot. It is not a frame rate: nothing is published unless the
-# sequence number actually moved.
-_POLL_PERIOD_S = 1.0 / 120.0
+# Poll period. The stream measured 29.9 fps (~33 ms), so this samples each frame
+# about twice. It is not a frame rate: nothing is published unless the sequence
+# number actually moved.
+#
+# This was 120 Hz (~4x). What the oversampling buys is margin, not throughput:
+# the SDK holds exactly **one slot per eye** (``PicoCameraFrames[eyeIndex]``,
+# overwritten by its callback), so a frame the poller does not collect before the
+# next one lands is gone. At 60 Hz that window is 16.7 ms against a ~33 ms frame
+# interval — comfortable in the steady state, half the jitter headroom the 120 Hz
+# setting had. A missed frame on one eye costs its counterpart too: the survivor
+# never finds a match and ages out of ``_pending``, which is what
+# ``dropped_unpaired`` counts. That counter is the tell if this turns out too low
+# — :meth:`StereoPoller.stop` reports it.
+_POLL_PERIOD_S = 1.0 / 60.0
 
 # How many un-paired frames to keep per eye while waiting for the other half.
 # One would do for the measured lag (one or two frames); four is slack for a
@@ -107,6 +116,18 @@ class StereoPoller:
         if self._thread is not None:
             self._thread.join(timeout=2.0)
         self._thread = None
+        # Report the two counters that say whether the poll rate is keeping up.
+        # Silent when both are zero, which is the normal case — the point is that
+        # a session where the poller *was* losing frames does not end looking
+        # identical to one where it was not.
+        if self.dropped_unpaired or self.decode_failures:
+            self.logger.warn(
+                f"Pico stereo poller: {self.dropped_unpaired} frame(s) aged out unpaired, "
+                f"{self.decode_failures} decode failure(s). Unpaired frames mean an eye's "
+                f"capture was overwritten before the poller collected it; if this is not near "
+                f"zero, raise the poll rate (_POLL_PERIOD_S, currently "
+                f"{1.0 / _POLL_PERIOD_S:.0f} Hz)."
+            )
 
     @property
     def is_running(self) -> bool:

--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -712,7 +712,9 @@ Two different things, and they answer two different questions.
 one id). It names the _seat_, not the hardware in it, so it stays put when a
 gripper is swapped. It reaches the log prefix, the calibration filename,
 `str(robot)` and the manifest below, but **not a dataset column** —
-`LeRobotDataset.create()` is handed `robot_type` and nothing else.
+`LeRobotDataset.create()` is handed `robot_type` and nothing else. It is still
+binding: a dataset records the station it was recorded in and refuses to be
+resumed from another one (below).
 
 **Pass a number.** `--robot.id=0` is stored as `taccap_0` here and as
 `bi_taccap_0` on a bimanual rig: a bare number is expanded against
@@ -740,12 +742,13 @@ defaults it to `taccap_0`.
 ```json
 {
   "robot_type": "bi_taccap_gripper",
+  "robot_id": "bi_taccap_0",
   "epochs": [
     {
       "from_episode": 0,
       "to_episode": null,
       "recorded_at": "2026-08-22T16:03:09+08:00",
-      "robot_id": "taccap_0",
+      "robot_id": "bi_taccap_0",
       "role": "leader",
       "units": [
         {
@@ -777,6 +780,33 @@ defaults it to `taccap_0`.
 open epoch is closed at the current episode count and a new one starts, so every
 episode keeps pointing at the devices that produced it. `to_episode` is exclusive
 and `null` on the epoch still being recorded.
+
+**`robot_id` is not one of those swaps — it is a wall.** One dataset belongs to
+one station, and `lerobot-record --resume` on a rig whose `--robot.id` disagrees
+with the manifest fails:
+
+```text
+ValueError: This dataset was recorded on station taccap_0 but this run is
+--robot.id=taccap_1; refusing to resume it (…/meta/hardware.json). One dataset is
+one station: a task recorded across two rigs mixes their calibration, timing and
+mounting into episodes nothing downstream can separate. Resume on the original
+station, or record this run into a dataset of its own (--dataset.repo_id=…).
+```
+
+Identical `units` on both sides do not make it one rig — the label names the
+_seat_, and the seat is where the mounting, the lighting and the operator are.
+The check runs twice: once in `lerobot-record` right after the resumed dataset is
+loaded, **before `robot.connect()`**, so a wrong rig is turned away before every
+gripper, sensor and tracker spins up; and once inside `write_hardware_manifest`,
+which is the choke point every writer goes through. Because the label is now a
+property of the dataset rather than of an epoch, it is also written at the top
+level beside `robot_type`, and repeated on each epoch so readers of older files
+keep working (`manifest_robot_ids` reads both).
+
+A dataset recorded before `--robot.id` was required carries no label, and that is
+not a mismatch: the file cannot say the station changed, and refusing would
+strand real datasets. Same reading as an open epoch — _"nothing here says it
+changed"_ is not _"it didn't"_.
 
 - `side` is which gripper; `finger` is which sensor on it. Both are called
   left/right and they are **independent** — 单左双右 is applied once to the

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -64,11 +64,13 @@ __all__ = [
     "build_head_camera_configs",
     "build_tactile_camera_configs",
     "build_wrist_camera_config",
+    "check_dataset_station",
     "connect_cameras_parallel",
     "disconnect_cameras_parallel",
     "epoch_for_episode",
     "hardware_manifest_unit",
     "manifest_epochs",
+    "manifest_robot_ids",
     "open_gripper",
     "prewarm_tactile_config_cache",
     "read_gripper_normalized",
@@ -887,9 +889,10 @@ dataset root.
 
 Deliberately a file of its own rather than a key in ``meta/info.json``: that
 file's schema belongs to upstream lerobot, and a fork-local key in it would
-collide on the next v5.x sync. ``robot.id`` does not reach the dataset at all
-(``LeRobotDataset.create`` takes only ``robot_type``), so this manifest is the
-only thing tying recorded episodes to the physical devices that produced them.
+collide on the next v5.x sync. Neither ``robot.id`` nor any serial reaches
+``meta/info.json`` or a dataset column (``LeRobotDataset.create`` takes only
+``robot_type``), so this manifest is the only thing tying recorded episodes to
+the physical devices — and to the station — that produced them.
 
 The same reasoning is why a swap mid-dataset is recorded here as another
 ``epochs`` entry rather than as a per-episode column in
@@ -1031,6 +1034,73 @@ def manifest_epochs(manifest: dict[str, Any]) -> list[dict[str, Any]]:
             "units": manifest.get("units", []),
         }
     ]
+
+
+def manifest_robot_ids(manifest: dict[str, Any]) -> set[str]:
+    """Every station label this manifest names, top level and epochs alike.
+
+    Both places are read because the top-level key is newer than the file: a
+    manifest written before it exists carries the label only on its epochs, and a
+    dataset recorded before *that* carries it only at the top (pre-epoch shape,
+    which ``manifest_epochs`` lifts in). Missing and blank labels are dropped
+    rather than reported as ``None`` — "this file does not say" is the absence of
+    an answer, not a station that anything can be compared against.
+
+    A dataset written by the current code has exactly one label here; see
+    ``check_dataset_station`` for why.
+    """
+    labels = {manifest.get("robot_id")}
+    labels.update(epoch.get("robot_id") for epoch in manifest_epochs(manifest))
+    return {label for label in labels if label}
+
+
+def _check_station_matches(manifest: dict[str, Any], robot_id: str | None, path: Any = None) -> None:
+    """Raise unless ``robot_id`` is the station this manifest was recorded on.
+
+    Silent when either side is unlabelled: a manifest with no ``robot_id``
+    anywhere cannot say the station changed, and refusing on that would block
+    resuming datasets recorded before ``--robot.id`` was required. "Nothing here
+    says it changed" is not "it did not change" — same caveat as an open epoch in
+    ``manifest_epochs`` — but a guess in either direction would be worse than
+    leaving the question where the file leaves it.
+    """
+    if not robot_id:
+        return
+    recorded = manifest_robot_ids(manifest)
+    if not recorded or recorded == {robot_id}:
+        return
+    where = f" ({path})" if path is not None else ""
+    raise ValueError(
+        f"This dataset was recorded on station {'/'.join(sorted(recorded))} but this run is "
+        f"--robot.id={robot_id}; refusing to resume it{where}. One dataset is one station: a task "
+        f"recorded across two rigs mixes their calibration, timing and mounting into episodes "
+        f"nothing downstream can separate. Resume on the original station, or record this run "
+        f"into a dataset of its own (--dataset.repo_id=...)."
+    )
+
+
+def check_dataset_station(root: str | Path, robot_id: str | None) -> None:
+    """Raise if ``root`` holds a dataset recorded on a different station.
+
+    Call it **before** ``robot.connect()``: ``--robot.id`` comes from the config,
+    so this needs no hardware, and the alternative is spinning up every gripper,
+    tactile sensor and tracker only to refuse the run seconds later.
+    ``write_hardware_manifest`` re-checks after connect — that is the choke point
+    every writer goes through, this is only the early exit.
+
+    A missing manifest is not an error: a dataset recorded before manifests
+    existed has no station on record to disagree with. An unreadable one is left
+    for ``write_hardware_manifest`` to warn about, so a truncated file produces
+    one complaint rather than two.
+    """
+    path = Path(root) / HARDWARE_MANIFEST_PATH
+    if not path.exists():
+        return
+    try:
+        existing = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return
+    _check_station_matches(existing, robot_id, path)
 
 
 def epoch_for_episode(manifest: dict[str, Any], episode_index: int) -> dict[str, Any] | None:
@@ -1232,8 +1302,12 @@ def _describe_change(previous: dict[str, Any] | None, current: dict[str, Any]) -
     )
     if swapped:
         return f"Hardware changed on the {' and '.join(swapped)} unit(s)"
+    # Reachable only when one side is unlabelled — a real station change raises
+    # before an epoch is ever appended (``_check_station_matches``). So this
+    # names a dataset recorded before ``--robot.id`` was required, now being
+    # resumed by a run that has one.
     if previous.get("robot_id") != current.get("robot_id"):
-        return f"Station changed ({previous.get('robot_id')} -> {current.get('robot_id')})"
+        return f"Station label recorded ({previous.get('robot_id')} -> {current.get('robot_id')})"
     # Same serials, same station: what differs is the runtime bundle, which the
     # sensor re-captures at every ``Sensor.create()``. Calling that "hardware
     # changed" would send someone hunting for a swap that never happened.
@@ -1264,17 +1338,20 @@ def write_hardware_manifest(
       and append a new one. Both stay named, and every episode keeps pointing at
       the devices that actually produced it.
 
-    "Different" means anything in ``units`` / ``robot_id`` / ``role`` changed.
-    Note that this includes running the *same* devices from another PC: the
-    station label changes while the hardware does not. That is recorded rather
-    than refused, because refusing would also drop a device swap that happened
-    to coincide with the move — and the devices are the part downstream cannot
-    guess. Consumers key on ``units``; an epoch boundary with identical ``units``
-    is simply the rig moving.
+    "Different" means anything in ``units`` / ``role`` changed — the devices, and
+    what they were doing. Consumers key on ``units``.
 
-    Only ``robot_type`` is treated as a hard mismatch: single vs bimanual changes
-    the observation keys, so it is not the same dataset at all, and epochs do not
-    model that.
+    ``robot_id`` is **not** in that list, because it is not an epoch boundary but
+    a wall: a dataset belongs to one station, and resuming it from another raises
+    (``check_dataset_station``). It is written at the top level for that reason,
+    beside ``robot_type``, and repeated on each epoch so readers of older files
+    keep working.
+
+    ``robot_type`` is the other hard mismatch, and the one case still handled by
+    keeping the original file and warning: single vs bimanual changes the
+    observation keys, so it is not the same dataset at all, and epochs do not
+    model that. It reaches here only from a caller that skipped
+    ``sanity_check_dataset_robot_compatibility``, which refuses it first.
 
     The swap case used to keep the original file and warn. The warning went to
     the log and never reached the dataset, so afterwards nothing on disk said the
@@ -1312,6 +1389,10 @@ def write_hardware_manifest(
         path.parent.mkdir(parents=True, exist_ok=True)
         fresh = {
             "robot_type": manifest.get("robot_type"),
+            # Dataset-level, like ``robot_type``, because nothing may resume this
+            # dataset from another station. The epochs repeat it; this is the
+            # invariant stated once, where a reader looks for it.
+            "robot_id": manifest.get("robot_id"),
             "epochs": [
                 {
                     "from_episode": int(episode_index),
@@ -1339,6 +1420,12 @@ def write_hardware_manifest(
         )
         return path
 
+    # After the type check and before anything is written: a station mismatch is
+    # the one difference that is not an epoch. Raising here rather than warning
+    # is the point — a warning goes to the log, and the dataset would keep no
+    # record that half its episodes came off another rig.
+    _check_station_matches(existing, manifest.get("robot_id"), path)
+
     epochs = manifest_epochs(existing)
     last = epochs[-1] if epochs else None
     if last is not None and all(last.get(key) == value for key, value in payload.items()):
@@ -1356,7 +1443,14 @@ def write_hardware_manifest(
         }
     )
 
-    path.write_text(json.dumps({"robot_type": existing.get("robot_type"), "epochs": updated}, indent=2) + "\n")
+    # ``or`` and not ``existing.get`` alone: a file written before the top-level
+    # key existed has none, and the check above has already established there is
+    # only one station to name.
+    header = {
+        "robot_type": existing.get("robot_type"),
+        "robot_id": existing.get("robot_id") or manifest.get("robot_id"),
+    }
+    path.write_text(json.dumps({**header, "epochs": updated}, indent=2) + "\n")
     logger.info(
         f"{_describe_change(last, payload)} at episode {episode_index}; recorded as a new epoch "
         f"in {path}. This dataset now spans {len(updated)} configurations."

--- a/src/lerobot/scripts/client_commands.md
+++ b/src/lerobot/scripts/client_commands.md
@@ -187,18 +187,31 @@ it. Details: [`robots/taccap_gripper/README.md`](../robots/taccap_gripper/README
 
 ### Recording with the viewer on — `[slow_frame]`
 
-`--display_data=true` costs loop time, and a bimanual rig with the head camera is
-eight images per frame. The defaults below are already the fast ones; reach for
-them only if the log shows `[slow_frame] ... overrun=`.
+**`--display_data=true` no longer costs loop time.** Rerun logging runs on its own
+thread (`RerunLogSink`), so the record loop hands off a frame and returns. Measured
+on a bimanual rig with the head camera — eight images per frame — against a 24.1 ms
+viewer-off baseline: **27.2 ms inline, 24.1 ms off-loop**. Those three milliseconds
+were the difference between hitting the 33.3 ms budget at 30 fps and not, which is
+why the standing advice was to record with the viewer off. That advice is retired.
 
-| Flag                          | Default | What it costs                                                                                                                                                                                                                                                                         |
-| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--display_compressed_images` | `false` | `true` JPEG-encodes every image inline on the record loop — measured at 13.2 ms/frame against a 33.3 ms budget at 30 fps, versus 3.1 ms off. Turn it on only when the viewer is on **another machine** (`--display_ip`), where saving IPC bandwidth is worth more than the loop time. |
-| `--display_image_every_n`     | `1`     | Log camera images every N-th frame. Scalars stay at full rate, so `tcp.*` and `gripper.pos` curves are unaffected — only the camera tiles get sparser. Every 3rd frame brings the image cost to ~1 ms. Last resort: it is the only one of these that changes what you see.            |
+The hand-off queue is one frame deep and latest-wins: when the viewer cannot keep up,
+display frames are dropped, counted, and reported once at the end of the session.
+Dropping what is on screen is always the right trade against overrunning the loop that
+writes the dataset — a report of dropped frames is the sink working, not a fault to
+chase.
 
-The `[slow_frame]` line carries a `top_obs=` suffix naming the slowest cameras of
-that frame, so check it before reaching for either flag — a single slow sensor is
-a different problem from the viewer being expensive.
+If `[slow_frame] ... overrun=` still appears, the viewer is no longer a plausible
+cause: read `top_obs=` and look at the hardware read. The two flags below now buy
+viewer throughput, not loop time.
+
+| Flag                          | Default | What it costs                                                                                                                                                                                                                                                                                                                       |
+| ----------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--display_compressed_images` | `false` | `true` JPEG-encodes every image — ~15 ms/frame versus ~3 ms off. On the sink's thread, so it costs display frames rather than loop time: at 30 fps the encode leaves little headroom and the sink starts dropping. Turn it on when the viewer is on **another machine** (`--display_ip`), where saving IPC bandwidth is worth more. |
+| `--display_image_every_n`     | `1`     | Log camera images every N-th frame. Scalars stay at full rate, so `tcp.*` and `gripper.pos` curves are unaffected — only the camera tiles get sparser. Reach for it when the sink reports dropping a lot and you would rather choose which frames go than let it choose.                                                            |
+
+The `[slow_frame]` line carries a `top_obs=` suffix naming the slowest cameras of that
+frame. With the viewer off the loop, that suffix is the whole diagnosis: a single slow
+sensor is what an overrun now means.
 
 ### Recording on a machine with no GPU
 

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -96,6 +96,7 @@ from lerobot.utils.utils import (
     log_say,
 )
 from lerobot.utils.visualization_utils import (
+    RerunLogSink,
     init_rerun,
     log_rerun_data,
     select_display_observation,
@@ -263,17 +264,19 @@ class RecordConfig:
     display_ip: str | None = None
     # Port of the remote Rerun server
     display_port: int | None = None
-    # JPEG-encode images before sending them to Rerun. Off by default: the encode
-    # runs inline on the record loop, and on a bimanual rig with a head camera it
-    # measures ~13 ms per frame against a 33 ms budget at 30 fps (~3 ms without),
-    # which is enough on its own to produce [slow_frame] overruns. Turn it on when
+    # JPEG-encode images before sending them to Rerun. Off by default: on a
+    # bimanual rig with a head camera the encode measures ~15 ms per frame versus
+    # ~3 ms without. Since RerunLogSink moved this onto its own thread it no
+    # longer costs the record loop anything — it costs the *viewer* frames, which
+    # the sink drops when the encode cannot keep up with 30 fps. Turn it on when
     # the viewer is on another machine (--display_ip), where the bandwidth it
-    # saves is worth more than the loop time it costs.
+    # saves is worth more than the display frames it drops.
     display_compressed_images: bool = False
     # Log camera images to Rerun every N-th frame (1 = every frame). Scalars are
     # always logged at full rate, so raising this thins the camera tiles without
-    # making the tcp.* / gripper.pos plots sparse. The last resort if the loop
-    # still overruns after turning compression off.
+    # making the tcp.* / gripper.pos plots sparse. Also off-loop; raise it when
+    # the sink reports dropping a lot of frames and you would rather choose which
+    # ones go than have it choose.
     display_image_every_n: int = 1
     # Overlay the 3D pose + breadcrumb trajectory view in Rerun (when display_data
     # is on and the device emits tcp.* poses). Auto-skips if enable_tracker=false.
@@ -302,7 +305,7 @@ def self_driven_record_loop(
     control_time_s: int | None = None,
     single_task: str | None = None,
     display_data: bool = False,
-    traj_viz: TaccapTrajectoryViz | None = None,
+    rerun_sink: RerunLogSink | None = None,
     display_features: dict | None = None,
     display_compressed_images: bool = False,
     display_image_every_n: int = 1,
@@ -403,16 +406,27 @@ def self_driven_record_loop(
 
         if display_data and observation is not None:
             display_observation = select_display_observation(observation, display_features)
-            log_rerun_data(
-                observation=display_observation,
-                action=action or {},
-                compress_images=display_compressed_images,
-                # Counts loop iterations, not recorded frames, so the viewer keeps
-                # a steady image cadence through the reset phase too.
-                log_images=display_image_every_n <= 1 or loop_iteration % display_image_every_n == 0,
-            )
-            if traj_viz is not None:
-                traj_viz.log(display_observation)
+            # Counts loop iterations, not recorded frames, so the viewer keeps
+            # a steady image cadence through the reset phase too.
+            log_images = display_image_every_n <= 1 or loop_iteration % display_image_every_n == 0
+            if rerun_sink is not None:
+                # Hands the frame to a worker thread and returns. This is what
+                # keeps the viewer out of the frame budget — see RerunLogSink.
+                rerun_sink.submit(
+                    display_observation,
+                    action or {},
+                    compress_images=display_compressed_images,
+                    log_images=log_images,
+                )
+            else:
+                # No sink (a direct caller that built none): log inline, as
+                # before. Costs the loop ~3 ms/frame on a bimanual rig.
+                log_rerun_data(
+                    observation=display_observation,
+                    action=action or {},
+                    compress_images=display_compressed_images,
+                    log_images=log_images,
+                )
 
         _record_loop_sleep(
             start_loop_t=start_loop_t,
@@ -441,6 +455,7 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
 
     dataset = None
     listener = None
+    rerun_sink = None
 
     try:
         if cfg.resume:
@@ -533,6 +548,10 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                 traj_viz.setup()
             else:
                 traj_viz = None
+            # Everything the viewer needs now happens on this worker's thread,
+            # not the record loop's. The blueprint above stays on this thread:
+            # it is sent once, before the loop.
+            rerun_sink = RerunLogSink(traj_viz=traj_viz)
 
         listener, events = init_keyboard_listener(teleop=teleop)
 
@@ -605,8 +624,8 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
 
                 # Fresh breadcrumb trail per episode so trajectories don't bleed
                 # across takes.
-                if traj_viz is not None:
-                    traj_viz.reset()
+                if rerun_sink is not None:
+                    rerun_sink.reset_trajectory()
 
                 set_capture_recording(True)
                 try:
@@ -618,7 +637,7 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                         control_time_s=cfg.dataset.episode_time_s,
                         single_task=cfg.dataset.single_task,
                         display_data=cfg.display_data,
-                        traj_viz=traj_viz,
+                        rerun_sink=rerun_sink,
                         display_features=display_features,
                         display_compressed_images=cfg.display_compressed_images,
                         display_image_every_n=cfg.display_image_every_n,
@@ -662,7 +681,7 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                         control_time_s=cfg.dataset.reset_time_s,
                         single_task=cfg.dataset.single_task,
                         display_data=cfg.display_data,
-                        traj_viz=traj_viz,
+                        rerun_sink=rerun_sink,
                         display_features=display_features,
                         display_compressed_images=cfg.display_compressed_images,
                         display_image_every_n=cfg.display_image_every_n,
@@ -679,6 +698,11 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                 recorded_episodes += 1
     finally:
         log_say("Stop recording", cfg.play_sounds, blocking=True)
+
+        # Before the devices go: the worker still holds the last frames they
+        # produced, and its drop count is only meaningful once it has stopped.
+        if rerun_sink is not None:
+            rerun_sink.close()
 
         if dataset:
             dataset.finalize()

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -85,7 +85,6 @@ from lerobot.utils.constants import ACTION, OBS_STR
 from lerobot.utils.control_utils import (
     init_keyboard_listener,
     is_headless,
-    refresh_listener_events,
     sanity_check_dataset_name,
     sanity_check_dataset_robot_compatibility,
 )
@@ -347,7 +346,6 @@ def self_driven_record_loop(
     while timestamp < control_time_s:
         loop_iteration += 1
         start_loop_t = time.perf_counter()
-        refresh_listener_events(events)
 
         # `exit_early` is the *only* break condition, as in upstream's
         # `record_loop`, and the loop that breaks on it always consumes it.

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -72,7 +72,7 @@ from lerobot.robots import (  # noqa: F401
     make_robot_from_config,
     taccap_gripper,
 )
-from lerobot.robots.taccap_gripper.common import write_hardware_manifest
+from lerobot.robots.taccap_gripper.common import check_dataset_station, write_hardware_manifest
 from lerobot.robots.taccap_gripper.visualization import TaccapTrajectoryViz
 from lerobot.teleoperators import (  # noqa: F401
     Teleoperator,
@@ -462,6 +462,13 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                     num_threads=cfg.dataset.num_image_writer_threads_per_camera * len(robot.cameras),
                 )
             sanity_check_dataset_robot_compatibility(dataset, robot, cfg.dataset.fps, dataset_features)
+            # One dataset, one station. Checked here — before connect(), off
+            # ``--robot.id`` alone — so a rig that cannot take this dataset says
+            # so now instead of after every gripper, sensor and tracker has been
+            # brought up. ``write_hardware_manifest`` re-checks below; this is
+            # the early exit, not the enforcement.
+            if hasattr(type(robot), "hardware_manifest"):
+                check_dataset_station(dataset.root, robot.id)
         else:
             # Create empty dataset or load existing saved episodes
             sanity_check_dataset_name(cfg.dataset.repo_id)

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -71,6 +71,7 @@ from lerobot.utils.robot_utils import (
 )
 from lerobot.utils.utils import move_cursor_up
 from lerobot.utils.visualization_utils import (
+    RerunLogSink,
     init_rerun,
     log_rerun_data,
     select_display_observation,
@@ -132,7 +133,10 @@ def _safe_disconnect(obj, name: str) -> None:
         logger.error(f"Error disconnecting {name}: {e}\n{traceback.format_exc()}")
 
 
-def _cleanup(robot, teleop, display_data: bool) -> None:
+def _cleanup(robot, teleop, display_data: bool, rerun_sink=None) -> None:
+    # Stop the display worker before tearing the SDK down under it.
+    if rerun_sink is not None:
+        rerun_sink.close()
     if display_data:
         try:
             rr.rerun_shutdown()
@@ -229,7 +233,7 @@ def self_driven_teleop_loop(
     duration: float | None = None,
     display_compressed_images: bool = False,
     debug_timing: bool = False,
-    traj_viz: TaccapTrajectoryViz | None = None,
+    rerun_sink: RerunLogSink | None = None,
     display_features: dict | None = None,
 ):
     """Data-stream + Rerun visualisation loop for self-driven, sensor-only robots
@@ -263,13 +267,16 @@ def self_driven_teleop_loop(
 
             if display_data:
                 display_obs = select_display_observation(obs, display_features)
-                log_rerun_data(
-                    observation=display_obs,
-                    action={},
-                    compress_images=display_compressed_images,
-                )
-                if traj_viz is not None:
-                    traj_viz.log(display_obs)
+                if rerun_sink is not None:
+                    # Off-loop, same as the record path: the viewer must not
+                    # eat into the frame budget. See RerunLogSink.
+                    rerun_sink.submit(display_obs, {}, compress_images=display_compressed_images)
+                else:
+                    log_rerun_data(
+                        observation=display_obs,
+                        action={},
+                        compress_images=display_compressed_images,
+                    )
                 if not debug_timing:
                     scalar_items = [(k, v) for k, v in obs.items() if not isinstance(v, np.ndarray)]
                     print("\n" + "-" * (display_len + 12))
@@ -326,6 +333,7 @@ def teleoperate(cfg: TeleoperateConfig):
 
     robot = None
     teleop = None
+    rerun_sink = None
 
     try:
         if cfg.robot.type not in SELF_DRIVEN_TELEOP_ROBOTS:
@@ -365,6 +373,7 @@ def teleoperate(cfg: TeleoperateConfig):
                 traj_viz.setup()
             else:
                 traj_viz = None
+            rerun_sink = RerunLogSink(traj_viz=traj_viz)
 
         # Ctrl+C is the normal way to end a teleop session: fall through to the
         # finally block below and disconnect cleanly rather than dumping a traceback.
@@ -376,14 +385,14 @@ def teleoperate(cfg: TeleoperateConfig):
                 duration=cfg.teleop_time_s,
                 display_compressed_images=display_compressed_images,
                 debug_timing=cfg.debug_timing,
-                traj_viz=traj_viz,
+                rerun_sink=rerun_sink,
                 display_features=display_features,
             )
 
     except Exception as e:
         logger.error(f"Error in teleoperation: {e}\n{traceback.format_exc()}")
     finally:
-        _cleanup(robot, teleop, cfg.display_data)
+        _cleanup(robot, teleop, cfg.display_data, rerun_sink)
 
 
 def main():

--- a/src/lerobot/teleoperators/pico4/tracker.py
+++ b/src/lerobot/teleoperators/pico4/tracker.py
@@ -105,6 +105,28 @@ STALE_WARN_THRESHOLD_S = 0.5
 # the log readable when the service is up but a tracker is unplugged.
 MISSING_SN_WARN_INTERVAL_S = 5.0
 
+# The Unity-origin notice below is a standing operating instruction, not a report
+# that something happened — so it is worth saying once and no more. It used to fire
+# from every reader's connect(), which on a bimanual rig meant two identical
+# warnings per launch, from two different logger names, before anything had gone
+# wrong. Process-scoped rather than per-reader for that reason.
+_origin_notice_lock = threading.Lock()
+_origin_notice_shown = False
+
+
+def _warn_unity_origin_once(logger: Any) -> None:
+    global _origin_notice_shown
+    with _origin_notice_lock:
+        if _origin_notice_shown:
+            return
+        _origin_notice_shown = True
+    logger.warn(
+        "Pico4 origin is fixed at Unity-app launch time. "
+        "Do NOT restart the Unity client between episodes, or recorded "
+        "episodes will be expressed in mismatched origin frames."
+    )
+
+
 # Fixed Pico→world frame remap, identical to the controller's
 # ``teleop_pico4._transform_pico_to_world_coordinate``:
 #   Pico4:  X right,   Y up, Z toward user
@@ -339,12 +361,9 @@ class Pico4TrackerReader:
         # IMPORTANT: the Pico4 coordinate origin is set by Unity at app
         # launch — not by xrt.init(), and not by re-clicking Connect in
         # Unity. If Unity restarts mid-session, all subsequent poses
-        # will be expressed in a different origin frame. Warn loudly.
-        self.logger.warn(
-            "Pico4 origin is fixed at Unity-app launch time. "
-            "Do NOT restart the Unity client between episodes, or recorded "
-            "episodes will be expressed in mismatched origin frames."
-        )
+        # will be expressed in a different origin frame. Said once per
+        # process — every reader in it shares the one Unity origin.
+        _warn_unity_origin_once(self.logger)
 
         deadline = time.monotonic() + self.device_wait_timeout
         attempt = 0

--- a/src/lerobot/utils/control_utils.py
+++ b/src/lerobot/utils/control_utils.py
@@ -61,15 +61,19 @@ def init_keyboard_listener(teleop: Any | None = None):
     """
     Initializes a non-blocking keyboard listener for real-time user interaction.
 
-    This function sets up a listener for specific keys (right arrow, left arrow, escape, space)
-    to control the program flow during execution. When `teleop` is provided and exposes
-    ``poll_buttons()`` + ``get_reset_button()``, the teleop's reset button is mapped to the same
-    ``go_start`` event as the Space key. Headless environments skip the keyboard listener but
-    still surface the event dict so recording loops keep working.
+    This function sets up a listener for specific keys (right arrow, left arrow, escape)
+    to control the program flow during execution. Headless environments skip the keyboard
+    listener but still surface the event dict so recording loops keep working.
+
+    Space used to set a ``go_start`` event, printing "Robot will go to start pose while
+    recording continues...". Nothing in this fork ever read that flag — the handheld TacCap
+    grippers have no start pose to go to and ``send_action`` is a no-op — so the key did
+    nothing but print a promise it could not keep. The teleop reset button (``poll_buttons``
+    / ``get_reset_button``) fed the same dead flag and went with it; both methods remain on
+    the Pico4 teleoperators, just no longer wired into the control loop.
 
     Args:
-        teleop: Optional teleoperator whose button events should be mapped into the same
-            `events` dictionary as keyboard shortcuts.
+        teleop: Unused, kept so callers do not have to change. See above.
 
     Returns:
         A tuple containing:
@@ -80,21 +84,6 @@ def init_keyboard_listener(teleop: Any | None = None):
     events["exit_early"] = False
     events["rerecord_episode"] = False
     events["stop_recording"] = False
-    events["go_start"] = False
-
-    def refresh_events_from_teleop() -> None:
-        if teleop is None:
-            return
-        try:
-            if hasattr(teleop, "poll_buttons"):
-                teleop.poll_buttons()
-            # Only A button (reset) is mapped — B/X/Y caused accidental triggers.
-            if hasattr(teleop, "get_reset_button") and teleop.get_reset_button():
-                events["go_start"] = True
-        except Exception as e:
-            logger.debug(f"Error refreshing teleop control events: {e}")
-
-    events["_refresh_events"] = refresh_events_from_teleop
 
     if is_headless():
         logger.warning(
@@ -126,9 +115,6 @@ def init_keyboard_listener(teleop: Any | None = None):
                 logger.info("Escape pressed -> stopping data recording.")
                 events["stop_recording"] = True
                 events["exit_early"] = True
-            elif key == keyboard.Key.space:
-                logger.info("Space pressed -> robot goes to start pose, recording continues.")
-                events["go_start"] = True
         except Exception as e:
             logger.error(f"Error handling key press: {e}")
 
@@ -136,13 +122,6 @@ def init_keyboard_listener(teleop: Any | None = None):
     listener.start()
 
     return listener, events
-
-
-def refresh_listener_events(events: dict[str, Any]) -> None:
-    """Polls teleop-derived control events attached by init_keyboard_listener()."""
-    refresh = events.get("_refresh_events")
-    if callable(refresh):
-        refresh()
 
 
 def sanity_check_dataset_name(repo_id):

--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import numbers
 import os
+import threading
 from typing import Any
 
 import numpy as np
 import rerun as rr
 
 from .constants import ACTION, ACTION_PREFIX, OBS_PREFIX, OBS_STR
+
+logger = logging.getLogger(__name__)
 
 RobotAction = dict[str, Any]
 RobotObservation = dict[str, Any]
@@ -94,11 +98,14 @@ def log_rerun_data(
         compress_images: JPEG-encode images before logging. Off by default,
                          because the encode runs inline on the caller's thread —
                          on a bimanual rig with a head camera (four tactile, two
-                         wrist, two eyes) it measures ~13 ms per frame against a
-                         33 ms budget at 30 fps, versus ~3 ms uncompressed. It
-                         buys lower viewer memory and IPC bandwidth, which is
-                         worth having when the viewer is on another machine
-                         (``--display_ip``) and not much otherwise.
+                         wrist, two eyes) it measures ~15 ms per frame versus
+                         ~3 ms uncompressed. Called through :class:`RerunLogSink`
+                         that thread is a worker, not the record loop, so the
+                         cost is paid in dropped display frames rather than
+                         overrun ones. It buys lower viewer memory and IPC
+                         bandwidth, which is worth having when the viewer is on
+                         another machine (``--display_ip``) and not much
+                         otherwise.
         log_images:      Log image entities at all. Scalars are always logged, so
                          turning this off thins the camera tiles without making
                          the pose and jaw plots sparse — the way to spend less
@@ -141,3 +148,146 @@ def log_rerun_data(
                     flat = v.flatten()
                     for i, vi in enumerate(flat):
                         rr.log(f"{key}_{i}", rr.Scalars(float(vi)))
+
+
+class RerunLogSink:
+    """Log to Rerun from a background thread, so the viewer costs the caller nothing.
+
+    ``log_rerun_data`` measures ~3.2 ms per frame on a bimanual rig with the head
+    camera (eight images), and its tail runs to ~10 ms whenever the viewer
+    backpressures the SDK's flush. Called inline from a 30 fps record loop that
+    already spends ~25 ms reading hardware, that is exactly the few milliseconds
+    that turn frames into ``[slow_frame] ... overrun=`` — which is why the data
+    team ended up recording with ``--display_data=false``.
+
+    Rerun's Rust bindings release the GIL for the heavy part of ``rr.log``, and on
+    Linux the loop paces itself with ``time.sleep``, so a worker does its work
+    inside the window the loop is idle anyway. Measured on that same eight-image
+    payload against a 24.1 ms viewer-off baseline: **27.2 ms inline, 24.1 ms
+    here** — the whole cost, tail included, leaves the loop.
+
+    The queue is **one frame deep and latest-wins**. If the viewer falls behind,
+    display frames are dropped rather than blocking capture: what is on screen is
+    always worth less than the loop that writes the dataset. Drops are counted and
+    reported once, at :meth:`close`.
+
+    Two consequences of logging off-loop, both display-only and both deliberate:
+
+    * Frames reach Rerun a few milliseconds late, so ``log_time`` lags capture by
+      up to one loop period. Nothing downstream reads it — the dataset carries its
+      own timestamps.
+    * The worker holds the images the loop just read while the loop moves on. They
+      are the same arrays ``dataset.add_frame`` already owns, so a camera that
+      recycled its buffer could tear a *displayed* frame. It cannot touch what is
+      recorded.
+    """
+
+    def __init__(self, traj_viz: Any = None, name: str = "rerun-sink") -> None:
+        self._traj_viz = traj_viz
+        # Depth-1 slot rather than a Queue: "latest wins" is the whole policy,
+        # and a Queue would need draining to express it.
+        self._slot: tuple | None = None
+        self._slot_lock = threading.Lock()
+        self._wake = threading.Event()
+        # Serialises the worker's traj_viz.log against reset_trajectory() from
+        # the caller's thread. Held only for the trail update (sub-millisecond),
+        # never for the image logging.
+        self._viz_lock = threading.Lock()
+        self._stop = threading.Event()
+        self._submitted = 0
+        self._dropped = 0
+        self._failures = 0
+        self._failure_logged = False
+        self._thread = threading.Thread(target=self._run, name=name, daemon=True)
+        self._thread.start()
+
+    def submit(
+        self,
+        observation: RobotObservation | None,
+        action: RobotAction | None = None,
+        compress_images: bool = False,
+        log_images: bool = True,
+    ) -> None:
+        """Hand one frame to the worker. Never blocks; never raises.
+
+        Replaces whatever the worker has not picked up yet — see the class
+        docstring on why dropping is the right failure mode here.
+        """
+        with self._slot_lock:
+            if self._slot is not None:
+                self._dropped += 1
+            self._slot = (observation, action, compress_images, log_images)
+            self._submitted += 1
+        self._wake.set()
+
+    def reset_trajectory(self) -> None:
+        """Clear the trajectory viz's breadcrumb trails (e.g. at a new episode).
+
+        Also drops any frame still queued: it belongs to the take that just
+        ended, and letting it through would seed the new trail with a stale
+        point.
+        """
+        if self._traj_viz is None:
+            return
+        with self._slot_lock:
+            if self._slot is not None:
+                self._dropped += 1
+                self._slot = None
+        with self._viz_lock:
+            self._traj_viz.reset()
+
+    def close(self, timeout: float = 2.0) -> None:
+        """Drain the pending frame, stop the worker, and report what was dropped."""
+        self._stop.set()
+        self._wake.set()
+        self._thread.join(timeout)
+        if self._thread.is_alive():
+            logger.warning(f"Rerun sink thread did not exit within {timeout:.1f}s.")
+        if self._dropped:
+            logger.info(
+                f"Rerun display: {self._dropped}/{self._submitted} frames dropped to keep the "
+                "loop on time (viewer-side only; nothing recorded was affected)."
+            )
+        if self._failures:
+            logger.warning(f"Rerun display: {self._failures} frames failed to log.")
+
+    # ---- worker ------------------------------------------------------------
+
+    def _run(self) -> None:
+        while True:
+            # Read the stop flag *before* claiming the slot, so a frame
+            # submitted before close() still gets logged on the way out.
+            stopping = self._stop.is_set()
+            with self._slot_lock:
+                item, self._slot = self._slot, None
+            if item is not None:
+                self._log_one(item)
+                continue
+            if stopping:
+                return
+            self._wake.wait(0.1)
+            self._wake.clear()
+
+    def _log_one(self, item: tuple) -> None:
+        observation, action, compress_images, log_images = item
+        try:
+            log_rerun_data(
+                observation=observation,
+                action=action or {},
+                compress_images=compress_images,
+                log_images=log_images,
+            )
+            if self._traj_viz is not None:
+                with self._viz_lock:
+                    self._traj_viz.log(observation)
+        except Exception as e:
+            # A dead viewer must never take a recording down with it. Warn once,
+            # then just count: the point of this class is to stop the display
+            # from generating per-frame log noise.
+            self._failures += 1
+            if not self._failure_logged:
+                self._failure_logged = True
+                logger.warning(
+                    f"Rerun logging failed ({type(e).__name__}: {e}); display frames will be "
+                    "dropped from here on. Recording is unaffected."
+                )

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -40,10 +40,12 @@ from lerobot.robots.taccap_gripper.common import (
     build_hardware_manifest,
     build_head_camera_configs,
     build_tactile_camera_configs,
+    check_dataset_station,
     connect_cameras_parallel,
     epoch_for_episode,
     hardware_manifest_unit,
     manifest_epochs,
+    manifest_robot_ids,
     open_gripper,
     read_head_camera_skew,
     resolve_wrist_undistorter,
@@ -757,6 +759,9 @@ class TestWriteHardwareManifest:
         path = write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
         on_disk = json.loads(path.read_text())
         assert on_disk["robot_type"] == "taccap_gripper"
+        # Dataset-level, beside robot_type: nothing may resume this dataset from
+        # another station, so the label is an invariant and is stated as one.
+        assert on_disk["robot_id"] == "taccap_0"
         (written,) = on_disk["epochs"]
         # Its shape is checked where it is the subject; dropped here so this
         # stays a test about the epoch boundary rather than about the clock.
@@ -808,25 +813,69 @@ class TestWriteHardwareManifest:
         epochs = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())["epochs"]
         assert [(e["from_episode"], e["to_episode"]) for e in epochs] == [(0, 57), (57, 90), (90, None)]
 
-    def test_the_same_devices_on_another_station_are_recorded_not_refused(self, tmp_path):
-        """``robot_id`` labels the station; the devices are the parts you swap in
-        and out of it. Moving a rig to another PC must not block the record —
-        refusing would also drop a device swap that coincided with the move, and
-        the devices are the part downstream cannot guess."""
+    def test_another_station_cannot_resume_the_dataset(self, tmp_path):
+        """One dataset is one station. A task recorded across two rigs mixes
+        their calibration, timing and mounting into episodes nothing downstream
+        can separate — and identical ``units`` do not make it one rig, because
+        the station is the seat, not the hardware in it."""
+        write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        before = (tmp_path / HARDWARE_MANIFEST_PATH).read_text()
+        moved = json.loads(json.dumps(self.MANIFEST))
+        moved["robot_id"] = "taccap_9"
+
+        with pytest.raises(ValueError, match="taccap_0.*taccap_9"):
+            write_hardware_manifest(tmp_path, moved, FakeLogger(), episode_index=57)
+
+        # Refused before anything was written: the file still describes only the
+        # episodes that are actually there.
+        assert (tmp_path / HARDWARE_MANIFEST_PATH).read_text() == before
+
+    def test_the_refusal_names_the_way_out(self, tmp_path):
+        """The fix is a new dataset or the original rig, and the message has to
+        say so — whoever hits this is mid-session with the hardware in hand."""
         write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
         moved = json.loads(json.dumps(self.MANIFEST))
         moved["robot_id"] = "taccap_9"
 
-        logger = FakeLogger()
-        write_hardware_manifest(tmp_path, moved, logger, episode_index=57)
+        with pytest.raises(ValueError) as excinfo:
+            write_hardware_manifest(tmp_path, moved, FakeLogger(), episode_index=57)
+        assert "repo_id" in str(excinfo.value)
 
-        epochs = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())["epochs"]
-        assert [(e["from_episode"], e["robot_id"]) for e in epochs] == [
-            (0, "taccap_0"),
-            (57, "taccap_9"),
-        ]
-        # Same hardware either side, so nothing downstream has to change sensor.
-        assert epochs[0]["units"] == epochs[1]["units"]
+    def test_the_station_check_precedes_the_swap_epoch(self, tmp_path):
+        """A device swap that coincides with a move to another PC is still a
+        refusal, not an epoch: the dataset is what is being protected, and it
+        cannot span two stations however much else changed with them."""
+        write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        moved_and_swapped = self._swapped()
+        moved_and_swapped["robot_id"] = "taccap_9"
+
+        with pytest.raises(ValueError, match="taccap_9"):
+            write_hardware_manifest(tmp_path, moved_and_swapped, FakeLogger(), episode_index=57)
+
+    def test_the_station_label_survives_a_hardware_swap(self, tmp_path):
+        """The top-level label describes the dataset, so appending an epoch must
+        carry it over — the rewrite replaces the whole file."""
+        write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        write_hardware_manifest(tmp_path, self._swapped(), FakeLogger(), episode_index=57)
+
+        on_disk = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
+        assert on_disk["robot_id"] == "taccap_0"
+        assert [e["robot_id"] for e in on_disk["epochs"]] == ["taccap_0", "taccap_0"]
+
+    def test_an_unlabelled_dataset_can_still_be_resumed(self, tmp_path):
+        """Recorded before ``--robot.id`` was required. The file cannot say the
+        station changed, and refusing on that would strand real datasets — same
+        reading as an open epoch: "nothing here says it changed"."""
+        legacy = json.loads(json.dumps(self.MANIFEST))
+        legacy["robot_id"] = None
+        write_hardware_manifest(tmp_path, legacy, FakeLogger())
+
+        logger = FakeLogger()
+        write_hardware_manifest(tmp_path, self.MANIFEST, logger, episode_index=57)
+
+        on_disk = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
+        assert on_disk["robot_id"] == "taccap_0"
+        assert [e["robot_id"] for e in on_disk["epochs"]] == [None, "taccap_0"]
         assert logger.warnings == []
 
     def test_swapping_one_arm_carries_the_other_over_untouched(self, tmp_path):
@@ -888,6 +937,95 @@ class TestWriteHardwareManifest:
 
         assert path.read_text() == "{ truncated"
         assert len(logger.warnings) == 1
+
+
+class TestStationCheck:
+    """One dataset, one station. The label is checked off ``--robot.id`` alone,
+    so this can run before a single device is powered up."""
+
+    MANIFEST = build_hardware_manifest(
+        robot_type="taccap_gripper",
+        robot_id="taccap_0",
+        role="leader",
+        units=[],
+    )
+
+    def test_a_dataset_with_no_manifest_is_not_a_mismatch(self, tmp_path):
+        """Recorded before manifests existed, or not recorded yet at all. There
+        is no station on record to disagree with."""
+        check_dataset_station(tmp_path, "taccap_0")
+
+    def test_the_same_station_passes(self, tmp_path):
+        write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        check_dataset_station(tmp_path, "taccap_0")
+
+    def test_another_station_raises_before_any_hardware_is_touched(self, tmp_path):
+        write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        with pytest.raises(ValueError, match="taccap_1"):
+            check_dataset_station(tmp_path, "taccap_1")
+
+    def test_an_unreadable_manifest_is_left_to_the_writer(self, tmp_path):
+        """It complains about a truncated file already. Raising here too would
+        turn one problem into two errors, and the earlier one would blame the
+        station for a mismatch nobody can read."""
+        path = tmp_path / HARDWARE_MANIFEST_PATH
+        path.parent.mkdir(parents=True)
+        path.write_text("{ truncated")
+
+        check_dataset_station(tmp_path, "taccap_1")
+
+    def test_a_pre_epoch_manifest_is_still_enforced(self, tmp_path):
+        """Old shape, no ``epochs`` — the label sits at the top level, which is
+        where the check has to find it or it silently passes everything."""
+        path = tmp_path / HARDWARE_MANIFEST_PATH
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps({"robot_type": "taccap_gripper", "robot_id": "taccap_0", "units": []}))
+
+        with pytest.raises(ValueError, match="taccap_0"):
+            check_dataset_station(tmp_path, "taccap_1")
+
+    def test_an_epoch_only_label_is_still_enforced(self, tmp_path):
+        """Written after epochs but before the top-level key. The label is only
+        on the epochs, and a check that read the top level alone would let
+        another rig resume every dataset recorded in that window."""
+        path = tmp_path / HARDWARE_MANIFEST_PATH
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "robot_type": "taccap_gripper",
+                    "epochs": [{"from_episode": 0, "to_episode": None, "robot_id": "taccap_0", "units": []}],
+                }
+            )
+        )
+
+        with pytest.raises(ValueError, match="taccap_0"):
+            check_dataset_station(tmp_path, "taccap_1")
+
+    def test_a_run_with_no_label_of_its_own_cannot_disagree(self, tmp_path):
+        """``--robot.id`` is required of both TacCap robots, so this is another
+        caller. Unknown is not a mismatch, in either direction."""
+        write_hardware_manifest(tmp_path, self.MANIFEST, FakeLogger())
+        check_dataset_station(tmp_path, None)
+
+
+class TestManifestRobotIds:
+    def test_both_places_are_read_and_blanks_dropped(self):
+        """Absent is the absence of an answer, not a station to compare against;
+        reporting it as ``None`` would make an unlabelled epoch look like a
+        second rig."""
+        manifest = {
+            "robot_id": "taccap_0",
+            "epochs": [
+                {"robot_id": None, "units": []},
+                {"robot_id": "taccap_0", "units": []},
+                {"units": []},
+            ],
+        }
+        assert manifest_robot_ids(manifest) == {"taccap_0"}
+
+    def test_a_dataset_that_predates_the_label_names_no_station(self):
+        assert manifest_robot_ids({"robot_type": "taccap_gripper", "units": []}) == set()
 
 
 class TestManifestEpochs:

--- a/tests/utils/test_visualization_utils.py
+++ b/tests/utils/test_visualization_utils.py
@@ -22,7 +22,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from lerobot.utils.constants import OBS_STATE
+from lerobot.utils.constants import OBS_STATE, OBS_STR
 
 
 class TransitionKey(str, Enum):
@@ -309,3 +309,166 @@ def test_log_images_false_still_logs_1d_arrays_as_scalars(mock_rerun):
     )
 
     assert set(_keys(calls)) == {"observation.vec_0", "observation.vec_1"}
+
+
+# ---------------------------------------------------------------- RerunLogSink
+#
+# The sink exists to keep Rerun off the record loop's critical path: logging
+# inline measured 27.2 ms/frame against a 24.1 ms viewer-off baseline on a
+# bimanual eight-image payload, and those few milliseconds are what produced the
+# `[slow_frame] ... overrun=` warnings the data team worked around by recording
+# with the viewer off. So the properties worth pinning are: the caller never
+# waits, and nothing the worker hits can reach the caller.
+
+
+class _RecordingViz:
+    """Stand-in for TaccapTrajectoryViz: records what it was handed."""
+
+    def __init__(self, on_log=None):
+        self.logged = []
+        self.resets = 0
+        self._on_log = on_log
+
+    def log(self, data):
+        if self._on_log is not None:
+            self._on_log(data)
+        self.logged.append(data)
+
+    def reset(self):
+        self.resets += 1
+
+
+def _drain(sink, timeout=2.0):
+    """Wait for the worker to have nothing left, without closing the sink."""
+    import time
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with sink._slot_lock:
+            empty = sink._slot is None
+        if empty:
+            time.sleep(0.02)  # let the in-flight frame finish
+            return True
+        time.sleep(0.005)
+    return False
+
+
+def test_sink_logs_frames_and_feeds_the_trajectory_viz(mock_rerun):
+    vu, calls = mock_rerun
+    viz = _RecordingViz()
+    sink = vu.RerunLogSink(traj_viz=viz)
+    try:
+        sink.submit({"gripper.pos": 0.5}, {"gripper.pos": 0.5})
+        assert _drain(sink)
+    finally:
+        sink.close()
+
+    assert f"{OBS_STR}.gripper.pos" in _keys(calls)
+    assert viz.logged == [{"gripper.pos": 0.5}]
+
+
+def test_close_drains_the_pending_frame(mock_rerun):
+    """A frame submitted right before close() still reaches the viewer, so the
+    display ends on the last thing recorded rather than one frame short."""
+    vu, calls = mock_rerun
+    sink = vu.RerunLogSink()
+    sink.submit({"gripper.pos": 1.25}, {})
+    sink.close()
+
+    assert _obj_for(calls, f"{OBS_STR}.gripper.pos").value == pytest.approx(1.25)
+
+
+def test_submit_never_blocks_and_drops_to_the_latest_frame(mock_rerun):
+    """The whole point: a stalled viewer costs the caller nothing, and what it
+    misses is the *stale* frames — the newest one always survives."""
+    import threading
+    import time
+
+    vu, calls = mock_rerun
+    release = threading.Event()
+    first = threading.Event()
+
+    def block_once(_data):
+        if not first.is_set():
+            first.set()
+            release.wait(5.0)
+
+    viz = _RecordingViz(on_log=block_once)
+    sink = vu.RerunLogSink(traj_viz=viz)
+    try:
+        sink.submit({"gripper.pos": 0.0}, {})
+        assert first.wait(2.0), "worker never picked up the first frame"
+
+        # Worker is wedged. Every one of these lands on the caller's thread.
+        t0 = time.perf_counter()
+        for i in range(1, 51):
+            sink.submit({"gripper.pos": float(i)}, {})
+        elapsed_ms = (time.perf_counter() - t0) * 1e3
+
+        assert elapsed_ms < 50, f"submit blocked: 50 frames took {elapsed_ms:.1f}ms"
+        assert sink._dropped == 49, f"expected 49 stale frames dropped, got {sink._dropped}"
+
+        release.set()
+        assert _drain(sink)
+    finally:
+        release.set()
+        sink.close()
+
+    # 49 dropped, so the viewer saw the first frame and the newest one only.
+    assert viz.logged == [{"gripper.pos": 0.0}, {"gripper.pos": 50.0}]
+
+
+def test_reset_trajectory_clears_trails_and_drops_the_queued_frame(mock_rerun):
+    """Between episodes: the frame still in flight belongs to the take that just
+    ended and must not seed the new trail."""
+    import threading
+
+    vu, _calls = mock_rerun
+    release = threading.Event()
+    first = threading.Event()
+
+    def block_once(_data):
+        if not first.is_set():
+            first.set()
+            release.wait(5.0)
+
+    viz = _RecordingViz(on_log=block_once)
+    sink = vu.RerunLogSink(traj_viz=viz)
+    try:
+        sink.submit({"gripper.pos": 0.0}, {})
+        assert first.wait(2.0)
+        sink.submit({"gripper.pos": 1.0}, {})  # queued behind the wedged worker
+
+        sink.reset_trajectory()
+        with sink._slot_lock:
+            assert sink._slot is None, "reset_trajectory left a stale frame queued"
+        assert viz.resets == 1
+
+        release.set()
+        assert _drain(sink)
+    finally:
+        release.set()
+        sink.close()
+
+    assert viz.logged == [{"gripper.pos": 0.0}]
+
+
+def test_a_failing_viewer_never_reaches_the_caller(mock_rerun):
+    """A dead viewer must not take a recording down, and must not spam a warning
+    per frame — that would just trade one flood of log lines for another."""
+    vu, _calls = mock_rerun
+
+    def boom(*_a, **_k):
+        raise RuntimeError("viewer went away")
+
+    vu.rr.log = boom
+    sink = vu.RerunLogSink()
+    try:
+        for i in range(10):
+            sink.submit({"gripper.pos": float(i)}, {})
+            assert _drain(sink)
+    finally:
+        sink.close()
+
+    assert sink._failures > 0
+    assert sink._failure_logged is True  # warned once, then counted


### PR DESCRIPTION
数采反馈:录制时必须关掉 rerun,否则大量 `[slow_frame] ... overrun=` 告警。

> 已 rebase 到 `c3b70237`,SHA 全部变更(见下)。`c3b70237` 与本分支在
> `self_driven_record_loop` 和 CLAUDE.md 两处交错,详见末节"与 main 的交互"。

## 主修复 — `d7833d14`

`log_rerun_data` 跑在录制循环里。双臂 + 头部相机每帧 8 张图,实测 ~3.2ms,
viewer 反压时尾部到 ~10ms。循环本身读硬件已 ~25ms,30fps 预算 33.3ms —— 就是
这几毫秒压垮的。

新增 `RerunLogSink`,日志搬到独立 worker 线程。成立的前提是 rerun 的 Rust
binding 在 `rr.log` 重活期间释放 GIL,且 Linux 上 `busy_wait` 是 `time.sleep`
—— worker 正好用循环本就空转的窗口干活。

| 模式 | loop mean | p90 | max |
| --- | --- | --- | --- |
| rerun 关(基线) | 24.09ms | 24.14 | 24.18 |
| rerun 内联(改前) | 27.24ms | 27.61 | 27.92 |
| rerun 后台(改后) | **24.08ms** | 24.11 | 24.22 |

真 SDK 端到端:`submit()` 本身 30µs(p99 81µs),对比内联 3200µs。
**开着 rerun 录制现在和关掉一样快。**

队列一帧深、后到覆盖先到:viewer 跟不上就丢显示帧而不阻塞采集,丢帧计数在
`close()` 汇报一次。`lerobot-teleoperate` 同病同治。

## 数据集与工位绑定 — `b9dc2267`

原先 `--robot.id` 只是本机的标定文件名和日志前缀,数据集完全不知道它的存在:
同一个 task 在 `taccap_0` 上录一半、在 `taccap_1` 上 `--resume` 录另一半,
不报错也不留痕。两条改动:

- **`robot_id` 提到 `meta/hardware.json` 顶层**,与 `robot_type` 并列。epoch
  里那份保留,老读者不受影响;`manifest_robot_ids()` 两处都读,所以在顶层键
  存在之前写的文件(只有 epoch 有)和 pre-epoch 形状的(只有顶层有)都查得出来。
- **跨工位 `--resume` 直接 `ValueError`**,不再是"开一个新 epoch"。检查两处:
  `lerobot-record` 载入数据集之后、**`robot.connect()` 之前**跑一次(id 来自
  config,不需要硬件),工位不对的话夹爪/触觉/tracker 全部不用白上电;
  `write_hardware_manifest` 里再跑一次,那是所有写入者的必经点。

三个刻意的边界,都有测试和 docstring:

| 情形 | 行为 |
| --- | --- |
| 换工位 + 同时换设备 | 拒绝(检查排在 epoch 追加之前) |
| `units` 完全相同、只换工位 | 拒绝 —— 标签命名的是**座位**,安装、光照、操作员都在座位上 |
| 任一侧无 `robot_id`(`--robot.id` 成为必填之前录的) | 放行 —— 文件说不出"工位变了",拒绝会堵死真实数据集 |

这条推翻了之前"换工位只开新 epoch、不拒绝"的规则,对应的测试
(`test_the_same_devices_on_another_station_are_recorded_not_refused`)已删除并
换成反向断言。

## 其余

- `fdca2fdc` 立体轮询 120 → 60 Hz(对 29.9fps 仍是 2x 过采样),并把原先全仓
  无人读取的 `dropped_unpaired` / `decode_failures` 接到 `stop()` 汇报 ——
  降频之后总得有仪表判断降得对不对。两者为 0 时完全静默。
  _与 overrun 无关_,poller 本就不在录制循环上,省的是 CPU 不是帧预算。
- `3fb0c2d2` 删掉 `go_start`:全仓只写不读,Space 键只是打印一句兑现不了的
  "Robot will go to start pose..."。连带删掉喂它的 `refresh_events_from_teleop`
  和随之变空壳、却每帧调用的 `refresh_listener_events`。
- `a8e0ee77` Unity origin 提示改为每进程一次(原先双臂两个 reader 各打一遍,
  且在任何事情出错之前)。

## 与 main 的交互(rebase 结果)

- **`lerobot_record.py`** — `origin/main` 用 `set_capture_recording(True/False)`
  包住了录制循环并在其后汇报 `[stale_frames]`;本分支把该调用的
  `traj_viz=traj_viz` 换成了 `rerun_sink=rerun_sink`。保留 main 的整块,只改
  那一个实参。
- **`control_utils.py`** — main 仍留着 `go_start`。已确认前提未变:在
  `origin/main` 上它依然只被写、从未被读,故按本分支删除。
- **CLAUDE.md** — `c3b70237` 新增的"The event contract"一节举证时写道
  "the teleop refresh (`control_utils.refresh_events_from_teleop`) writes only
  `go_start`",而本分支正好删掉了这条路径。两边改的是文件不同区域,git 无冲突
  合并,结果是新文档引用了本分支删除的函数。已改为说明该写入方已消失、表中三个
  标志即完整清单,并用 `--fixup` 折进 `3fb0c2d2` —— 删机器的提交自己带上文档
  修正。

## 验证

660 passed / 7 skipped。本地 conda 环境缺 `safetensors`,`test_datasets.py` /
`test_image_transforms.py` / `test_random_utils.py` 三个模块无法 collect,已
`--ignore`(本 PR 未触及这三个)。`ruff check` / `ruff format` 结果与
`origin/main` 逐项一致 —— 余下 7 个 `UP042` 和 `cameras/xense/README.md` 的
格式项都是继承的,非本 PR 引入。

新增测试:5 个 sink 测试(不阻塞、丢最旧保最新、reset 清掉在途帧、viewer 挂掉
不上抛且只警告一次、close 排空),以及工位绑定的 `TestStationCheck` /
`TestManifestRobotIds` 两组 + 写入侧的拒绝/放行断言。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
