### PR TITLE
Improve local dataset edit and upload workflows

### DIFF
--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -22,7 +22,9 @@ remove features, modify tasks, and convert image datasets to video format.
 When new_repo_id is specified, creates a new dataset.
 
 Path semantics (v2): --root and --new_root are exact dataset folders containing
-meta/, data/, videos/. When omitted, defaults to $HF_LEROBOT_HOME/{repo_id}.
+meta/, data/, videos/. When --root is omitted, defaults to $HF_LEROBOT_HOME/{repo_id}.
+When --root is provided, local edits stay on that filesystem tree instead of
+being redirected into the HF cache.
 
 Usage Examples:
 
@@ -261,7 +263,12 @@ def get_output_path(
     input_path = Path(root) if root else HF_LEROBOT_HOME / repo_id
 
     output_repo_id = new_repo_id if new_repo_id else repo_id
-    output_path = Path(new_root) if new_root else HF_LEROBOT_HOME / output_repo_id
+    if new_root:
+        output_path = Path(new_root)
+    elif root:
+        output_path = input_path if output_repo_id == repo_id else input_path.parent / output_repo_id
+    else:
+        output_path = HF_LEROBOT_HOME / output_repo_id
 
     # In case of in-place modification, create a backup of the original dataset (if it exists)
     if output_path == input_path:
@@ -476,6 +483,11 @@ def handle_convert_image_to_video(cfg: EditDatasetConfig) -> None:
         output_dir = Path(cfg.new_root)
         output_repo_id = cfg.new_repo_id or f"{cfg.repo_id}_video"
         logging.info(f"Saving to new_root: {output_dir} as {output_repo_id}")
+    elif cfg.root:
+        output_repo_id = cfg.new_repo_id or f"{cfg.repo_id}_video"
+        input_path = Path(cfg.root)
+        output_dir = input_path if output_repo_id == cfg.repo_id else input_path.parent / output_repo_id
+        logging.info(f"Saving next to source dataset: {output_dir} as {output_repo_id}")
     elif cfg.new_repo_id:
         output_repo_id = cfg.new_repo_id
         output_dir = HF_LEROBOT_HOME / cfg.new_repo_id

--- a/src/lerobot/scripts/push_dataset_to_hub.py
+++ b/src/lerobot/scripts/push_dataset_to_hub.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""
+r"""
 Push a local LeRobot dataset to the Hugging Face Hub.
 
 This script is useful when:
@@ -8,38 +8,61 @@ This script is useful when:
 3. You want to re-upload a dataset with different settings
 
 Usage:
-    # Basic usage (requires both --repo-id and --dataset-path)
-    python -m lerobot.scripts.push_dataset_to_hub \\
-        --repo-id Vertax/xense_flare_pick_and_place \\
+    # First login to Hugging Face with a token that can write datasets.
+    huggingface-cli login
+
+    # Basic usage with the installed console command.
+    lerobot-push-dataset-to-hub \
+        --repo-id Vertax/xense_flare_pick_and_place \
         --dataset-path ~/.cache/huggingface/lerobot/Vertax/xense_flare_pick_and_place
 
-    # Use upload_large_folder for large datasets (recommended)
+    # Equivalent module invocation, useful from a source checkout.
     python -m lerobot.scripts.push_dataset_to_hub \
+        --repo-id Vertax/xense_flare_pick_and_place \
+        --dataset-path ~/.cache/huggingface/lerobot/Vertax/xense_flare_pick_and_place
+
+    # Push a dataset stored outside the default HF cache.
+    lerobot-push-dataset-to-hub \
+        --repo-id Xense/local_recording \
+        --dataset-path /data/lerobot/local_recording
+
+    # Limit the upload to selected files with glob patterns.
+    lerobot-push-dataset-to-hub \
+        --repo-id Xense/metadata_only_review \
+        --dataset-path /data/lerobot/metadata_only_review \
+        --allow-patterns "meta/**" "data/**"
+
+    # Use the legacy upload_large_folder API when needed for an older hub setup.
+    lerobot-push-dataset-to-hub \
         --repo-id Xense/forward-06_test \
         --dataset-path ~/.cache/huggingface/lerobot/Xense/forward-06_test \
         --upload-large-folder
 
-    # Push as private dataset
-    python -m lerobot.scripts.push_dataset_to_hub \\
-        --repo-id Vertax/xense_flare_pick_and_place \\
-        --dataset-path ~/.cache/huggingface/lerobot/Vertax/xense_flare_pick_and_place \\
+    # Push as a private dataset.
+    lerobot-push-dataset-to-hub \
+        --repo-id Vertax/xense_flare_pick_and_place \
+        --dataset-path ~/.cache/huggingface/lerobot/Vertax/xense_flare_pick_and_place \
         --private
 
-    # Skip pushing videos (only push metadata and parquet files)
-    python -m lerobot.scripts.push_dataset_to_hub \\
-        --repo-id Vertax/xense_flare_pick_and_place \\
-        --dataset-path ~/.cache/huggingface/lerobot/Vertax/xense_flare_pick_and_place \\
+    # Skip videos and upload only metadata, parquet files and the dataset card.
+    lerobot-push-dataset-to-hub \
+        --repo-id Vertax/xense_flare_pick_and_place \
+        --dataset-path ~/.cache/huggingface/lerobot/Vertax/xense_flare_pick_and_place \
         --no-videos
 
-Examples:
-    # First login to Hugging Face
-    huggingface-cli login
+    # Push to a branch, add card tags and override the dataset license.
+    lerobot-push-dataset-to-hub \
+        --repo-id Xense/experiment_20260902 \
+        --dataset-path /data/lerobot/experiment_20260902 \
+        --branch review \
+        --tags taccap bimanual tactile \
+        --license apache-2.0
 
-    # Push xense_flare dataset with large folder API
-    python -m lerobot.scripts.push_dataset_to_hub \\
-        --repo-id Vertax/xense_flare_pick_and_place_cubes_20260104 \\
-        --dataset-path ~/.cache/huggingface/lerobot/Vertax/xense_flare_pick_and_place_cubes_20260104 \\
-        --upload-large-folder
+    # Re-upload without updating the codebase-version tag.
+    lerobot-push-dataset-to-hub \
+        --repo-id Xense/experiment_20260902 \
+        --dataset-path /data/lerobot/experiment_20260902 \
+        --no-tag-version
 """
 
 import argparse
@@ -120,7 +143,7 @@ def push_dataset_to_hub(
     except Exception as e:
         logging.error(f"Upload failed: {e}")
         logging.info("Tips:")
-        logging.info("  - Try using --upload-large-folder for large datasets")
+        logging.info("  - Try --upload-large-folder only if your installed huggingface_hub needs the legacy uploader")
         logging.info("  - Check your network connection")
         logging.info("  - Make sure you have write access to the repository")
         logging.info("  - Make sure you are logged in with: huggingface-cli login")
@@ -180,7 +203,14 @@ def main():
     parser.add_argument(
         "--upload-large-folder",
         action="store_true",
-        help="Use upload_large_folder API (recommended for large datasets with many files)",
+        help="Use the legacy upload_large_folder API instead of upload_folder",
+    )
+    parser.add_argument(
+        "--allow-patterns",
+        type=str,
+        nargs="*",
+        default=None,
+        help="Only upload files matching these glob patterns (e.g., 'meta/**' 'data/**')",
     )
     parser.add_argument(
         "--no-tag-version",
@@ -202,6 +232,7 @@ def main():
             tag_version=not args.no_tag_version,
             push_videos=not args.no_videos,
             private=args.private,
+            allow_patterns=args.allow_patterns,
             upload_large_folder=args.upload_large_folder,
         )
     except KeyboardInterrupt:

--- a/tests/scripts/test_edit_dataset_parsing.py
+++ b/tests/scripts/test_edit_dataset_parsing.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock, patch
+
 import draccus
 import pytest
 
@@ -28,6 +30,8 @@ from lerobot.scripts.lerobot_edit_dataset import (
     RemoveFeatureConfig,
     SplitConfig,
     _validate_config,
+    get_output_path,
+    handle_convert_image_to_video,
 )
 
 
@@ -83,3 +87,53 @@ class TestOperationTypeParsing:
         cfg = parse_cfg(["--repo_id", "test/repo", "--new_repo_id", "test/merged", "--operation.type", type_name])
         resolved_name = OperationConfig.get_choice_name(type(cfg.operation))
         assert resolved_name == type_name
+
+
+def test_get_output_path_prefers_local_dataset_root(tmp_path):
+    root = tmp_path / "pusht"
+
+    output_repo_id, output_path = get_output_path(
+        repo_id="lerobot/pusht",
+        new_repo_id=None,
+        root=root,
+        new_root=None,
+    )
+
+    assert output_repo_id == "lerobot/pusht"
+    assert output_path == root
+
+
+def test_get_output_path_places_new_local_dataset_next_to_source(tmp_path):
+    root = tmp_path / "pusht"
+
+    output_repo_id, output_path = get_output_path(
+        repo_id="lerobot/pusht",
+        new_repo_id="lerobot/pusht_filtered",
+        root=root,
+        new_root=None,
+    )
+
+    assert output_repo_id == "lerobot/pusht_filtered"
+    assert output_path == tmp_path / "lerobot" / "pusht_filtered"
+
+
+def test_convert_image_to_video_uses_local_root(tmp_path):
+    root = tmp_path / "pusht_image"
+    dataset = MagicMock()
+    dataset.meta.video_keys = []
+    dataset.meta.features = {}
+
+    cfg = EditDatasetConfig(
+        operation=ConvertImageToVideoConfig(),
+        repo_id="pusht_image",
+        root=str(root),
+    )
+
+    with (
+        patch("lerobot.scripts.lerobot_edit_dataset.LeRobotDataset", return_value=dataset),
+        patch("lerobot.scripts.lerobot_edit_dataset.convert_image_to_video_dataset") as mock_convert,
+    ):
+        mock_convert.return_value = dataset
+        handle_convert_image_to_video(cfg)
+
+    assert mock_convert.call_args.kwargs["output_dir"] == tmp_path / "pusht_image_video"


### PR DESCRIPTION
## Summary
- keep single-dataset edit outputs on the local dataset tree when --root is provided
- update push_dataset_to_hub usage examples for the installed command and local dataset paths
- expose --allow-patterns and align upload-large-folder wording with its legacy role
- add parsing/path tests for local edit output behavior

## Validation
- python -m py_compile src/lerobot/scripts/lerobot_edit_dataset.py src/lerobot/scripts/push_dataset_to_hub.py tests/scripts/test_edit_dataset_parsing.py
- git diff --check

Full pytest was not run because this environment does not have pytest installed.