### PR TITLE
fix(log): 相机 stall 改测后台采集，只在录制期上报，并实测重复帧

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,20 +163,44 @@ Console level is `$XENSE_LOG_LEVEL` (default INFO), the session file is
 bridge filters at the console level _before_ spdlog sees a record, so the
 DEBUG-level file does not fill with third-party chatter.
 
-### Per-frame timings are warnings, not debug lines — `SlowCallMonitor`
+### A camera stall is a stale frame, not a slow loop — `CaptureStallMonitor`
 
 Every camera backend used to end `read()` with
 `logger.debug(f"{self} read took: {ms:.1f}ms")`. On a bimanual rig that is six
 cameras at 30 Hz: ~180 records a second, ~1 MiB a minute, none of it on the
-console (the sink filters at INFO) and all of it in the DEBUG-level session
-file. `SlowCallMonitor` (`utils/robot_utils.py`) replaces it — the first overrun
-after a clean window is logged as it happens, the rest of the window is folded
-into one summary, and reads inside budget say nothing at all. A camera with no
-configured `fps` has no budget and is therefore silent by design. `str(owner)`
-is resolved only when a warning is actually emitted; building it per call is the
-cost the class exists to avoid. The record loop's `[slow_frame] ... top_obs=`
-line already attributes a blown frame to individual cameras, so this covers the
-other case: a camera over budget while the loop as a whole still makes it.
+console (the sink filters at INFO) and all of it in the DEBUG-level session file.
+
+`CaptureStallMonitor` (`utils/robot_utils.py`) replaces it, and is wired into
+each backend's **background `_read_loop`**, not `read()`. That placement is the
+whole point:
+
+- The record loop takes frames through `CameraReadGuard.read()` →
+  `cam.async_read()`, which returns the cached `latest_frame` **without
+  blocking**. A slow capture therefore never stalls the record loop — it means
+  the loop is handed the _same_ frame, and roughly `duration / budget` recorded
+  frames are duplicates of one image. Read the warning as "the loop was blocked"
+  and you will go looking in the wrong place; the message says stale frames
+  because that is the actual cost.
+- Only `XenseTactileCamera` has `_read_loop` call `self.read()`. OpenCV,
+  RealSense and ZMQ capture via `_read_from_hardware()` and their `read()` is not
+  in the record path at all — instrumenting `read()` there measured nothing,
+  which is why only `[XenseCam]` warnings ever appeared.
+- Timing the loop rather than `read()` also keeps the connect-time warmup out of
+  it, where "errors are expected" and a slow read means nothing.
+
+Nothing else sees this class of problem. `[slow_frame]` cannot — the loop is not
+blocked. `CameraReadGuard`'s freeze detection cannot either: `CAM_FREEZE_TIMEOUT_S`
+is 2s, deliberately well above any frame interval so a slow sensor never trips
+it, and the stalls that matter are shorter. Measured on the rig: 8-stream nvenc
+warm-up and episode save starve the tactile capture threads for 0.3–0.9s, i.e.
+~10–25 duplicate frames, every episode boundary.
+
+The first stall after a clean window is logged as it happens; the rest of the
+window folds into one summary carrying the worst stall's **wall-clock time** —
+that is what tells you whether it landed inside an episode or in the gap between
+two. Captures inside budget say nothing, and a camera with no configured `fps`
+has no budget and is silent by design. `str(owner)` is resolved only when a
+warning is emitted; building it per call is the cost the class exists to avoid.
 
 ### libav noise — `quiet_libav()`, not `setLevel`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,16 @@ it, and the stalls that matter are shorter. Measured on the rig: 8-stream nvenc
 warm-up and episode save starve the tactile capture threads for 0.3–0.9s, i.e.
 ~10–25 duplicate frames, every episode boundary.
 
+Reporting is gated on a dataset actually being written (`set_capture_recording`,
+bracketed per episode in `lerobot_record.py`). Encoder warm-up, the reset phase
+and the save/encode gap all stall captures but record nothing, so a stall there
+damages nothing and warning about it is noise nobody can act on — in the measured
+run, all eight onset warnings of the session fired outside an episode. The gate
+is process-global on purpose: a camera is a leaf with no reference back to the
+session, and "is a dataset being written right now" is a property of the process.
+It defaults **open**, so a consumer that never manages it (teleoperate, ad-hoc
+scripts) still gets the diagnostic.
+
 The first stall after a clean window is logged as it happens; the rest of the
 window folds into one summary carrying the worst stall's **wall-clock time** —
 that is what tells you whether it landed inside an episode or in the gap between

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,39 @@ two. Captures inside budget say nothing, and a camera with no configured `fps`
 has no budget and is silent by design. `str(owner)` is resolved only when a
 warning is emitted; building it per call is the cost the class exists to avoid.
 
+### Duplicate frames are counted by identity, never by pixels
+
+`CameraReadGuard.stale_frame_report()` reports, per episode, how much of what
+went to disk is a repeat of the previous frame:
+
+```
+[stale_frames] episode 3  [left_tactile_left] 45/1800 frames served stale (2.5%): 25 gap(s), longest 21 frame(s)
+```
+
+The predicate is `frame is prev` — Python object identity, already computed for
+freeze detection. **Do not replace it with a pixel or hash comparison.** A
+resting tactile gel barely changes between frames, so any content test flags the
+normal case; and the recorded stream is lossily encoded, which destroys
+bit-exactness in both directions (noise-level differences quantize to identical
+output). A real capture allocates a new array — `_format_read_result` returns
+`np.ascontiguousarray` of a reversed view — so identity is exact and free.
+
+Run length is what separates the two causes, which is why it is reported
+alongside the percentage:
+
+- **a long run** is a capture stall (`CaptureStallMonitor` reports the same event
+  from the capture side; the two should agree, and if they do not, something else
+  is producing stale frames);
+- **many one-frame runs** are the beat between two unsynchronised 30 Hz loops —
+  the sensor's background capture and the record loop each free-run at the same
+  nominal rate, so the phase drifts and the loop occasionally samples twice
+  before a new frame lands. Tolerated by design, but nothing measured it until
+  now.
+
+Logged at INFO, not WARNING: some duplication is expected, and warning on it
+every episode is the noise this whole change removed. Promote it once a rig's
+baseline is known and there is a defensible threshold.
+
 ### libav noise — `quiet_libav()`, not `setLevel`
 
 `video_utils.py` calls `av.logging.restore_default_callback()` deliberately:

--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -35,7 +35,7 @@ import cv2  # type: ignore  # TODO: add type stubs for OpenCV
 
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
 from lerobot.utils.errors import DeviceNotConnectedError
-from lerobot.utils.robot_utils import SlowCallMonitor
+from lerobot.utils.robot_utils import CaptureStallMonitor
 
 from ..camera import Camera
 from ..utils import get_cv2_rotation
@@ -144,9 +144,10 @@ class OpenCVCamera(Camera):
             config: The configuration settings for the camera.
         """
         super().__init__(config)
-        # Per-read timing is reported only when it overruns the frame budget;
-        # see SlowCallMonitor for why the old per-read debug line is gone.
-        self._slow_read = SlowCallMonitor(logger, self)
+        # Background-capture stalls are reported only when they overrun the frame
+        # budget; see CaptureStallMonitor for why the old per-read debug line is
+        # gone and what a stall actually costs downstream.
+        self._capture_stall = CaptureStallMonitor(logger, self)
 
         self.config = config
         self.index_or_path = config.index_or_path
@@ -507,8 +508,6 @@ class OpenCVCamera(Camera):
             ValueError: If an invalid `color_mode` is requested.
         """
 
-        start_time = time.perf_counter()
-
         if color_mode is not None:
             logger.warning(f"{self} read() color_mode parameter is deprecated and will be removed in future versions.")
 
@@ -516,12 +515,7 @@ class OpenCVCamera(Camera):
             raise RuntimeError(f"{self} read thread is not running.")
 
         self.new_frame_event.clear()
-        frame = self.async_read(timeout_ms=10000)
-
-        read_duration_ms = (time.perf_counter() - start_time) * 1e3
-        self._slow_read.observe(read_duration_ms, 1e3 / self.fps if self.fps else None)
-
-        return frame
+        return self.async_read(timeout_ms=10000)
 
     def _postprocess_image(self, image: NDArray[Any]) -> NDArray[Any]:
         """
@@ -578,9 +572,13 @@ class OpenCVCamera(Camera):
         failure_count = 0
         while not self.stop_event.is_set():
             try:
+                loop_start = time.perf_counter()
                 raw_frame = self._read_from_hardware()
                 processed_frame = self._postprocess_image(raw_frame)
                 capture_time = time.perf_counter()
+                # The background capture is what the record loop pays for in
+                # stale frames; read() below just hands back the cached one.
+                self._capture_stall.observe((capture_time - loop_start) * 1e3, 1e3 / self.fps if self.fps else None)
 
                 with self.frame_lock:
                     self.latest_frame = processed_frame

--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -32,7 +32,7 @@ except Exception as e:
 
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
 from lerobot.utils.errors import DeviceNotConnectedError
-from lerobot.utils.robot_utils import SlowCallMonitor
+from lerobot.utils.robot_utils import CaptureStallMonitor
 
 from ..camera import Camera
 from ..configs import ColorMode
@@ -115,9 +115,10 @@ class RealSenseCamera(Camera):
         """
 
         super().__init__(config)
-        # Per-read timing is reported only when it overruns the frame budget;
-        # see SlowCallMonitor for why the old per-read debug line is gone.
-        self._slow_read = SlowCallMonitor(logger, self)
+        # Background-capture stalls are reported only when they overrun the frame
+        # budget; see CaptureStallMonitor for why the old per-read debug line is
+        # gone and what a stall actually costs downstream.
+        self._capture_stall = CaptureStallMonitor(logger, self)
 
         self.config = config
 
@@ -387,8 +388,6 @@ class RealSenseCamera(Camera):
             ValueError: If an invalid `color_mode` is requested.
         """
 
-        start_time = time.perf_counter()
-
         if color_mode is not None:
             logger.warning(f"{self} read() color_mode parameter is deprecated and will be removed in future versions.")
 
@@ -400,12 +399,7 @@ class RealSenseCamera(Camera):
 
         self.new_frame_event.clear()
 
-        frame = self.async_read(timeout_ms=10000)
-
-        read_duration_ms = (time.perf_counter() - start_time) * 1e3
-        self._slow_read.observe(read_duration_ms, 1e3 / self.fps if self.fps else None)
-
-        return frame
+        return self.async_read(timeout_ms=10000)
 
     def _postprocess_image(self, image: NDArray[Any], depth_frame: bool = False) -> NDArray[Any]:
         """
@@ -467,6 +461,7 @@ class RealSenseCamera(Camera):
         failure_count = 0
         while not self.stop_event.is_set():
             try:
+                loop_start = time.perf_counter()
                 frame = self._read_from_hardware()
                 color_frame_raw = frame.get_color_frame()
                 color_frame = np.asanyarray(color_frame_raw.get_data())
@@ -478,6 +473,9 @@ class RealSenseCamera(Camera):
                     processed_depth_frame = self._postprocess_image(depth_frame, depth_frame=True)
 
                 capture_time = time.perf_counter()
+                # The background capture is what the record loop pays for in
+                # stale frames; read() below just hands back the cached one.
+                self._capture_stall.observe((capture_time - loop_start) * 1e3, 1e3 / self.fps if self.fps else None)
 
                 with self.frame_lock:
                     self.latest_color_frame = processed_color_frame

--- a/src/lerobot/cameras/xense/camera_xense.py
+++ b/src/lerobot/cameras/xense/camera_xense.py
@@ -25,7 +25,7 @@ from typing import Any, cast
 import numpy as np
 
 from lerobot.utils.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
-from lerobot.utils.robot_utils import SlowCallMonitor, get_logger
+from lerobot.utils.robot_utils import CaptureStallMonitor, get_logger
 
 from ..camera import Camera
 from .configuration_xense import XenseOutputType, XenseTactileCameraConfig
@@ -138,9 +138,10 @@ class XenseTactileCamera(Camera):
             config: The configuration settings for the Xense sensor.
         """
         super().__init__(config)
-        # Per-read timing is reported only when it overruns the frame budget;
-        # see SlowCallMonitor for why the old per-read debug line is gone.
-        self._slow_read = SlowCallMonitor(logger, self)
+        # Background-capture stalls are reported only when they overrun the frame
+        # budget; see CaptureStallMonitor for why the old per-read debug line is
+        # gone and what a stall actually costs downstream.
+        self._capture_stall = CaptureStallMonitor(logger, self)
 
         self.config = config
         self.serial_number = config.serial_number
@@ -449,15 +450,8 @@ class XenseTactileCamera(Camera):
         if not self.is_connected:
             raise DeviceNotConnectedError(f"{self} is not connected.")
 
-        start_time = time.perf_counter()
-
         data = self._read_sensor_data()
-        formatted = self._format_read_result(data)
-
-        read_duration_ms = (time.perf_counter() - start_time) * 1e3
-        self._slow_read.observe(read_duration_ms, 1e3 / self.fps if self.fps else None)
-
-        return formatted
+        return self._format_read_result(data)
 
     def _read_loop(self):
         """
@@ -478,6 +472,12 @@ class XenseTactileCamera(Camera):
 
             try:
                 data = self.read()
+                # Timed here, not inside read(): this is the capture whose delay
+                # the record loop pays for in stale frames. read() is also called
+                # by the connect-time warmup, where a slow read means nothing.
+                self._capture_stall.observe(
+                    (time.perf_counter() - loop_start) * 1e3, 1e3 / self.fps if self.fps else None
+                )
 
                 with self.frame_lock:
                     self.latest_data = data

--- a/src/lerobot/cameras/zmq/camera_zmq.py
+++ b/src/lerobot/cameras/zmq/camera_zmq.py
@@ -36,7 +36,7 @@ from numpy.typing import NDArray
 
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
 from lerobot.utils.errors import DeviceNotConnectedError
-from lerobot.utils.robot_utils import SlowCallMonitor
+from lerobot.utils.robot_utils import CaptureStallMonitor
 
 from ..camera import Camera
 from ..configs import ColorMode
@@ -76,9 +76,10 @@ class ZMQCamera(Camera):
 
     def __init__(self, config: ZMQCameraConfig):
         super().__init__(config)
-        # Per-read timing is reported only when it overruns the frame budget;
-        # see SlowCallMonitor for why the old per-read debug line is gone.
-        self._slow_read = SlowCallMonitor(logger, self)
+        # Background-capture stalls are reported only when they overrun the frame
+        # budget; see CaptureStallMonitor for why the old per-read debug line is
+        # gone and what a stall actually costs downstream.
+        self._capture_stall = CaptureStallMonitor(logger, self)
         import zmq
 
         self.config = config
@@ -226,8 +227,6 @@ class ZMQCamera(Camera):
         Returns:
             np.ndarray: Decoded frame (height, width, 3)
         """
-        start_time = time.perf_counter()
-
         if color_mode is not None:
             logger.warning(f"{self} read() color_mode parameter is deprecated and will be removed in future versions.")
 
@@ -235,12 +234,7 @@ class ZMQCamera(Camera):
             raise RuntimeError(f"{self} read thread is not running.")
 
         self.new_frame_event.clear()
-        frame = self.async_read(timeout_ms=10000)
-
-        read_duration_ms = (time.perf_counter() - start_time) * 1e3
-        self._slow_read.observe(read_duration_ms, 1e3 / self.fps if self.fps else None)
-
-        return frame
+        return self.async_read(timeout_ms=10000)
 
     def _read_loop(self) -> None:
         """
@@ -252,8 +246,12 @@ class ZMQCamera(Camera):
         failure_count = 0
         while not self.stop_event.is_set():
             try:
+                loop_start = time.perf_counter()
                 frame = self._read_from_hardware()
                 capture_time = time.perf_counter()
+                # The background capture is what the record loop pays for in
+                # stale frames; read() below just hands back the cached one.
+                self._capture_stall.observe((capture_time - loop_start) * 1e3, 1e3 / self.fps if self.fps else None)
 
                 with self.frame_lock:
                     self.latest_frame = frame

--- a/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
@@ -333,6 +333,15 @@ class BiTaccapGripper(Robot):
 
         return features
 
+    def stale_frame_report(self) -> list[str]:
+        """Per-camera stale-frame lines for the episode just recorded, then reset.
+
+        Delegates to :class:`CameraReadGuard`, which already computes the
+        freshness predicate for its freeze detection. See its docstring for why
+        this is object identity and not a pixel comparison.
+        """
+        return self._cam_guard.stale_frame_report()
+
     @cached_property
     def display_features(self) -> dict[str, type | tuple]:
         """Rerun-facing schema: ``observation_features`` with each tactile camera's

--- a/src/lerobot/robots/taccap_gripper/camera_health.py
+++ b/src/lerobot/robots/taccap_gripper/camera_health.py
@@ -29,6 +29,8 @@ from typing import Any
 
 import numpy as np
 
+from lerobot.utils.robot_utils import capture_recording_active
+
 # Freeze timeout for graceful degradation. If a camera's ``async_read`` keeps
 # returning the *same* frame object for this long, the stream is treated as
 # physically lost. This covers Xense tactile sensors, whose background read
@@ -72,6 +74,11 @@ class CameraReadGuard:
         # used to detect a frozen (non-raising) stream — see :meth:`read`.
         self._last_new_frame_t: dict[str, float] = {}
         self._lost: set[str] = set()
+        # Per-camera freshness tally for the episode being recorded, keyed
+        # ``{cam: [reads, stale, gaps, longest_run, current_run]}``. Counted only
+        # while a dataset is being written (`capture_recording_active`), since a
+        # stale frame outside an episode is not recorded and costs nothing.
+        self._freshness: dict[str, list[int]] = {}
 
     @property
     def lost(self) -> bool:
@@ -89,6 +96,7 @@ class CameraReadGuard:
         self._last_frame.clear()
         self._last_new_frame_t.clear()
         self._lost.clear()
+        self._freshness.clear()
 
     def read(self, cam_name: str, cam: Any) -> np.ndarray | dict[str, np.ndarray]:
         """Read one camera, degrading gracefully on physical loss.
@@ -132,7 +140,8 @@ class CameraReadGuard:
         # genuinely new object, so a sensor slower than the sample loop (which
         # legitimately re-reads one frame) does not trip it.
         prev = self._last_frame.get(cam_name)
-        if prev is None or frame is not prev:
+        fresh = prev is None or frame is not prev
+        if fresh:
             self._last_new_frame_t[cam_name] = now
         else:
             frozen_for = now - self._last_new_frame_t.get(cam_name, now)
@@ -141,9 +150,68 @@ class CameraReadGuard:
                     cam_name,
                     f"no new frame for {frozen_for:.1f}s (stream frozen, sensor likely unplugged)",
                 )
+        self._note_freshness(cam_name, fresh)
 
         self._last_frame[cam_name] = frame
         return frame
+
+    def _note_freshness(self, cam_name: str, fresh: bool) -> None:
+        """Tally whether this read got a new frame or the previous one again.
+
+        Identity, not pixels. A resting tactile gel barely changes between
+        frames, so any content-based "is this a duplicate" test would flag the
+        normal case; and the recorded stream is lossily encoded, which destroys
+        bit-exactness in both directions. But a real capture allocates a new
+        array (``_format_read_result`` returns ``np.ascontiguousarray`` of a
+        reversed view), so ``frame is prev`` is exact and free — it is already
+        computed above for freeze detection.
+
+        Only counted while a dataset is being written: a stale frame served
+        during encoder warm-up, the reset phase or the save/encode gap is not
+        recorded and costs nothing.
+        """
+        if not capture_recording_active():
+            return
+        tally = self._freshness.setdefault(cam_name, [0, 0, 0, 0, 0])
+        tally[0] += 1
+        if fresh:
+            tally[4] = 0
+            return
+        tally[1] += 1
+        if tally[4] == 0:
+            tally[2] += 1  # a new run of stale frames starts here
+        tally[4] += 1
+        tally[3] = max(tally[3], tally[4])
+
+    def stale_frame_report(self) -> list[str]:
+        """One line per camera that served a stale frame, then reset the tally.
+
+        Two different problems show up in the same numbers, which is why the run
+        length is reported and not just the percentage:
+
+        * **a long run** is a capture stall — the background thread fell behind
+          and ``async_read`` handed back the same frame N times in a row. See
+          ``CaptureStallMonitor``, which reports the same event from the capture
+          side; the two numbers should agree, and if they do not, something else
+          is producing stale frames.
+        * **many single-frame runs** are the steady-state beat between two
+          unsynchronised 30 Hz loops — the sensor's background capture and the
+          record loop each free-run at the same nominal rate, so the phase drifts
+          and the loop occasionally samples twice before a new frame lands. This
+          is tolerated by design (``CAM_FREEZE_TIMEOUT_S`` is set well above a
+          frame interval precisely so it never trips), but nothing measured how
+          often it happens until now.
+        """
+        lines = []
+        for cam_name, (reads, stale, gaps, longest, _) in sorted(self._freshness.items()):
+            if not stale or not reads:
+                continue
+            lines.append(
+                f"  [{cam_name}] {stale}/{reads} frames served stale ({stale / reads * 100:.1f}%): "
+                f"{gaps} gap(s), longest {longest} frame(s)"
+            )
+        self._freshness.clear()
+        return lines
 
     def flag_lost(self, cam_name: str, reason: str) -> None:
         """Mark a camera as physically lost so :attr:`lost` trips. Idempotent;

--- a/src/lerobot/robots/taccap_gripper/taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/taccap_gripper.py
@@ -344,6 +344,15 @@ class TaccapGripper(Robot):
 
         return features
 
+    def stale_frame_report(self) -> list[str]:
+        """Per-camera stale-frame lines for the episode just recorded, then reset.
+
+        Delegates to :class:`CameraReadGuard`, which already computes the
+        freshness predicate for its freeze detection. See its docstring for why
+        this is object identity and not a pixel comparison.
+        """
+        return self._cam_guard.stale_frame_report()
+
     @cached_property
     def display_features(self) -> dict[str, type | tuple]:
         """Rerun-facing schema: ``observation_features`` with each tactile camera's

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -602,6 +602,22 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                 finally:
                     set_capture_recording(False)
 
+                # How much of what just went to disk is duplicated frames. The
+                # guard counts this by frame-object identity while reading (see
+                # CameraReadGuard.stale_frame_report), so it is exact and costs
+                # nothing: a long run is a capture stall, many one-frame runs are
+                # the beat between the sensor's capture loop and this one, both
+                # free-running at the same nominal rate.
+                # INFO, not WARNING, on purpose: some duplication is expected
+                # (the beat between two unsynchronised 30 Hz loops) and warning
+                # on it every episode is the noise this whole change removed.
+                # Promote to a warning once a rig's baseline is known and there
+                # is a defensible threshold — there is not one yet.
+                stale_report = getattr(robot, "stale_frame_report", None)
+                if callable(stale_report):
+                    for line in stale_report():
+                        logger.info(f"[stale_frames] episode {dataset.num_episodes}{line}")
+
                 # Execute a few seconds without recording to give time to manually reset the environment
                 # Skip reset for the last episode to be recorded
                 if not events["stop_recording"] and (

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -90,7 +90,7 @@ from lerobot.utils.control_utils import (
     sanity_check_dataset_robot_compatibility,
 )
 from lerobot.utils.import_utils import register_third_party_plugins
-from lerobot.utils.robot_utils import busy_wait, get_logger
+from lerobot.utils.robot_utils import busy_wait, get_logger, set_capture_recording
 from lerobot.utils.utils import (
     init_logging,
     log_say,
@@ -520,6 +520,17 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
 
         listener, events = init_keyboard_listener(teleop=teleop)
 
+        # A camera's background capture can stall without blocking the record
+        # loop — async_read() hands back the cached frame — so the cost shows up
+        # as duplicated frames in the dataset, and only while a dataset is
+        # actually being written. Default the reporting window closed and open it
+        # per episode below: encoder warm-up, the reset phase and the save/encode
+        # gap all stall captures (8-stream nvenc starves the tactile threads for
+        # ~0.3-0.9s) but record nothing, so warning there is noise nobody can act
+        # on. Measured: a session's first stalls fire during
+        # `[streaming_encoder] warming up`, entirely before "Recording episode 0".
+        set_capture_recording(False)
+
         if not cfg.dataset.streaming_encoding:
             logger.info(
                 "Streaming encoding is disabled. If you have capable hardware, consider enabling it for way faster episode saving. --dataset.streaming_encoding=true --dataset.encoder_threads=2 # --dataset.vcodec=auto. More info in the documentation: https://huggingface.co/docs/lerobot/streaming_video_encoding"
@@ -573,19 +584,23 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                 if traj_viz is not None:
                     traj_viz.reset()
 
-                self_driven_record_loop(
-                    robot=robot,
-                    events=events,
-                    fps=cfg.dataset.fps,
-                    dataset=dataset,
-                    control_time_s=cfg.dataset.episode_time_s,
-                    single_task=cfg.dataset.single_task,
-                    display_data=cfg.display_data,
-                    traj_viz=traj_viz,
-                    display_features=display_features,
-                    display_compressed_images=cfg.display_compressed_images,
-                    display_image_every_n=cfg.display_image_every_n,
-                )
+                set_capture_recording(True)
+                try:
+                    self_driven_record_loop(
+                        robot=robot,
+                        events=events,
+                        fps=cfg.dataset.fps,
+                        dataset=dataset,
+                        control_time_s=cfg.dataset.episode_time_s,
+                        single_task=cfg.dataset.single_task,
+                        display_data=cfg.display_data,
+                        traj_viz=traj_viz,
+                        display_features=display_features,
+                        display_compressed_images=cfg.display_compressed_images,
+                        display_image_every_n=cfg.display_image_every_n,
+                    )
+                finally:
+                    set_capture_recording(False)
 
                 # Execute a few seconds without recording to give time to manually reset the environment
                 # Skip reset for the last episode to be recorded

--- a/src/lerobot/utils/robot_utils.py
+++ b/src/lerobot/utils/robot_utils.py
@@ -276,22 +276,34 @@ def install_stdlib_bridge(console_level: str | None = None, quiet_third_party: b
     return handler
 
 
-class SlowCallMonitor:
-    """Report calls that overrun a time budget, instead of logging every call.
+class CaptureStallMonitor:
+    """Report stalls in a camera's **background** capture loop.
 
     Replaces the per-call ``logger.debug(f"{self} read took: {ms:.1f}ms")`` that
-    each camera backend used to emit. On a bimanual rig that is six cameras at
-    30 Hz — 180 records a second, ~1 MiB a minute — none of which reaches the
-    console (the sink filters at INFO) and all of which reaches the DEBUG-level
-    session file, where it buries everything else. The number was also only ever
-    interesting when it was large, and the record loop already prints a
-    per-camera breakdown when a frame overruns (``[slow_frame] ... top_obs=``).
+    each backend used to emit. On a bimanual rig that is six cameras at 30 Hz —
+    180 records a second, ~1 MiB a minute — none of which reaches the console
+    (the sink filters at INFO) and all of which reaches the DEBUG-level session
+    file, where it buries everything else. The number was only ever interesting
+    when it was large.
 
-    What is left is the part worth a log line: a call that blew its budget. The
-    first overrun in a window is logged as it happens, so onset keeps a
-    timestamp; the rest of the window is counted and folded into one summary, so
-    a camera that is persistently slow costs one line per window rather than one
-    per frame.
+    **What a stall here means.** Every backend runs a background thread that
+    captures into ``latest_frame``; the record loop takes frames with
+    ``async_read()``, which returns that cached frame **without blocking**. So a
+    slow capture never stalls the record loop — it means the loop keeps being
+    handed the *same* frame, and roughly ``duration / budget`` recorded frames
+    are duplicates of one image. That is a data-quality problem, not a timing
+    one, and the messages below say so: reading them as "the loop was blocked"
+    sends you looking in the wrong place.
+
+    Nothing else sees this. ``[slow_frame]`` in the record loop cannot — the loop
+    is not blocked. ``CameraReadGuard``'s freeze detection cannot either: its
+    ``CAM_FREEZE_TIMEOUT_S`` is 2s, deliberately well above any frame interval so
+    a slow sensor never trips it, and the stalls that matter here are shorter.
+
+    The first stall in a window is logged as it happens, so onset keeps a
+    timestamp; the rest of the window is counted and folded into one summary,
+    which carries the worst stall's own wall-clock time — that is what tells you
+    whether it landed inside an episode or in the encode/save gap between two.
 
     ``str(owner)`` is resolved only when a warning is actually emitted — building
     it per call is the cost this class exists to avoid.
@@ -302,7 +314,7 @@ class SlowCallMonitor:
         logger: Any,
         owner: Any = None,
         *,
-        label: str = "read",
+        label: str = "capture",
         overrun_factor: float = 2.0,
         min_overrun_ms: float = 5.0,
         report_every_s: float = 10.0,
@@ -317,14 +329,15 @@ class SlowCallMonitor:
         self._total = 0
         self._slow = 0
         self._worst_ms = 0.0
-        # Whether the window that just closed had overruns. Gates the onset
-        # line: a camera that is slow window after window should cost one
-        # summary each, not a summary plus a "first overrun" that repeats it.
+        self._worst_at = ""
+        self._worst_stale = 0
+        # Whether the window that just closed had stalls. Gates the onset line: a
+        # camera stalling window after window should cost one summary each, not a
+        # summary plus a "first stall" that repeats it.
         self._was_slow = False
-        # Overruns already reported individually this window (0 or 1). The
-        # summary covers whatever this does not, so a camera dropping exactly
-        # one frame per window keeps being reported instead of going quiet
-        # after its first onset line.
+        # Stalls already reported individually this window (0 or 1). The summary
+        # covers whatever this does not, so a camera stalling exactly once per
+        # window keeps being reported instead of going quiet after its onset line.
         self._announced = 0
 
     def _prefix(self) -> str:
@@ -345,10 +358,12 @@ class SlowCallMonitor:
         self._total = 0
         self._slow = 0
         self._worst_ms = 0.0
+        self._worst_at = ""
+        self._worst_stale = 0
         self._announced = 0
 
     def observe(self, duration_ms: float, budget_ms: float | None = None) -> None:
-        """Record one call's duration and warn if the budget is clearly blown."""
+        """Record one capture's duration and warn if the budget is clearly blown."""
         threshold_ms = self._threshold_ms(budget_ms)
         if threshold_ms is None:
             return
@@ -360,16 +375,22 @@ class SlowCallMonitor:
 
         if duration_ms > threshold_ms:
             self._slow += 1
-            self._worst_ms = max(self._worst_ms, duration_ms)
-            # Onset only: the first overrun after a clean window, so the moment
+            # Frames a non-blocking consumer was handed the stale image for.
+            stale = max(1, int(duration_ms / budget_ms))
+            if duration_ms > self._worst_ms:
+                self._worst_ms = duration_ms
+                self._worst_stale = stale
+                self._worst_at = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+            # Onset only: the first stall after a clean window, so the moment
             # things went wrong keeps its own timestamp. While it stays wrong,
             # the window summary below is the whole report.
             if self._slow == 1 and not self._was_slow:
                 self._announced = 1
                 self._logger.warning(
-                    f"{self._prefix()}slow {self._label}: {duration_ms:.1f}ms "
-                    f"(budget {budget_ms:.1f}ms, warn over {threshold_ms:.1f}ms); "
-                    f"further overruns are summarised every {self._report_every_s:g}s, not logged one by one"
+                    f"{self._prefix()}background {self._label} stalled {duration_ms:.1f}ms "
+                    f"({stale}x the {budget_ms:.1f}ms budget) — async_read() served the same frame "
+                    f"throughout, so ~{stale} recorded frames repeat one image. "
+                    f"Further stalls are summarised every {self._report_every_s:g}s, not logged one by one"
                 )
 
         elapsed = now - self._window_start
@@ -377,7 +398,8 @@ class SlowCallMonitor:
             if self._slow > self._announced:
                 self._logger.warning(
                     f"{self._prefix()}{self._slow}/{self._total} {self._label}s over "
-                    f"{threshold_ms:.1f}ms in the last {elapsed:.1f}s (worst {self._worst_ms:.1f}ms)"
+                    f"{threshold_ms:.1f}ms in the last {elapsed:.1f}s "
+                    f"(worst {self._worst_ms:.1f}ms at {self._worst_at}, ~{self._worst_stale} frames stale)"
                 )
             self._reset(now)
 

--- a/src/lerobot/utils/robot_utils.py
+++ b/src/lerobot/utils/robot_utils.py
@@ -276,6 +276,35 @@ def install_stdlib_bridge(console_level: str | None = None, quiet_third_party: b
     return handler
 
 
+# Whether captured frames are currently being written into a dataset. A stall
+# only costs anything when its stale frames land in an episode: during encoder
+# warm-up, the between-episode reset and the save/encode gap, nothing is
+# recording and a stalled capture damages nothing, so warning about it is noise.
+# The measured run showed exactly that — the first stalls of a session fired
+# during `[streaming_encoder] warming up`, entirely before "Recording episode 0".
+#
+# Process-global on purpose: a camera is a leaf object with no reference back to
+# the recording session, and "is a dataset being written right now" is genuinely
+# a property of the process, not of any one camera. Defaults to active so a
+# consumer that never manages the gate (teleoperate, ad-hoc scripts) still gets
+# the diagnostic; `lerobot-record` brackets its episodes explicitly.
+_RECORDING_ACTIVE = threading.Event()
+_RECORDING_ACTIVE.set()
+
+
+def set_capture_recording(active: bool) -> None:
+    """Open or close the window in which capture stalls are worth reporting."""
+    if active:
+        _RECORDING_ACTIVE.set()
+    else:
+        _RECORDING_ACTIVE.clear()
+
+
+def capture_recording_active() -> bool:
+    """Whether captured frames are currently being recorded."""
+    return _RECORDING_ACTIVE.is_set()
+
+
 class CaptureStallMonitor:
     """Report stalls in a camera's **background** capture loop.
 
@@ -363,9 +392,25 @@ class CaptureStallMonitor:
         self._announced = 0
 
     def observe(self, duration_ms: float, budget_ms: float | None = None) -> None:
-        """Record one capture's duration and warn if the budget is clearly blown."""
+        """Record one capture's duration and warn if the budget is clearly blown.
+
+        A no-op while nothing is being recorded — see :data:`_RECORDING_ACTIVE`.
+        The window is dropped rather than carried across the pause, so the first
+        stall of the next episode is reported as an onset instead of being folded
+        into a summary spanning the gap.
+        """
         threshold_ms = self._threshold_ms(budget_ms)
         if threshold_ms is None:
+            return
+
+        if not _RECORDING_ACTIVE.is_set():
+            self._reset(time.perf_counter())
+            # _reset carries "the window that just closed was bad" forward; across
+            # a recording pause there is nothing to carry, and window_start=None
+            # makes the next active capture start a fresh window rather than one
+            # already stretched across the gap.
+            self._was_slow = False
+            self._window_start = None
             return
 
         now = time.perf_counter()


### PR DESCRIPTION
#60 上线后跑了一轮 8 路相机的录制，日志暴露出三个问题。3 个 commit，可以分开看。

## 背景：那批 674ms 的警告在说什么

```
22:22:39.214  [streaming_encoder] warming up 8 encoder(s)
22:22:40.038  XenseCam ... slow read: 674.1ms (budget 33.3ms)
22:22:40.564  [streaming_encoder] all encoders ready
22:22:40.564  Recording episode 0
```

数值是对的（那次后台采集确实花了 674ms），但 `[slow_frame]` 那边几乎是干净的——
因为**录制回路根本没被卡住**。取帧路径是
`CameraReadGuard.read()` → `cam.async_read()`，而 `async_read()` 直接返回缓存的
`latest_frame`，**不阻塞**。所以一次慢采集的代价不是延迟，是**约 20 帧录进去的是
同一张图**。

这类问题现有检查都看不到：`[slow_frame]` 看不到（回路没被阻塞），
`CameraReadGuard` 的冻结检测也看不到（`CAM_FREEZE_TIMEOUT_S = 2s`，为了不让慢传感器
误触发而故意设宽，而真正要抓的 stall 比它短）。

## 1. `fix(log)` — 改测后台采集，并说清真实代价

- **措辞**：改成直接讲后果 —— `background capture stalled 674.1ms (20x the 33.3ms
  budget) — async_read() served the same frame throughout, so ~20 recorded frames
  repeat one image`。
- **三个后端的插桩原来是死代码**：只有 `XenseTactileCamera._read_loop` 调
  `self.read()`；OpenCV / RealSense / ZMQ 的后台线程走 `_read_from_hardware()`，它们的
  `read()` 在录制流程里根本没人调 —— 这正是日志里只有 `[XenseCam]` 报警的原因。四个
  统一挪进各自的 `_read_loop`，顺带把连接期 warmup 读排除（那里注释写明 "errors are
  expected"）。
- **摘要带上最差那次的墙钟时刻和折算帧数**，能直接判断它落在 episode 内还是落在两条
  之间的空档里。
- 类名 `SlowCallMonitor` → `CaptureStallMonitor`。

## 2. `fix(log)` — 只在真正录制期间统计

原日志 19 条警告里，**8 条 onset 全部落在 episode 之外**（编码器 warmup、以及右键结束
reset 之后的 `save_episode` 空档）。那些旧帧一帧都没进 dataset，报警没人能处理。

`set_capture_recording()` 把上报窗口收敛到 episode 内，`lerobot_record` 逐条用
`try/finally` 括起来。放在调用点而不是循环体内，避免为了加 `try` 重排 70 行缩进。

默认开着，这样从不管理这道门的消费方（teleoperate、临时脚本）照样拿得到诊断。进程级
全局是刻意的：相机是叶子对象，没有指回录制会话的引用，而"此刻是否正在写 dataset"
本来就是进程的属性。

跨暂停时窗口整个丢弃而不是延续，所以下一条 episode 的第一次 stall 仍然报成 onset。

## 3. `feat(log)` — 按对象身份统计每条 episode 的重复帧

把"约 20 帧"从推算变成实测：

```
[stale_frames] episode 3  [left_tactile_left] 45/1800 frames served stale (2.5%): 25 gap(s), longest 21 frame(s)
```

判据是 `frame is prev`（对象身份），本来就为冻结检测算过了，等于免费。

**不要改成按像素或哈希比对**，两个独立的理由：触觉胶体静置时画面几乎不变，任何内容
判据都会把正常帧判成重复；而录制流是**有损编码**的，位级一致性两个方向都被破坏（只差
传感器噪声的两帧会量化成完全相同的解码输出）。一次真实采集会新分配一块数组
（`_format_read_result` 对 rectify 返回 `np.ascontiguousarray(arr[..., ::-1])`），所以
身份判据是精确的。

同时报 **run 长度**而不只是百分比，因为两种成因混在同一个数字里：

- **长 run** 是采集 stall。`CaptureStallMonitor` 从采集侧报同一件事，两边数字应该对得
  上；对不上就说明还有别的东西在制造旧帧。
- **大量单帧 run** 是两个不同步的 30Hz 循环之间的节拍差——传感器后台采集和录制回路各自
  自由运行在同一标称频率上，相位会漂移，回路偶尔会在新帧落地前采两次。这是设计上容忍
  的，但在此之前没人量过它多频繁。

用 INFO 不用 WARNING：一定量的重复是预期内的，每条 episode 都 warn 就又变回这轮改动要
消除的噪音。等测出基线、有了站得住脚的阈值再提。

## 验证

- 用复刻现场时序的场景跑过：warmup 期 4 次大 stall 静默、落盘空档 3 次静默、episode 内
  的照报，下一条 episode 的首次 stall 仍是 onset（不被折进跨空档的摘要）。
- 计数器用「1 次 21 帧 stall + 25 次单帧节拍」的合成序列验证，正确输出
  `45/1800 (2.5%): 25 gap(s), longest 21 frame(s)`，且 report 后自动 reset、未录制期间
  不计数。
- 静态核对四个后端的插桩位置：`observe` 全部在 `_read_loop` 内、`read()` 内全部移除。
- `642 passed, 7 skipped`；ruff check 0 新增错误（`main` 上既有的 6 个 `UP042` 不变）。

## 待办（不在本 PR）

基线重复率现在还不知道。跑一轮拿到数字后，才有依据决定：
(a) `[stale_frames]` 要不要提到 WARNING、阈值定多少；
(b) 要不要让录制回路等 `new_frame_event` 而不是取缓存 —— 那是另一个量级的改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
