### PR TITLE
fix(record): 修掉打死采集会话的 exit_early 滞留，并把日志收敛到 spdlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,98 @@ Discovery deliberately loads without holding (`ensure_loaded`), so one-shot
 enumeration cannot leak a hold. Closing matters: the SDK's joinable
 `std::thread`s call `std::terminate()` if the process exits without it.
 
+## Logging goes through spdlog — including the stdlib
+
+`utils/robot_utils.py:get_logger()` is the logger for this fork. Two things
+about it are load-bearing:
+
+- **`init_logging()` installs a stdlib→spdlog bridge, not a `StreamHandler`.**
+  Upstream lerobot, `xensesdk` and libav all log through `logging`, so without
+  the bridge they took a different path, to a different stream, in a different
+  format, and never reached the session file. Those were the
+  `INFO 2026-08-27 16:58:52 eo_utils.py:189` lines — whose location field is the
+  _tail_ of the path cut to 15 chars, which is why `video_utils.py` reads as
+  `eo_utils.py`. `install_stdlib_bridge()` clears root's handlers on purpose:
+  leaving one in place is how every line gets printed twice. The bridge names
+  each record by its **module**, because upstream logs via the root logger and
+  `root` identifies nothing.
+- **`get_logger()` caches per `(name, level)` and shares its sinks.** Calling it
+  twice for one name used to stack a second stdout sink onto the same terminal.
+  Sinks in this pybind expose only `set_level` — no `Sink.set_pattern` — so the
+  pattern is set on the logger and both sinks render `SPDLOG_PATTERN`;
+  `FILE_LOG_PATTERN` is aspirational until the binding grows one.
+
+Console level is `$XENSE_LOG_LEVEL` (default INFO), the session file is
+`$XENSE_LOG_DIR/session_<ts>.log` (default `~/xenselogs`, 15 files kept). The
+bridge filters at the console level _before_ spdlog sees a record, so the
+DEBUG-level file does not fill with third-party chatter.
+
+### Per-frame timings are warnings, not debug lines — `SlowCallMonitor`
+
+Every camera backend used to end `read()` with
+`logger.debug(f"{self} read took: {ms:.1f}ms")`. On a bimanual rig that is six
+cameras at 30 Hz: ~180 records a second, ~1 MiB a minute, none of it on the
+console (the sink filters at INFO) and all of it in the DEBUG-level session
+file. `SlowCallMonitor` (`utils/robot_utils.py`) replaces it — the first overrun
+after a clean window is logged as it happens, the rest of the window is folded
+into one summary, and reads inside budget say nothing at all. A camera with no
+configured `fps` has no budget and is therefore silent by design. `str(owner)`
+is resolved only when a warning is actually emitted; building it per call is the
+cost the class exists to avoid. The record loop's `[slow_frame] ... top_obs=`
+line already attributes a blown frame to individual cameras, so this covers the
+other case: a camera over budget while the loop as a whole still makes it.
+
+### libav noise — `quiet_libav()`, not `setLevel`
+
+`video_utils.py` calls `av.logging.restore_default_callback()` deliberately:
+PyAV's Python callback "sometimes doesn't play nicely with multi-threaded
+workflows" and the streaming encoder is threaded. But once restored, **only
+ffmpeg's own level matters** — the `logging.getLogger("libav").setLevel(...)`
+calls that sat next to it did nothing, which is why every episode save printed a
+screen of `[mov,mp4,...] Auto-inserting h264_mp4toannexb bitstream filter` and
+`Starting second pass: moving the moov atom`. `quiet_libav()` sets
+`av.logging.set_libav_level` (the native printer) **and** `set_level` (PyAV's
+callback, feeding the bridge), at ERROR — not `None`, because PyAV drops the
+message text from raised exceptions when its logging is fully off. Those two
+constant scales are different (libav `WARNING` is 24, stdlib's is 30); do not
+pass one to the other.
+
+### Keyboard events are a global X hook, not terminal input
+
+`control_utils.init_keyboard_listener()` uses `pynput`, which hooks the whole X
+session through XRecord. A right arrow pressed in **any** window — the Rerun
+viewer (whose timeline steps on arrow keys), a browser, another shell, and in a
+container the whole _host_ desktop — ends the episode exactly as if it had been
+typed at the recording terminal. When an operator reports "it exited and I never
+touched the arrow key", that is the mechanism; the handler logs through spdlog
+so the press carries a timestamp. It used to be a bare `print()`, which is
+block-buffered on a redirected stdout and could therefore surface in a captured
+log well after the press it described.
+
+`exit_early` is cleared at the top of each episode in `lerobot_record.py`, and
+that line is load-bearing. The listener runs for the whole session but only the
+record/reset loops consume the flag, and between the reset loop ending and the
+next episode starting there is a gap — `save_episode()` plus the encoder warm-up
+— with no consumer (~2s with streaming encoding, much longer without).
+
+A right arrow pressed there is still set when the next episode's first iteration
+checks it. That episode ends after zero frames, the reset then runs its **full**
+duration, and `save_episode()` reaches `validate_episode_buffer`, which raises on
+an empty buffer — `You must add one or several frames with add_frame`. The
+session dies mid-collection, minutes after the press that caused it, which is
+what makes it hard to connect back to a key someone pressed.
+
+`rerecord_episode` has a related hole (the record loop breaks on it without
+clearing it) but that one is **self-correcting**: it short-circuits the reset
+too, so the empty buffer reaches `clear_episode_buffer()` rather than
+`save_episode()` and the episode is just retried. It is cleared alongside anyway,
+to avoid announcing "Re-record episode" for an episode that never started.
+`stop_recording` is deliberately _not_ cleared: that one should survive the gap.
+
+Upstream lerobot and the sister repo `lerobot-xense` both carry this hole — the
+event-flag lifecycle there is byte-identical to ours — so the clear is a
+deliberate divergence, not a fork-local quirk being papered over.
+
 ## Recorded files land 0600 if they come from a temp file
 
 Python's temp-file APIs create restrictively **on purpose**, and `shutil.move` /

--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -35,6 +35,7 @@ import cv2  # type: ignore  # TODO: add type stubs for OpenCV
 
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
 from lerobot.utils.errors import DeviceNotConnectedError
+from lerobot.utils.robot_utils import SlowCallMonitor
 
 from ..camera import Camera
 from ..utils import get_cv2_rotation
@@ -143,6 +144,9 @@ class OpenCVCamera(Camera):
             config: The configuration settings for the camera.
         """
         super().__init__(config)
+        # Per-read timing is reported only when it overruns the frame budget;
+        # see SlowCallMonitor for why the old per-read debug line is gone.
+        self._slow_read = SlowCallMonitor(logger, self)
 
         self.config = config
         self.index_or_path = config.index_or_path
@@ -515,7 +519,7 @@ class OpenCVCamera(Camera):
         frame = self.async_read(timeout_ms=10000)
 
         read_duration_ms = (time.perf_counter() - start_time) * 1e3
-        logger.debug(f"{self} read took: {read_duration_ms:.1f}ms")
+        self._slow_read.observe(read_duration_ms, 1e3 / self.fps if self.fps else None)
 
         return frame
 

--- a/src/lerobot/cameras/pico/debug_viewer.py
+++ b/src/lerobot/cameras/pico/debug_viewer.py
@@ -27,6 +27,8 @@ import cv2
 import numpy as np
 from PIL import Image, ImageTk
 
+from lerobot.utils.robot_utils import get_logger
+
 REQUIRED_XRT_APIS = (
     "has_pico_camera_frame",
     "get_pico_camera_frame_metadata",
@@ -49,6 +51,7 @@ def load_xensevr_sdk():
 
 
 xrt = load_xensevr_sdk()
+logger = get_logger("PicoDebugViewer")
 
 
 EYES = {
@@ -157,12 +160,12 @@ class CameraViewer:
             self.status_vars[eye_index] = status_var
 
     def start(self):
-        print("Initializing XenseVR PC Service SDK...")
+        logger.info("Initializing XenseVR PC Service SDK...")
         xrt.init()
         self.sdk_initialized = True
-        print("SDK initialized. Close the window or press Ctrl+C to exit.")
+        logger.info("SDK initialized. Close the window or press Ctrl+C to exit.")
         if self.args.once:
-            print("--once enabled: exits after one left frame and one right frame are displayed.")
+            logger.info("--once enabled: exits after one left frame and one right frame are displayed.")
         self.root.after(0, self.update_once)
 
     def update_once(self):
@@ -211,10 +214,10 @@ class CameraViewer:
         self.photo_refs.clear()
         gc.collect()
         if self.sdk_initialized:
-            print("Closing SDK...")
+            logger.info("Closing SDK...")
             xrt.close()
             self.sdk_initialized = False
-            print("SDK closed.")
+            logger.info("SDK closed.")
         self.root.destroy()
 
 
@@ -225,7 +228,7 @@ def run_camera_viewer(args):
         viewer.start()
         root.mainloop()
     except KeyboardInterrupt:
-        print("\nInterrupted by user.")
+        logger.info("Interrupted by user.")
         if viewer.running:
             viewer.stop()
 

--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -32,6 +32,7 @@ except Exception as e:
 
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
 from lerobot.utils.errors import DeviceNotConnectedError
+from lerobot.utils.robot_utils import SlowCallMonitor
 
 from ..camera import Camera
 from ..configs import ColorMode
@@ -114,6 +115,9 @@ class RealSenseCamera(Camera):
         """
 
         super().__init__(config)
+        # Per-read timing is reported only when it overruns the frame budget;
+        # see SlowCallMonitor for why the old per-read debug line is gone.
+        self._slow_read = SlowCallMonitor(logger, self)
 
         self.config = config
 
@@ -399,7 +403,7 @@ class RealSenseCamera(Camera):
         frame = self.async_read(timeout_ms=10000)
 
         read_duration_ms = (time.perf_counter() - start_time) * 1e3
-        logger.debug(f"{self} read took: {read_duration_ms:.1f}ms")
+        self._slow_read.observe(read_duration_ms, 1e3 / self.fps if self.fps else None)
 
         return frame
 

--- a/src/lerobot/cameras/xense/camera_xense.py
+++ b/src/lerobot/cameras/xense/camera_xense.py
@@ -25,7 +25,7 @@ from typing import Any, cast
 import numpy as np
 
 from lerobot.utils.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
-from lerobot.utils.robot_utils import get_logger
+from lerobot.utils.robot_utils import SlowCallMonitor, get_logger
 
 from ..camera import Camera
 from .configuration_xense import XenseOutputType, XenseTactileCameraConfig
@@ -138,6 +138,9 @@ class XenseTactileCamera(Camera):
             config: The configuration settings for the Xense sensor.
         """
         super().__init__(config)
+        # Per-read timing is reported only when it overruns the frame budget;
+        # see SlowCallMonitor for why the old per-read debug line is gone.
+        self._slow_read = SlowCallMonitor(logger, self)
 
         self.config = config
         self.serial_number = config.serial_number
@@ -452,7 +455,7 @@ class XenseTactileCamera(Camera):
         formatted = self._format_read_result(data)
 
         read_duration_ms = (time.perf_counter() - start_time) * 1e3
-        logger.debug(f"{self} read took: {read_duration_ms:.1f}ms")
+        self._slow_read.observe(read_duration_ms, 1e3 / self.fps if self.fps else None)
 
         return formatted
 

--- a/src/lerobot/cameras/zmq/camera_zmq.py
+++ b/src/lerobot/cameras/zmq/camera_zmq.py
@@ -36,6 +36,7 @@ from numpy.typing import NDArray
 
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
 from lerobot.utils.errors import DeviceNotConnectedError
+from lerobot.utils.robot_utils import SlowCallMonitor
 
 from ..camera import Camera
 from ..configs import ColorMode
@@ -75,6 +76,9 @@ class ZMQCamera(Camera):
 
     def __init__(self, config: ZMQCameraConfig):
         super().__init__(config)
+        # Per-read timing is reported only when it overruns the frame budget;
+        # see SlowCallMonitor for why the old per-read debug line is gone.
+        self._slow_read = SlowCallMonitor(logger, self)
         import zmq
 
         self.config = config
@@ -234,7 +238,7 @@ class ZMQCamera(Camera):
         frame = self.async_read(timeout_ms=10000)
 
         read_duration_ms = (time.perf_counter() - start_time) * 1e3
-        logger.debug(f"{self} read took: {read_duration_ms:.1f}ms")
+        self._slow_read.observe(read_duration_ms, 1e3 / self.fps if self.fps else None)
 
         return frame
 

--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -53,6 +53,56 @@ HW_ENCODERS = [
 
 VALID_VIDEO_CODECS = {"h264", "hevc", "libsvtav1", "auto"} | set(HW_ENCODERS)
 
+# libav speaks its own level scale (PANIC=0 … DEBUG=48), Python's logging speaks
+# another (DEBUG=10 … CRITICAL=50). Passing an av constant straight to a stdlib
+# setLevel — which the call sites used to do — pins the stdlib logger to 24, not
+# a stdlib level at all; it only happens to sit between INFO and WARNING.
+_AV_TO_STDLIB_LEVEL = {
+    av.logging.PANIC: logging.CRITICAL,
+    av.logging.FATAL: logging.CRITICAL,
+    av.logging.ERROR: logging.ERROR,
+    av.logging.WARNING: logging.WARNING,
+    av.logging.INFO: logging.INFO,
+    av.logging.VERBOSE: logging.DEBUG,
+    av.logging.DEBUG: logging.DEBUG,
+}
+
+
+def quiet_libav(av_level: int = av.logging.ERROR) -> None:
+    """Stop libav from narrating routine muxing onto the terminal.
+
+    Encoding an episode emits a handful of AV_LOG_INFO lines per video — the
+    ``[mov,mp4,...] Auto-inserting h264_mp4toannexb bitstream filter`` and
+    ``Starting second pass: moving the moov atom`` blocks. With six cameras and
+    one save per episode that is a screen of undated, unattributed text between
+    two useful log lines, and none of it says anything a normal save does not.
+
+    Both levers are needed because there are two paths out of libav:
+
+    * ``set_libav_level`` is ffmpeg's own ``av_log_set_level`` and governs what
+      the **native** callback prints straight to stderr. That is the live path
+      here — the encode helpers below call
+      :func:`av.logging.restore_default_callback`, deliberately, because PyAV's
+      Python callback "sometimes doesn't play nicely with multi-threaded
+      workflows" and the streaming encoder is threaded. Once restored, this is
+      the only lever that has any effect, which is why the pre-existing
+      ``setLevel`` calls did nothing about the noise.
+    * ``set_level`` governs PyAV's Python callback, which feeds
+      ``logging.getLogger("libav")`` and, through the stdlib bridge, spdlog and
+      the session file. ERROR rather than ``None`` on purpose: PyAV drops the
+      message text from raised exceptions when its logging is fully off.
+
+    ERROR, not WARNING: a hardware encoder that is absent logs at ERROR while we
+    are only probing whether it opens, so that path mutes itself separately
+    (see ``_probe_hw_encoders``).
+    """
+    av.logging.set_libav_level(av_level)
+    av.logging.set_level(av_level)
+    logging.getLogger("libav").setLevel(_AV_TO_STDLIB_LEVEL.get(av_level, logging.WARNING))
+
+
+quiet_libav()
+
 
 def _get_codec_options(
     vcodec: str,
@@ -520,10 +570,9 @@ def encode_video_frames(
         else:
             video_options["threads"] = str(encoder_threads)
 
-    # Set logging level
+    # Set logging level (av scale in, both libav and stdlib levels out)
     if log_level is not None:
-        # "While less efficient, it is generally preferable to modify logging with Python's logging"
-        logging.getLogger("libav").setLevel(log_level)
+        quiet_libav(log_level)
 
     # Create and open output file (overwrite by default)
     with av.open(str(video_path), "w") as output:
@@ -722,7 +771,7 @@ class _CameraEncoderThread(threading.Thread):
         frame_count = 0
 
         try:
-            logging.getLogger("libav").setLevel(av.logging.WARNING)
+            quiet_libav(av.logging.WARNING)
 
             # Warmup: open the encoder up front when the frame shape is known, so
             # the codec context is hot before the first frame is fed.
@@ -1093,7 +1142,7 @@ with warnings.catch_warnings():
 
 def get_audio_info(video_path: Path | str) -> dict:
     # Set logging level
-    logging.getLogger("libav").setLevel(av.logging.WARNING)
+    quiet_libav(av.logging.WARNING)
 
     # Getting audio stream information
     audio_info = {}
@@ -1125,7 +1174,7 @@ def get_audio_info(video_path: Path | str) -> dict:
 
 def get_video_info(video_path: Path | str) -> dict:
     # Set logging level
-    logging.getLogger("libav").setLevel(av.logging.WARNING)
+    quiet_libav(av.logging.WARNING)
 
     # Getting video stream information
     video_info = {}

--- a/src/lerobot/robots/taccap_gripper/check_tracker.py
+++ b/src/lerobot/robots/taccap_gripper/check_tracker.py
@@ -45,6 +45,9 @@ import numpy as np
 
 from lerobot.robots.taccap_gripper.ee_transform import tracker_to_tcp
 from lerobot.teleoperators.pico4.tracker import Pico4TrackerReader
+from lerobot.utils.robot_utils import get_logger
+
+logger = get_logger("check_tracker")
 
 
 def main() -> None:
@@ -61,16 +64,16 @@ def main() -> None:
 
     if args.side is None:
         ee_pos, ee_quat = np.zeros(3), np.array([1.0, 0.0, 0.0, 0.0])
-        print("[check] no --side: transform is identity, 'ee' will track 'raw'.")
+        logger.info("no --side: transform is identity, 'ee' will track 'raw'.")
     else:
         ee_pos, ee_quat = tracker_to_tcp(args.side)
         offset_mm = float(np.linalg.norm(ee_pos)) * 1e3
-        print(f"[check] side={args.side} tracker→TCP pos={ee_pos.tolist()} quat={ee_quat.tolist()}")
-        print(f"[check] TCP sits {offset_mm:.2f} mm from the tracker origin.")
+        logger.info(f"side={args.side} tracker→TCP pos={ee_pos.tolist()} quat={ee_quat.tolist()}")
+        logger.info(f"TCP sits {offset_mm:.2f} mm from the tracker origin.")
 
     reader = Pico4TrackerReader(tracker_sn=args.tracker_sn, tracker_to_ee_pos=ee_pos, tracker_to_ee_quat=ee_quat)
     reader.connect()
-    print("[check] tracker connected. Press Ctrl+C to stop.")
+    logger.info("Tracker connected. Press Ctrl+C to stop.")
 
     t_start = time.monotonic()
     try:
@@ -90,8 +93,8 @@ def main() -> None:
                     flush=True,
                 )
             if args.duration > 0 and t >= args.duration:
-                print()
-                print(f"[check] reached duration={args.duration}s")
+                print()  # close the in-place status line before logging
+                logger.info(f"Reached duration={args.duration}s")
                 break
             time.sleep(0.1)
     except KeyboardInterrupt:

--- a/src/lerobot/robots/taccap_gripper/taccap_gripper_example.py
+++ b/src/lerobot/robots/taccap_gripper/taccap_gripper_example.py
@@ -49,6 +49,9 @@ import pprint
 import time
 
 from lerobot.robots.taccap_gripper import TaccapGripper, TaccapGripperConfig
+from lerobot.utils.robot_utils import get_logger
+
+logger = get_logger("taccap_example")
 
 
 def main() -> None:
@@ -91,10 +94,10 @@ def main() -> None:
 
     robot = TaccapGripper(cfg)
 
-    print("[example] observation features:")
-    pprint.pprint(robot.observation_features)
-    print("[example] action features:")
-    pprint.pprint(robot.action_features)
+    # pformat, not pprint: keeps the schema dump inside the log record so it
+    # reaches the session file along with everything else.
+    logger.info(f"observation features:\n{pprint.pformat(robot.observation_features)}")
+    logger.info(f"action features:\n{pprint.pformat(robot.action_features)}")
 
     robot.connect()
     try:

--- a/src/lerobot/robots/taccap_gripper/visualization.py
+++ b/src/lerobot/robots/taccap_gripper/visualization.py
@@ -32,7 +32,6 @@ rotation matrix (``rotation_6d_to_quaternion``). When no ``tcp.*`` keys are pres
 
 from __future__ import annotations
 
-import logging
 from collections import deque
 from typing import Any
 
@@ -40,9 +39,9 @@ import numpy as np
 import rerun as rr
 import rerun.blueprint as rrb
 
-from lerobot.utils.robot_utils import rotation_6d_to_quaternion
+from lerobot.utils.robot_utils import get_logger, rotation_6d_to_quaternion
 
-logger = logging.getLogger(__name__)
+logger = get_logger("taccap_viz")
 
 # Per-side marker / trail colour. Empty key = the single unprefixed unit.
 _SIDE_COLOR = {

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -532,6 +532,40 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                 # doesn't overrun on encoder/codec initialization.
                 dataset.prepare_episode_recording()
 
+                # Discard any exit request that arrived while nothing was
+                # reading events. The keyboard listener runs for the whole
+                # session, but only the record/reset loops consume these flags —
+                # between the reset loop ending and the next episode starting
+                # there is a gap (save_episode + the encoder warm-up above) with
+                # no consumer, ~2s here with streaming encoding and much longer
+                # without it.
+                #
+                # A right arrow in that gap — the natural double-press when the
+                # reset happens to time out on its own just as the operator
+                # reaches for the key — is still set when this episode's first
+                # iteration checks it. The episode ends after zero frames, the
+                # reset then runs its full duration (the flag was consumed by
+                # that break), and `save_episode()` below hits
+                # `validate_episode_buffer`, which raises on an empty buffer:
+                # "You must add one or several frames with `add_frame`". That
+                # kills the session, mid-collection, minutes after the press.
+                #
+                # `rerecord_episode` has a related hole — the record loop breaks
+                # on it without clearing it — but that one is self-correcting: it
+                # also short-circuits the reset, so the empty buffer reaches
+                # `clear_episode_buffer()` instead of `save_episode()` and the
+                # episode is simply retried. Cleared here anyway so the operator
+                # does not see a "Re-record episode" for an episode that never
+                # started.
+                #
+                # `stop_recording` is deliberately NOT cleared: that one should
+                # survive the gap, and the `while` above has already acted on it.
+                #
+                # Upstream lerobot and the sister repo `lerobot-xense` both carry
+                # this hole; these two lines are a deliberate divergence.
+                events["exit_early"] = False
+                events["rerecord_episode"] = False
+
                 log_say(f"Recording episode {dataset.num_episodes}", cfg.play_sounds)
 
                 # Fresh breadcrumb trail per episode so trajectories don't bleed

--- a/src/lerobot/teleoperators/pico4/xrt_session.py
+++ b/src/lerobot/teleoperators/pico4/xrt_session.py
@@ -40,9 +40,12 @@ tears the SDK down cleanly.
 from __future__ import annotations
 
 import atexit
-import contextlib
 import threading
 from types import ModuleType
+
+from lerobot.utils.robot_utils import get_logger
+
+logger = get_logger("xrt_session")
 
 _lock = threading.Lock()
 _xrt: ModuleType | None = None
@@ -132,11 +135,17 @@ def release() -> bool:
             _holders -= 1
         if _holders > 0 or _xrt is None:
             return False
-        # Suppressed on purpose: a failing close() must not mask whatever the
-        # caller was actually doing (usually its own teardown). The caller
-        # logs the outcome; state is reset either way.
-        with contextlib.suppress(Exception):  # pragma: no cover
+        # Swallowed on purpose: a failing close() must not mask whatever the
+        # caller was actually doing (usually its own teardown). The caller logs
+        # the lifecycle ("last reader; SDK closed"); state is reset either way.
+        # But it is logged rather than dropped — a close() that did not take is
+        # exactly what leaves the SDK's joinable threads to std::terminate() the
+        # process on the way out, and silently discarding the reason turns that
+        # into an unexplained crash at exit.
+        try:
             _xrt.close()
+        except Exception as e:  # pragma: no cover — teardown-only path
+            logger.warning(f"xrt.close() failed on release ({type(e).__name__}: {e}); SDK state reset anyway")
         _xrt = None
         return True
 
@@ -146,8 +155,16 @@ def shutdown() -> None:
     global _xrt, _holders
     with _lock:
         if _xrt is not None:
-            with contextlib.suppress(Exception):  # pragma: no cover
+            if _holders:
+                # Reached atexit with holders still registered: someone skipped
+                # its release(). Harmless here (we close anyway) but it means a
+                # disconnect path did not run, so say so while there is still a
+                # log to say it in.
+                logger.debug(f"atexit shutdown with {_holders} hold(s) outstanding; closing SDK anyway")
+            try:
                 _xrt.close()
+            except Exception as e:  # pragma: no cover — exit-only path
+                logger.warning(f"xrt.close() failed at shutdown ({type(e).__name__}: {e})")
         _xrt = None
         _holders = 0
 

--- a/src/lerobot/utils/control_utils.py
+++ b/src/lerobot/utils/control_utils.py
@@ -17,7 +17,6 @@
 ########################################################################################
 
 
-import logging
 import traceback
 from functools import cache
 from typing import Any
@@ -27,6 +26,9 @@ from deepdiff import DeepDiff
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
 from lerobot.datasets.utils import DEFAULT_FEATURES
 from lerobot.robots import Robot
+from lerobot.utils.robot_utils import get_logger
+
+logger = get_logger("control_utils")
 
 
 @cache
@@ -46,14 +48,12 @@ def is_headless():
 
         return False
     except Exception:
-        print(
+        logger.warning(
             "Error trying to import pynput. Switching to headless mode. "
             "As a result, the video stream from the cameras won't be shown, "
             "and you won't be able to change the control flow with keyboards. "
-            "For more info, see traceback below.\n"
+            f"Traceback:\n{traceback.format_exc()}"
         )
-        traceback.print_exc()
-        print()
         return True
 
 
@@ -92,12 +92,12 @@ def init_keyboard_listener(teleop: Any | None = None):
             if hasattr(teleop, "get_reset_button") and teleop.get_reset_button():
                 events["go_start"] = True
         except Exception as e:
-            logging.debug(f"Error refreshing teleop control events: {e}")
+            logger.debug(f"Error refreshing teleop control events: {e}")
 
     events["_refresh_events"] = refresh_events_from_teleop
 
     if is_headless():
-        logging.warning(
+        logger.warning(
             "Headless environment detected. On-screen cameras display and keyboard inputs will not be available."
         )
         listener = None
@@ -107,23 +107,30 @@ def init_keyboard_listener(teleop: Any | None = None):
     from pynput import keyboard
 
     def on_press(key):
+        # pynput hooks the whole X session, not this terminal: a right arrow
+        # pressed in *any* window (the Rerun viewer, a browser, another shell)
+        # ends the episode exactly as if it had been typed here. When an operator
+        # reports "it exited and I never touched the arrow key", this timestamp
+        # is what tells you whether the key really arrived — and when. The bare
+        # print() this replaces was block-buffered on a redirected stdout, so in
+        # a captured log it could surface well after the press it described.
         try:
             if key == keyboard.Key.right:
-                print("Right arrow key pressed. Exiting loop...")
+                logger.info("Right arrow pressed -> ending the current episode/reset early.")
                 events["exit_early"] = True
             elif key == keyboard.Key.left:
-                print("Left arrow key pressed. Exiting loop and rerecord the last episode...")
+                logger.info("Left arrow pressed -> ending early and re-recording the last episode.")
                 events["rerecord_episode"] = True
                 events["exit_early"] = True
             elif key == keyboard.Key.esc:
-                print("Escape key pressed. Stopping data recording...")
+                logger.info("Escape pressed -> stopping data recording.")
                 events["stop_recording"] = True
                 events["exit_early"] = True
             elif key == keyboard.Key.space:
-                print("Space key pressed. Robot will go to start pose while recording continues...")
+                logger.info("Space pressed -> robot goes to start pose, recording continues.")
                 events["go_start"] = True
         except Exception as e:
-            print(f"Error handling key press: {e}")
+            logger.error(f"Error handling key press: {e}")
 
     listener = keyboard.Listener(on_press=on_press)
     listener.start()

--- a/src/lerobot/utils/robot_utils.py
+++ b/src/lerobot/utils/robot_utils.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import platform
+import threading
 import time
 from datetime import datetime
 from pathlib import Path
@@ -22,12 +24,22 @@ import numpy as np
 import spdlog
 
 SPDLOG_PATTERN = "[%D %T.%e] [%n] [%^%l%$] %v"
+# Aspirational: this spdlog pybind exposes only `set_level` on a Sink, so a
+# pattern can be set on the logger but not per sink. Both sinks therefore render
+# SPDLOG_PATTERN; the file sink simply drops the `%^`/`%$` colour markers, which
+# only the ansicolor console sink emits. Wire this up if the binding ever grows
+# Sink.set_pattern.
 FILE_LOG_PATTERN = "[%Y-%m-%d %H:%M:%S.%e] [%n] [%l] %v"
 
 # Global log directory — set via XENSE_LOG_DIR env var, defaults to ~/xenselogs.
 _LOG_DIR = Path(os.environ.get("XENSE_LOG_DIR", Path.home() / "xenselogs"))
 _LOG_SESSION = datetime.now().strftime("%Y%m%d_%H%M%S")
 _MAX_LOG_FILES = 15
+
+# Default console verbosity for every logger in the process. Overridable per rig
+# without touching code — handy when a station is misbehaving and you want DEBUG
+# for one session only.
+DEFAULT_CONSOLE_LEVEL = os.environ.get("XENSE_LOG_LEVEL", "INFO")
 
 _SPDLOG_LEVEL_MAP = {
     "TRACE": spdlog.LogLevel.TRACE,
@@ -41,8 +53,29 @@ _SPDLOG_LEVEL_MAP = {
     "OFF": spdlog.LogLevel.OFF,
 }
 
-# Shared file sink (one log file per session, all loggers write to it).
+# Third-party loggers that emit per-request/per-frame chatter at INFO or DEBUG.
+# They are pinned to WARNING so the shared session file stays readable; anything
+# actually wrong still gets through.
+_NOISY_STDLIB_LOGGERS = (
+    "asyncio",
+    "botocore",
+    "datasets",
+    "filelock",
+    "fsspec",
+    "huggingface_hub",
+    "matplotlib",
+    "numba",
+    "PIL",
+    "urllib3",
+)
+
+# Shared sinks. One file sink per session and one console sink per level, shared
+# by every logger: a sink owns a lock and a flush, so minting a fresh one per
+# logger multiplies both for no benefit.
 _file_sink: spdlog.Sink | None = None
+_console_sinks: dict[int, spdlog.Sink] = {}
+_loggers: dict[tuple[str, str], spdlog.Logger] = {}
+_LOG_LOCK = threading.RLock()
 
 
 def _get_file_sink() -> spdlog.Sink | None:
@@ -50,18 +83,38 @@ def _get_file_sink() -> spdlog.Sink | None:
     global _file_sink
     if _file_sink is not None:
         return _file_sink
-    try:
-        _LOG_DIR.mkdir(parents=True, exist_ok=True)
-        # Rotate: keep newest _MAX_LOG_FILES - 1, drop the rest.
-        log_files = sorted(_LOG_DIR.glob("*.log"), key=lambda f: f.stat().st_mtime)
-        while len(log_files) >= _MAX_LOG_FILES:
-            log_files.pop(0).unlink(missing_ok=True)
-        log_path = _LOG_DIR / f"session_{_LOG_SESSION}.log"
-        _file_sink = spdlog.basic_file_sink_mt(str(log_path))
-        _file_sink.set_level(spdlog.LogLevel.DEBUG)
-        return _file_sink
-    except Exception:
-        return None
+    with _LOG_LOCK:
+        if _file_sink is not None:
+            return _file_sink
+        try:
+            _LOG_DIR.mkdir(parents=True, exist_ok=True)
+            # Rotate: keep newest _MAX_LOG_FILES - 1, drop the rest.
+            log_files = sorted(_LOG_DIR.glob("*.log"), key=lambda f: f.stat().st_mtime)
+            while len(log_files) >= _MAX_LOG_FILES:
+                log_files.pop(0).unlink(missing_ok=True)
+            log_path = _LOG_DIR / f"session_{_LOG_SESSION}.log"
+            sink = spdlog.basic_file_sink_mt(str(log_path))
+            sink.set_level(spdlog.LogLevel.DEBUG)
+            _file_sink = sink
+            return _file_sink
+        except Exception:
+            return None
+
+
+def _get_console_sink(level: spdlog.LogLevel) -> spdlog.Sink:
+    """Return the process-wide console sink for ``level``, creating it once."""
+    with _LOG_LOCK:
+        sink = _console_sinks.get(int(level))
+        if sink is None:
+            sink = spdlog.stdout_color_sink_mt()
+            sink.set_level(level)
+            _console_sinks[int(level)] = sink
+        return sink
+
+
+def session_log_path() -> Path:
+    """Path of this session's log file (whether or not the sink opened)."""
+    return _LOG_DIR / f"session_{_LOG_SESSION}.log"
 
 
 class _SinkLogger(spdlog.SinkLogger):
@@ -82,39 +135,144 @@ class _SinkLogger(spdlog.SinkLogger):
     exception = spdlog.SinkLogger.error
 
 
-def get_logger(name: str, loglevel: str = "INFO") -> spdlog.Logger:
-    """Create a spdlog logger with console + file output.
+def get_logger(name: str, loglevel: str | None = None) -> spdlog.Logger:
+    """Create (or fetch) a spdlog logger with console + file output.
 
     Console shows ``loglevel`` and above with colors. The file sink captures
     DEBUG+ to ``~/xenselogs/session_<timestamp>.log`` (override the directory
     via the ``XENSE_LOG_DIR`` env var). Old log files in that directory are
     rotated; only the most recent :data:`_MAX_LOG_FILES` are kept.
 
+    Loggers are cached per ``(name, loglevel)``. Calling this twice for the same
+    name — a robot reconnecting, a module imported from two entry points — hands
+    back the same logger instead of stacking another console sink onto stdout,
+    which is how the same line ends up printed twice.
+
     Args:
         name: Logger name.
         loglevel: Console log level: TRACE/DEBUG/INFO/WARN/ERR/CRITICAL/OFF.
+            Defaults to ``$XENSE_LOG_LEVEL`` or INFO.
 
     Returns:
         spdlog logger that fans out to the console and the shared session file.
     """
-    console_level = _SPDLOG_LEVEL_MAP.get(loglevel.upper(), spdlog.LogLevel.INFO)
+    level_name = (loglevel or DEFAULT_CONSOLE_LEVEL).upper()
+    key = (name, level_name)
 
-    console_sink = spdlog.stdout_color_sink_mt()
-    console_sink.set_level(console_level)
+    with _LOG_LOCK:
+        cached = _loggers.get(key)
+        if cached is not None:
+            return cached
 
-    sinks = [console_sink]
+        console_level = _SPDLOG_LEVEL_MAP.get(level_name, spdlog.LogLevel.INFO)
+        sinks = [_get_console_sink(console_level)]
 
-    file_sink = _get_file_sink()
-    if file_sink is not None:
-        sinks.append(file_sink)
+        file_sink = _get_file_sink()
+        if file_sink is not None:
+            sinks.append(file_sink)
 
-    logger = _SinkLogger(name, sinks)
-    logger.set_pattern(SPDLOG_PATTERN)
-    # Logger-level DEBUG so the file sink sees everything; each sink filters
-    # to its own configured level.
-    logger.set_level(spdlog.LogLevel.DEBUG)
+        logger = _SinkLogger(name, sinks)
+        logger.set_pattern(SPDLOG_PATTERN)
+        # Logger-level DEBUG so the file sink sees everything; each sink filters
+        # to its own configured level.
+        logger.set_level(spdlog.LogLevel.DEBUG)
+        logger.flush_on(spdlog.LogLevel.WARN)
+        _loggers[key] = logger
+        return logger
 
-    return logger
+
+class _StdlibToSpdlogHandler(logging.Handler):
+    """Forward stdlib ``logging`` records into spdlog.
+
+    Most of this tree logs through :func:`get_logger`, but upstream lerobot,
+    ``xensesdk`` and libav all log through the stdlib. Without a bridge those
+    lines take a different path to a different stream with a different format —
+    they are the ``INFO 2026-08-27 16:58:52 eo_utils.py:189`` lines, whose
+    location field is the *tail* of the path truncated to 15 characters
+    (``video_utils.py`` reads as ``eo_utils.py``), and they never reach the
+    session file at all. Routing them here gives one format, one stream and one
+    file for the whole process.
+
+    The spdlog logger name is the record's module, not ``root`` — upstream logs
+    via the root logger, so the module is the only part that identifies anything.
+    """
+
+    _LEVEL_METHODS = (
+        (logging.CRITICAL, "critical"),
+        (logging.ERROR, "error"),
+        (logging.WARNING, "warn"),
+        (logging.INFO, "info"),
+        (logging.DEBUG, "debug"),
+    )
+
+    def __init__(self, level: int = logging.INFO):
+        super().__init__(level=level)
+        self._level_name = logging.getLevelName(level)
+
+    @staticmethod
+    def _logger_name(record: logging.LogRecord) -> str:
+        # Root records carry no useful name; named third-party loggers do.
+        if record.name and record.name != "root":
+            return record.name
+        return record.module or "python"
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            message = record.getMessage().rstrip()
+            # Warnings and worse are the ones someone will go read the source
+            # for, so they keep their origin; INFO stays uncluttered. Records
+            # routed by ``logging.captureWarnings`` are the exception: the
+            # formatted warning already opens with "<file>:<line>: UserWarning",
+            # and appending warnings.py's own location on top says nothing.
+            if record.levelno >= logging.WARNING and record.name != "py.warnings":
+                message = f"{message} ({record.filename}:{record.lineno})"
+            if record.exc_info:
+                message = f"{message}\n{logging.Formatter().formatException(record.exc_info)}"
+            logger = get_logger(self._logger_name(record), self._level_name)
+            for levelno, method in self._LEVEL_METHODS:
+                if record.levelno >= levelno:
+                    getattr(logger, method)(message)
+                    return
+            logger.debug(message)
+        except Exception:
+            self.handleError(record)
+
+
+def install_stdlib_bridge(console_level: str | None = None, quiet_third_party: bool = True) -> logging.Handler:
+    """Point the stdlib root logger at spdlog and return the installed handler.
+
+    Idempotent: re-installing replaces the previous bridge rather than stacking a
+    second one. Existing root handlers are dropped, which is what the caller
+    wants — leaving them in place is how every line gets printed twice.
+
+    The handler filters at ``console_level`` *before* spdlog sees the record, so
+    the DEBUG-level session file does not fill up with third-party DEBUG chatter
+    that nothing asked for.
+    """
+    level_name = (console_level or DEFAULT_CONSOLE_LEVEL).upper()
+    level = logging.getLevelName(level_name)
+    if not isinstance(level, int):
+        level = logging.INFO
+
+    root = logging.getLogger()
+    for existing in list(root.handlers):
+        root.removeHandler(existing)
+
+    handler = _StdlibToSpdlogHandler(level=level)
+    root.addHandler(handler)
+    # NOTSET on the root logger means "hand everything to the handlers"; the
+    # handler's own level is the filter.
+    root.setLevel(logging.NOTSET)
+
+    # `warnings.warn` output otherwise goes straight to stderr, unformatted and
+    # absent from the session file.
+    logging.captureWarnings(True)
+
+    if quiet_third_party:
+        for noisy in _NOISY_STDLIB_LOGGERS:
+            logging.getLogger(noisy).setLevel(logging.WARNING)
+
+    return handler
 
 
 def busy_wait(seconds):

--- a/src/lerobot/utils/robot_utils.py
+++ b/src/lerobot/utils/robot_utils.py
@@ -19,6 +19,7 @@ import threading
 import time
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import spdlog
@@ -273,6 +274,112 @@ def install_stdlib_bridge(console_level: str | None = None, quiet_third_party: b
             logging.getLogger(noisy).setLevel(logging.WARNING)
 
     return handler
+
+
+class SlowCallMonitor:
+    """Report calls that overrun a time budget, instead of logging every call.
+
+    Replaces the per-call ``logger.debug(f"{self} read took: {ms:.1f}ms")`` that
+    each camera backend used to emit. On a bimanual rig that is six cameras at
+    30 Hz — 180 records a second, ~1 MiB a minute — none of which reaches the
+    console (the sink filters at INFO) and all of which reaches the DEBUG-level
+    session file, where it buries everything else. The number was also only ever
+    interesting when it was large, and the record loop already prints a
+    per-camera breakdown when a frame overruns (``[slow_frame] ... top_obs=``).
+
+    What is left is the part worth a log line: a call that blew its budget. The
+    first overrun in a window is logged as it happens, so onset keeps a
+    timestamp; the rest of the window is counted and folded into one summary, so
+    a camera that is persistently slow costs one line per window rather than one
+    per frame.
+
+    ``str(owner)`` is resolved only when a warning is actually emitted — building
+    it per call is the cost this class exists to avoid.
+    """
+
+    def __init__(
+        self,
+        logger: Any,
+        owner: Any = None,
+        *,
+        label: str = "read",
+        overrun_factor: float = 2.0,
+        min_overrun_ms: float = 5.0,
+        report_every_s: float = 10.0,
+    ):
+        self._logger = logger
+        self._owner = owner
+        self._label = label
+        self._overrun_factor = overrun_factor
+        self._min_overrun_ms = min_overrun_ms
+        self._report_every_s = report_every_s
+        self._window_start: float | None = None
+        self._total = 0
+        self._slow = 0
+        self._worst_ms = 0.0
+        # Whether the window that just closed had overruns. Gates the onset
+        # line: a camera that is slow window after window should cost one
+        # summary each, not a summary plus a "first overrun" that repeats it.
+        self._was_slow = False
+        # Overruns already reported individually this window (0 or 1). The
+        # summary covers whatever this does not, so a camera dropping exactly
+        # one frame per window keeps being reported instead of going quiet
+        # after its first onset line.
+        self._announced = 0
+
+    def _prefix(self) -> str:
+        return f"{self._owner} " if self._owner is not None else ""
+
+    def _threshold_ms(self, budget_ms: float | None) -> float | None:
+        if not budget_ms or budget_ms <= 0:
+            # No configured rate means no budget to overrun, so nothing to say.
+            return None
+        # Both terms matter: the factor keeps fast cameras from tripping on a
+        # couple of milliseconds, the floor keeps very high frame rates from
+        # warning on jitter that is under a millisecond of real delay.
+        return max(budget_ms * self._overrun_factor, budget_ms + self._min_overrun_ms)
+
+    def _reset(self, now: float) -> None:
+        self._window_start = now
+        self._was_slow = self._slow > 0
+        self._total = 0
+        self._slow = 0
+        self._worst_ms = 0.0
+        self._announced = 0
+
+    def observe(self, duration_ms: float, budget_ms: float | None = None) -> None:
+        """Record one call's duration and warn if the budget is clearly blown."""
+        threshold_ms = self._threshold_ms(budget_ms)
+        if threshold_ms is None:
+            return
+
+        now = time.perf_counter()
+        if self._window_start is None:
+            self._window_start = now
+        self._total += 1
+
+        if duration_ms > threshold_ms:
+            self._slow += 1
+            self._worst_ms = max(self._worst_ms, duration_ms)
+            # Onset only: the first overrun after a clean window, so the moment
+            # things went wrong keeps its own timestamp. While it stays wrong,
+            # the window summary below is the whole report.
+            if self._slow == 1 and not self._was_slow:
+                self._announced = 1
+                self._logger.warning(
+                    f"{self._prefix()}slow {self._label}: {duration_ms:.1f}ms "
+                    f"(budget {budget_ms:.1f}ms, warn over {threshold_ms:.1f}ms); "
+                    f"further overruns are summarised every {self._report_every_s:g}s, not logged one by one"
+                )
+
+        elapsed = now - self._window_start
+        if elapsed >= self._report_every_s:
+            if self._slow > self._announced:
+                self._logger.warning(
+                    f"{self._prefix()}{self._slow}/{self._total} {self._label}s over "
+                    f"{threshold_ms:.1f}ms in the last {elapsed:.1f}s (worst {self._worst_ms:.1f}ms)"
+                )
+            self._reset(now)
 
 
 def busy_wait(seconds):

--- a/src/lerobot/utils/utils.py
+++ b/src/lerobot/utils/utils.py
@@ -182,10 +182,19 @@ def init_logging(
 
     # Console logging (main process only)
     if is_main_process:
-        console_handler = logging.StreamHandler()
-        console_handler.setFormatter(formatter)
-        console_handler.setLevel(console_level.upper())
-        logger.addHandler(console_handler)
+        # Xense fork: stdlib records go through spdlog so the whole process —
+        # upstream lerobot, xensesdk, libav and our own get_logger() callers —
+        # shares one console format, one stream and one session file. The
+        # StreamHandler below is the fallback for an environment without spdlog.
+        try:
+            from lerobot.utils.robot_utils import install_stdlib_bridge
+
+            install_stdlib_bridge(console_level=console_level)
+        except Exception:
+            console_handler = logging.StreamHandler()
+            console_handler.setFormatter(formatter)
+            console_handler.setLevel(console_level.upper())
+            logger.addHandler(console_handler)
     else:
         # Suppress console output for non-main processes
         logger.addHandler(logging.NullHandler())


### PR DESCRIPTION
起因是一份采集日志：数采员报告"我没按方向右键，episode 自己就结束了"。查下去牵出
一个会打死采集会话的 bug，以及一批把它掩盖掉的日志问题。5 个 commit，可以分开看。

## 1. `fix(record)` — 清掉空档里滞留的 `exit_early`

键盘监听线程活整个 session，但 `exit_early` / `rerecord_episode` 只有录制循环和
reset 循环在消费。reset 循环结束到下一条 episode 开始之间有一段**没有消费者的空档**
—— `save_episode()` 加编码器预热，约 2 秒：

```
监听线程   ├────────────────── 整个 session 一直在收键 ──────────────────┤
消费者     ├─ 录制循环 ─┤├─ reset 循环 ─┤          ├─ 下一条录制循环 ─┤
                                        └─ 空档 ─┘
```

在这段空档里按下的右方向键会挂着 `True`，下一条 episode 第 0 次迭代撞上它 → 0 帧
退出 → 那次 `break` 又把标志清了，于是 reset **跑满整个 `reset_time_s`**（看起来
完全正常）→ `save_episode()` 拿着 0 帧 buffer 撞上 `validate_episode_buffer`：

```
ValueError: You must add one or several frames with `add_frame` before calling `add_episode`.
```

**整个采集会话崩掉**——在按键之后两分多钟，中间还夹着一段正常的 reset。

用 stub 忠实复刻外层循环的标志生命周期验证过，右方向键必崩、修复后不崩；左方向键
是自纠正的（空 buffer 走到 `clear_episode_buffer()` 而不是 `save_episode()`，
episode 直接重试，**不丢数据**），一并清掉只是为了不报一条根本没开始过的
"Re-record episode"。`stop_recording` 故意不清。

洞是从 upstream lerobot 继承的，姊妹仓库 `lerobot-xense` 这段逐字节相同，同一处修复
已合并：Vertax42/lerobot-xense#19。

## 2. `refactor(log)` — stdlib logging 经桥接汇入 spdlog

此前两套日志并行，upstream / xensesdk / libav 走 stdlib，格式不同、走另一个流、
**完全不进 `~/xenselogs/session_*.log`**。就是日志里那些

```
INFO 2026-08-27 16:58:52 eo_utils.py:189 ...
```

（位置字段是路径截最后 15 字符，所以 `video_utils.py` 显示成 `eo_utils.py`）。

`init_logging()` 改装 `_StdlibToSpdlogHandler`，整个进程一套格式、一个流、一个文件：

```
[08/27/26 17:48:39.611] [video_utils]     [info]    Using video codec: h264
[08/27/26 17:48:39.611] [xensesdk.sensor] [info]    third-party named logger
[08/27/26 17:48:39.611] [logtest]         [warning] upstream root WARNING (logtest.py:16)
```

顺带：`get_logger()` 按 `(name, level)` 缓存并共享 sink（同名重复调用以前会往 stdout
叠第二个 sink，同一行打两遍）；`$XENSE_LOG_LEVEL` 可调控制台等级；
`logging.captureWarnings(True)`。

按键处理也换成 logger——裸 `print` 在重定向的 stdout 上是块缓冲的，抓下来的日志里
可能**晚于**它描述的按键才出现，这正是没法判断"到底啥时候按的"的原因。

## 3. `fix(log)` — libav 降噪

每存一条 episode 都会多出一屏 `[mov,mp4,...] Auto-inserting h264_mp4toannexb`。
旁边的 `logging.getLogger("libav").setLevel(...)` **完全无效**：同一段代码调了
`restore_default_callback()`，之后只有 ffmpeg 自己的等级说了算。

`restore_default_callback()` 本身是故意的（PyAV 的 Python 回调在多线程下有官方警告，
流式编码器是多线程的），**不动它**。`quiet_libav()` 拨的是
`set_libav_level`（原生回调）+ `set_level`（Python 回调，喂 stdlib 桥）。顺带修掉
两套等级常量混用（libav `WARNING` 是 24，stdlib 是 30）。

实测：libav 等级放回 INFO 复现出 3 行噪音，改动后 0 行。

## 4. `perf(log)` — 逐帧 `read took` 换成超时才 warn

六路相机 30fps = 每秒 180 条 debug，**实测 10 秒 164 KiB**，一条 10 分钟 episode 约
10 MiB。控制台一条不显示（sink 在 INFO 过滤），全部沉进 DEBUG 级 session 文件。

| 场景 | 旧 | 新 |
|---|---|---|
| 300 次正常读 | 300 行 | **0 行** |
| 一次 120ms 抖动 | 101 行 | **1 行 warning** |
| 持续慢（200 次 90ms） | 200 行 | **1 行 onset + 每 10s 一行摘要** |
| 没配 fps | 逐帧 debug | **静默**（没预算就无所谓超时） |

阈值 `max(2×budget, budget+5ms)`；倍数不能少，`async_read` 本来就要等一帧。摘要条件
是 `slow > announced` 而非 `slow > 1`，否则每窗口恰好慢一次的相机会永远沉默。
`str(owner)` 只在真要 warn 时求值。

和 `[slow_frame] ... top_obs=` 不重复：那个在整个循环超时才触发；这个补的是单相机超了
但循环还赶得上的情况。

## 5. `docs(claude)`

把上面几个坑记进 `CLAUDE.md`，重点是"别再往 root 加 `StreamHandler`"和"别把
`restore_default_callback` 当重置等级用"。

---

## 与 lerobot-xense 的关系

commit 1 与已合并的 lerobot-xense#19 同源。**commit 2–5 是相对 lerobot-xense 的主动
分叉**（那边同样有逐帧 `read took`、同样的 `restore_default_callback`、
`init_logging` 里同样是 `StreamHandler`）。需要的话可以照样 port 过去。

## 验证

- **逐个 commit checkout 验证**：5 个 commit 都是 0 新增 lint 错误、3 个入口点
  import 正常。基线对照：`main` 上本来就有 6 个 `UP042` 和 1 个待格式化文件（本地
  ruff 比 CI pin 新），本分支一个没加。
- 分支 tip：`642 passed, 7 skipped`。
- libav 噪音、日志桥、`SlowCallMonitor` 三项都用真实执行验证，不是只读代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
