### PR TITLE
fix(record): 重录时 reset 阶段被跳过，复位动作被录进下一条 episode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,16 +285,71 @@ an empty buffer — `You must add one or several frames with add_frame`. The
 session dies mid-collection, minutes after the press that caused it, which is
 what makes it hard to connect back to a key someone pressed.
 
-`rerecord_episode` has a related hole (the record loop breaks on it without
-clearing it) but that one is **self-correcting**: it short-circuits the reset
-too, so the empty buffer reaches `clear_episode_buffer()` rather than
-`save_episode()` and the episode is just retried. It is cleared alongside anyway,
-to avoid announcing "Re-record episode" for an episode that never started.
-`stop_recording` is deliberately _not_ cleared: that one should survive the gap.
+`rerecord_episode` is cleared on the same line for a milder version of the same
+problem. A **left** arrow in that gap is self-correcting as far as the buffer
+goes — it sets `exit_early` too, so the next episode ends at zero frames, but the
+empty buffer then reaches `clear_episode_buffer()` rather than `save_episode()`
+and the take is simply retried. What it does without the clear is announce
+"Re-record episode" for an episode that never started, after sitting through a
+full `reset_time_s` for a scene nobody disturbed. `stop_recording` is deliberately
+_not_ cleared: that one should survive the gap.
 
-Upstream lerobot and the sister repo `lerobot-xense` both carry this hole — the
-event-flag lifecycle there is byte-identical to ours — so the clear is a
-deliberate divergence, not a fork-local quirk being papered over.
+Upstream lerobot and the sister repo `lerobot-xense` both carry the `exit_early`
+hole, so the clear is a deliberate divergence, not a fork-local quirk being
+papered over. Our loop's break conditions have since diverged further — see "The
+event contract" below.
+
+### The event contract — one break signal, two intent flags
+
+A record loop sees three flags and must treat them differently:
+
+| flag               | meaning                    | consumed by                                 |
+| ------------------ | -------------------------- | ------------------------------------------- |
+| `exit_early`       | leave **this** loop now    | the loop that breaks on it — always         |
+| `rerecord_episode` | discard the take, retry it | `record()`, after the reset                 |
+| `stop_recording`   | end the session            | `record()`'s outer `while` — never the loop |
+
+So `self_driven_record_loop` breaks on `exit_early` and on **nothing else**,
+which is upstream's `record_loop` exactly. Every keypress that should end it sets
+`exit_early` too (`control_utils.on_press`), so one condition covers all three —
+left arrow ends the loop _and_ leaves `rerecord_episode` standing for the caller,
+which is the whole point of an intent flag.
+
+Checking the intent flags as well is not merely redundant, it is how the bug got
+in. Nothing ever sets `stop_recording` on its own either — ESC sets both, the
+teleop refresh (`control_utils.refresh_events_from_teleop`) writes only
+`go_start`, and the `device_lost` path sets it and breaks on the next line — so a
+`stop_recording` branch here is dead code whose only effect is which line gets
+logged. Do not add one back.
+
+Breaking on `rerecord_episode` instead is what put reset activity _inside_
+episodes. That break left `exit_early` unconsumed; the reset phase is this same
+loop with `dataset=None`, so it broke in its own first iteration and the retake
+got **0 seconds** of reset while `log_say("Reset the environment")` was still
+playing (`spd-say` is non-blocking — "Reset the environment" / "Re-record
+episode" / "Recording episode N" simply queue up). Measured 2.35s from that
+announcement to "Recording episode 56", twice in one session. Nothing from the
+reset phase is ever written to the dataset; the contamination is entirely the
+operator putting the scene back while the retake records them doing it.
+
+The `or events["rerecord_episode"]` in the skip-reset condition — there so a
+retake of the _last_ episode still gets reset time — was dead for the same
+reason, and needed no change of its own to come back to life.
+
+`"Recording episode N"` stays **non-blocking**, as in `lerobot-xense`. Making it
+`blocking=True` looks like part of the same fix and is the wrong direction: it
+opens a ~1s window in which nothing is recorded while the operator, hearing the
+announcement finish, has already started moving — it drops the beginning of the
+demonstration and puts speech-dispatcher's latency inside the record loop. The
+phrase playing over the take's first second is correct; a second of lead-in at
+the head of an episode costs nothing.
+
+`lerobot-xense` has the same defect, but only on its **RT** path:
+`run_rt_record_loop` checks `rerecord_episode` before `exit_early` and breaks
+without consuming it, so the reset (the generic `record_loop`, whose first check
+is `exit_early`) exits at once. Its non-RT robots run `record_loop` for both
+phases and that one ignores `rerecord_episode` entirely, so they get a real reset
+by accident. Unfixed there as of `2b737e45`.
 
 ## Recorded files land 0600 if they come from a temp file
 

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -346,12 +346,21 @@ def self_driven_record_loop(
         start_loop_t = time.perf_counter()
         refresh_listener_events(events)
 
-        if events["stop_recording"]:
-            logger.info("Stop recording requested, exiting record loop early")
-            break
-        if events["rerecord_episode"]:
-            logger.info("Re-record episode requested, exiting record loop early")
-            break
+        # `exit_early` is the *only* break condition, as in upstream's
+        # `record_loop`, and the loop that breaks on it always consumes it.
+        # `stop_recording` and `rerecord_episode` are intent flags owned by the
+        # caller; this loop neither breaks on them nor clears them.
+        #
+        # Every keypress that should end this loop sets `exit_early` too
+        # (`control_utils.on_press`: left also sets `rerecord_episode`, ESC also
+        # sets `stop_recording`), so one condition is enough — and checking the
+        # intent flags instead is actively wrong. Breaking on `rerecord_episode`
+        # left `exit_early` unconsumed, and the reset phase is this same loop with
+        # `dataset=None`, so it broke in its own first iteration: the retake got
+        # 0s of reset while "Reset the environment" was still playing, and the
+        # operator put the scene back *into* the next take. Measured 2.35s from
+        # that announcement to "Recording episode 56". See CLAUDE.md →
+        # "The event contract".
         if events["exit_early"]:
             events["exit_early"] = False
             logger.info("Exit early requested, exiting record loop early")
@@ -577,6 +586,14 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                 events["exit_early"] = False
                 events["rerecord_episode"] = False
 
+                # Non-blocking, matching `lerobot-xense`: the phrase plays over
+                # the take's first second rather than in front of it. Waiting for
+                # it (`blocking=True`) opens a ~1s window in which nothing is
+                # recorded but the operator, hearing the announcement end, has
+                # already started moving — it loses the beginning of the
+                # demonstration, and puts speech-dispatcher's latency inside the
+                # record loop. A second of lead-in at the head of an episode costs
+                # nothing.
                 log_say(f"Recording episode {dataset.num_episodes}", cfg.play_sounds)
 
                 # Fresh breadcrumb trail per episode so trajectories don't bleed
@@ -620,6 +637,11 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
 
                 # Execute a few seconds without recording to give time to manually reset the environment
                 # Skip reset for the last episode to be recorded
+                #
+                # `or events["rerecord_episode"]` — a retake of the *last* episode
+                # still gets reset time — only became reachable once the loop
+                # stopped breaking on that flag. It used to enter the reset and
+                # leave again in the same millisecond.
                 if not events["stop_recording"] and (
                     (recorded_episodes < cfg.dataset.num_episodes - 1) or events["rerecord_episode"]
                 ):


### PR DESCRIPTION
## 问题

数采员反映 reset env 的动作被录进了 episode。日志实测（`bi_taccap_4`，2026-08-29）：

```
14:12:02.815  Re-record episode requested, exiting record loop early   ← 左箭头
14:12:02.815  Reset the environment          ← 播报"复位环境"
14:12:02.816  Re-record episode requested, exiting record loop early   ← reset 循环 1ms 就退出
14:12:05.163  Recording episode 56           ← 2.35 秒后已在录制
```

一次会话里出现两次。

## 根因

`self_driven_record_loop` break 在 `rerecord_episode` 上，而左箭头会同时置 `exit_early`（`control_utils.on_press`）。break 在意图标志上导致 `exit_early` 没被消费；reset 阶段是**同一个循环**（`dataset=None`），于是它在自己的第一次迭代就退出——重录只拿到 0 秒 reset，而 `log_say("Reset the environment")` 还在播（`spd-say` 非阻塞，三句话排队）。操作者听到播报就去复位场景，此时下一条已经在录。

reset 阶段本身从不写盘，污染完全来自操作者的时序。

## 改动

对齐上游 `record_loop` 的事件契约：

| flag | 含义 | 由谁消费 |
|---|---|---|
| `exit_early` | 离开**本**循环 | break 它的那个循环，必消费 |
| `rerecord_episode` | 丢弃本条、重来 | `record()`，在 reset 之后 |
| `stop_recording` | 结束整个 session | `record()` 的外层 `while`，循环从不碰 |

- 删掉 `rerecord_episode` 的 break——左箭头本来就置 `exit_early`，循环照样立刻结束，意图标志得以活到外层。
- 顺带删掉同样冗余的 `stop_recording` 分支：没有任何路径会单独置它（ESC 两个一起置，teleop 刷新只写 `go_start`，`device_lost` 置完下一行直接 break），它唯一的作用是打哪条日志。

改完后循环的事件处理和上游 `record_loop` 逐字一致（多一条 `logger.info`）。

副作用：`or events["rerecord_episode"]`（本意"最后一条被重录时也给 reset 时间"）自此可达，不需要自身改动。

`"Recording episode N"` 保持**非阻塞**。改成 `blocking=True` 看着像同一个修复，方向是反的：会开出约 1 秒不录制的窗口，而操作者听完播报已经动了，丢的是示教起手，还把 speech-dispatcher 的延迟接进录制循环。CLAUDE.md 里记了这点，免得以后被当成"顺手的改进"加回来。

## 关联

sister repo `lerobot-xense` 有同样缺陷，但只在 RT 路径：Vertax42/lerobot-xense#fix/rt-rerecord-reset-skipped

## 验证

`py_compile` / `ruff format --check` 通过。`ruff check` 剩 5 个 `UP038` 在 `_format_slow_frame_obs_suffix`（本次未触碰，HEAD 上即存在，pin 的 ruff v0.14.1 里该规则已废弃）。

**未上机验证**：需接硬件跑一次，按左箭头，确认 "Reset the environment" 之后隔了 `reset_time_s` 才出现 "Recording episode N"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)