### PR TITLE
chore: point repo, submodule and GHCR paths at the XenseRobotics-AI org

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -97,8 +97,8 @@ jobs:
               tag="$(sed -n 's/^version *= *".*+xtac\.\([^"]*\)"/\1/p' pyproject.toml)"
           fi
           [[ -n "${tag}" ]] || { echo "Could not resolve an image tag" >&2; exit 1; }
-          # A registry reference has to be lowercase and the account is
-          # `Vertax42`. metadata-action lowercases its own `images` input, but
+          # A registry reference has to be lowercase and the owner is
+          # `XenseRobotics-AI`. metadata-action lowercases its own `images` input, but
           # the buildcache refs below are passed to buildx verbatim.
           image="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/xense-taccap-lerobot"
           {

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/taccap-gripper"]
 	path = third_party/taccap-gripper
-	url = git@github.com:Vertax42/TacCap-Gripper.git
+	url = git@github.com:XenseRobotics-AI/TacCap-Gripper.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -800,7 +800,7 @@ Two consequences worth remembering:
   a proxy for the SDK, it _is_ where the SDK came from — so `pip list` and the
   installed daemon can no longer disagree.
 
-To work on the C SDK itself, clone `Vertax42/XenseVR-PC-Service` separately. Its
+To work on the C SDK itself, clone `XenseRobotics-AI/XenseVR-PC-Service` separately. Its
 Windows and aarch64 trees were pruned; the Linux Unity demo lives as a release
 asset that `SDKDemo/UnityBin/fetch_linux_demo.sh` fetches on demand.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ tracks upstream and intentionally stays slim.
 ## Ways to contribute
 
 - **Report bugs** or request features via the
-  [issue tracker](https://github.com/Vertax42/xense-taccap-lerobot/issues)
+  [issue tracker](https://github.com/XenseRobotics-AI/xense-taccap-lerobot/issues)
   (use the bug-report template).
 - **Improve docs** — the root `README.md`, the device guide
   (`src/lerobot/robots/taccap_gripper/README.md`), and docstrings.
@@ -33,7 +33,7 @@ tracks upstream and intentionally stays slim.
 ## Development setup
 
 ```bash
-git clone --recurse-submodules https://github.com/Vertax42/xense-taccap-lerobot.git
+git clone --recurse-submodules https://github.com/XenseRobotics-AI/xense-taccap-lerobot.git
 cd xense-taccap-lerobot
 bash ./setup_env.sh --mamba xense-taccap
 mamba activate xense-taccap

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ training scripts) refer to the
 > **Docker users:** a complete GPU + hardware-SDK image and Compose setup are
 > available in [`docker/README.md`](docker/README.md). It is the quickest way to
 > give an end user a reproducible environment. Images are published on
-> `ghcr.io/vertax42/xense-taccap-lerobot` and need no login to pull;
+> `ghcr.io/xenserobotics-ai/xense-taccap-lerobot` and need no login to pull;
 > `docker/install_customer.sh` prepares the host (Docker, NVIDIA Container
 > Toolkit, the udev rules documented below) and pulls one — see
 > [the quickstart](docker/README.md#快速开始). Building the image
@@ -45,7 +45,7 @@ bash Miniforge3-$(uname)-$(uname -m).sh
 ```bash
 git clone \
   --recurse-submodules \
-  https://github.com/Vertax42/xense-taccap-lerobot.git
+  https://github.com/XenseRobotics-AI/xense-taccap-lerobot.git
 cd xense-taccap-lerobot
 ```
 
@@ -104,7 +104,7 @@ main `lerobot` package.
 > likewise shipped as a separate ~110 MB Debian package (installs to
 > `/opt/apps/roboticsservice`). `setup_env.sh --install` installs it
 > automatically by **downloading the matching-arch asset** from the
-> [v0.2.1 release](https://github.com/Vertax42/XenseVR-PC-Service/releases/tag/v0.2.1)
+> [v0.2.1 release](https://github.com/XenseRobotics-AI/XenseVR-PC-Service/releases/tag/v0.2.1)
 > (override the URL with `$XENSEVR_DEB_URL`), then runs `sudo dpkg -i`
 > (idempotent — same version is skipped). It no longer searches repo `dist/`
 > or `~/Downloads/`; set `$XENSEVR_DEB` only when you explicitly need an
@@ -388,7 +388,7 @@ If you use this fork (LeRobot-Xense) specifically, please also cite:
 @misc{xense-taccap-lerobot,
     author = {XenseRobotics Team},
     title = {LeRobot-Xense: LeRobot with Xense Tactile Robotics Support},
-    howpublished = "\url{https://github.com/Vertax42/xense-taccap-lerobot}",
+    howpublished = "\url{https://github.com/XenseRobotics-AI/xense-taccap-lerobot}",
     year = {2026}
 }
 ```

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,7 +13,7 @@ services:
     # `docker compose build` tags its output with this same name, which keeps it
     # matching docker/push_ghcr.sh and docker/package_customer_delivery.sh. Set
     # LEROBOT_IMAGE to build or run under a different name.
-    image: ${LEROBOT_IMAGE:-ghcr.io/vertax42/xense-taccap-lerobot}:${LEROBOT_IMAGE_TAG:-latest}
+    image: ${LEROBOT_IMAGE:-ghcr.io/xenserobotics-ai/xense-taccap-lerobot}:${LEROBOT_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.user

--- a/doc/pico_camera_integration.md
+++ b/doc/pico_camera_integration.md
@@ -53,7 +53,7 @@ payload 内部格式：
 ### 1. XenseVR-PC-Service 接收 `0x30`
 
 路径（在
-[`Vertax42/XenseVR-PC-Service`](https://github.com/Vertax42/XenseVR-PC-Service)
+[`XenseRobotics-AI/XenseVR-PC-Service`](https://github.com/XenseRobotics-AI/XenseVR-PC-Service)
 仓库内 —— 它不再是本仓库的 submodule，改动这一侧需要单独 clone）：
 
 ```text

--- a/docker/MAINTAINING.md
+++ b/docker/MAINTAINING.md
@@ -30,7 +30,7 @@ Dockerfile 已包含 apt/curl 自动重试、CUDA 12.8 构建期覆盖和 flexib
 priority，不再需要使用临时 `sed` 命令修改构建过程。
 
 `docker compose build` 打出来的镜像名和 compose 的默认值一致，也就是
-`ghcr.io/vertax42/xense-taccap-lerobot:latest` —— 和拉下来的镜像同名。想构建成别的
+`ghcr.io/xenserobotics-ai/xense-taccap-lerobot:latest` —— 和拉下来的镜像同名。想构建成别的
 名字或版本，用 `LEROBOT_IMAGE` / `LEROBOT_IMAGE_TAG` 覆盖。
 
 **注意 tag：`docker compose build` 默认打 `latest`。** 要构建一个具体版本，构建时就得
@@ -63,7 +63,7 @@ tag 留空则取 `pyproject.toml` 里 `+xtac.` 之后的版本号，`push_latest
 发布后确认三件事：
 
 ```bash
-R=ghcr.io/vertax42/xense-taccap-lerobot
+R=ghcr.io/xenserobotics-ai/xense-taccap-lerobot
 docker manifest inspect $R:0.0.8 | grep -m1 digest   # 新 tag 存在
 docker manifest inspect $R:latest | grep -m1 digest  # 与上面一致
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,7 @@ TacCap-Gripper SDK 和 Pico4 绑定的镜像。**从 GHCR 拉取，不需要自�
 **逐条敲,不要整块粘贴** —— `newgrp` 会开一个子 shell，整块粘贴时它后面的命令会被吃掉。
 
 ```bash
-git clone https://github.com/Vertax42/xense-taccap-lerobot.git
+git clone https://github.com/XenseRobotics-AI/xense-taccap-lerobot.git
 cd xense-taccap-lerobot
 ./docker/install_customer.sh          # 装 Docker / NVIDIA Toolkit / udev 规则，并拉镜像
 ```
@@ -74,7 +74,7 @@ LEROBOT_IMAGE_TAG=0.0.8
 | 跑一次性命令             | `docker compose run --rm xense-taccap lerobot-info`                     |
 | 升级镜像                 | 改 `.env` 的 tag，再 `docker compose pull`                              |
 | 确认解析到哪个镜像       | `docker compose config --images`                                        |
-| 看远端有什么（不下载）   | `docker manifest inspect ghcr.io/vertax42/xense-taccap-lerobot:0.0.8`   |
+| 看远端有什么（不下载）   | `docker manifest inspect ghcr.io/xenserobotics-ai/xense-taccap-lerobot:0.0.8`   |
 | 确认本地跑的是哪个       | `docker image inspect --format '{{index .RepoDigests 0}}' <镜像>:<tag>` |
 | 不用 Pico4，关掉随启服务 | `START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap`          |
 | 查看数据                 | `docker compose run --rm xense-taccap bash -lc 'ls -la /data'`          |

--- a/docker/README.md
+++ b/docker/README.md
@@ -69,15 +69,15 @@ LEROBOT_IMAGE_TAG=0.0.8
 
 ## 常用操作
 
-| 想做什么                 | 命令                                                                    |
-| ------------------------ | ----------------------------------------------------------------------- |
-| 跑一次性命令             | `docker compose run --rm xense-taccap lerobot-info`                     |
-| 升级镜像                 | 改 `.env` 的 tag，再 `docker compose pull`                              |
-| 确认解析到哪个镜像       | `docker compose config --images`                                        |
-| 看远端有什么（不下载）   | `docker manifest inspect ghcr.io/xenserobotics-ai/xense-taccap-lerobot:0.0.8`   |
-| 确认本地跑的是哪个       | `docker image inspect --format '{{index .RepoDigests 0}}' <镜像>:<tag>` |
-| 不用 Pico4，关掉随启服务 | `START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap`          |
-| 查看数据                 | `docker compose run --rm xense-taccap bash -lc 'ls -la /data'`          |
+| 想做什么                 | 命令                                                                          |
+| ------------------------ | ----------------------------------------------------------------------------- |
+| 跑一次性命令             | `docker compose run --rm xense-taccap lerobot-info`                           |
+| 升级镜像                 | 改 `.env` 的 tag，再 `docker compose pull`                                    |
+| 确认解析到哪个镜像       | `docker compose config --images`                                              |
+| 看远端有什么（不下载）   | `docker manifest inspect ghcr.io/xenserobotics-ai/xense-taccap-lerobot:0.0.8` |
+| 确认本地跑的是哪个       | `docker image inspect --format '{{index .RepoDigests 0}}' <镜像>:<tag>`       |
+| 不用 Pico4，关掉随启服务 | `START_XENSEVR_SERVICE=0 docker compose run --rm xense-taccap`                |
+| 查看数据                 | `docker compose run --rm xense-taccap bash -lc 'ls -la /data'`                |
 
 ## 数据存在哪
 

--- a/docker/install_customer.sh
+++ b/docker/install_customer.sh
@@ -15,7 +15,7 @@ ARCHIVE_PATH="${1:-${XENSE_IMAGE_ARCHIVE:-}}"
 PROXY_URL="${XENSE_PROXY_URL:-}"
 IMAGE_REPOSITORY="${XENSE_IMAGE_REPOSITORY:-}"
 IMAGE_TAG="${LEROBOT_IMAGE_TAG:-}"
-DEFAULT_IMAGE_REPOSITORY="ghcr.io/vertax42/xense-taccap-lerobot"
+DEFAULT_IMAGE_REPOSITORY="ghcr.io/xenserobotics-ai/xense-taccap-lerobot"
 TEMP_DIR=""
 DOCKER_CMD=(docker)
 

--- a/docker/package_customer_delivery.sh
+++ b/docker/package_customer_delivery.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # Matches compose.yaml's default image name, so this packages whatever
 # `docker compose build` just produced.
-IMAGE_REPOSITORY="${XENSE_IMAGE_REPOSITORY:-ghcr.io/vertax42/xense-taccap-lerobot}"
+IMAGE_REPOSITORY="${XENSE_IMAGE_REPOSITORY:-ghcr.io/xenserobotics-ai/xense-taccap-lerobot}"
 IMAGE_TAG="${1:-${LEROBOT_IMAGE_TAG:-latest}}"
 IMAGE_REF="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
 DIST_ROOT="${XENSE_DIST_DIR:-${ROOT_DIR}/dist/customer}"

--- a/docker/push_ghcr.sh
+++ b/docker/push_ghcr.sh
@@ -77,7 +77,7 @@ derive_tag_from_pyproject() {
   sed -n 's/^version *= *".*+xtac\.\([^"]*\)"/\1/p' "${ROOT_DIR}/pyproject.toml"
 }
 
-# GHCR namespaces are lowercase, but the GitHub account (`Vertax42`) is not, so
+# GHCR namespaces are lowercase, but the GitHub owner (`XenseRobotics-AI`) is not, so
 # a reference built from the remote URL verbatim is rejected at push time.
 resolve_owner() {
   local url owner

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -312,7 +312,7 @@ install_xensevr_service() {
         echo "        no longer a matter of running a script in that repository."
     fi
 
-    DEB_URL="${XENSEVR_DEB_URL:-https://github.com/Vertax42/XenseVR-PC-Service/releases/download/v${DEB_VER}/XenseVR-PC-Service_${DEB_VER}_${ARCH}.deb}"
+    DEB_URL="${XENSEVR_DEB_URL:-https://github.com/XenseRobotics-AI/XenseVR-PC-Service/releases/download/v${DEB_VER}/XenseVR-PC-Service_${DEB_VER}_${ARCH}.deb}"
 
     local WANT INSTALLED STATUS
     # Check the status, not just the version. `dpkg -r` leaves the package in
@@ -366,7 +366,7 @@ install_xensevr_service() {
             if ! curl -fL "${RETRY[@]}" -C - "$DEB_URL" -o "$DEB.part"; then
                 echo "  WARN: download failed — skipping service install."
                 echo "  The partial file is kept at $DEB.part — re-run to resume it."
-                echo "  Or get it from https://github.com/Vertax42/XenseVR-PC-Service/releases"
+                echo "  Or get it from https://github.com/XenseRobotics-AI/XenseVR-PC-Service/releases"
                 echo "  then: sudo dpkg -i XenseVR-PC-Service_*_${ARCH}.deb"
                 return 0
             fi

--- a/src/lerobot/datasets/card_template.md
+++ b/src/lerobot/datasets/card_template.md
@@ -50,7 +50,7 @@ head keys to the headset's stereo eyes.</em></p>
 @misc{xense-taccap-lerobot,
     author = {XenseRobotics Team},
     title = {LeRobot-Xense: LeRobot with Xense Tactile Robotics Support},
-    howpublished = {\url{https://github.com/Vertax42/xense-taccap-lerobot}},
+    howpublished = {\url{https://github.com/XenseRobotics-AI/xense-taccap-lerobot}},
     year = {2026}
 }{% if citation_bibtex is defined and citation_bibtex %}
 


### PR DESCRIPTION
## Background

The repository has been transferred from `Vertax42` to the `XenseRobotics-AI` organization, following `lerobot-xense`, `TacCap-Gripper` and `XenseVR-PC-Service`. GitHub redirects the old repository paths, but **GHCR packages do not move with a repository and have no redirect**, so the default image namespace changes as well.

## Changes (14 files, 21 references)

- `.gitmodules`: `third_party/taccap-gripper` -> `git@github.com:XenseRobotics-AI/TacCap-Gripper.git` (that repo already moved)
- `compose.yaml`, `docker/install_customer.sh`, `docker/package_customer_delivery.sh`: default image -> `ghcr.io/xenserobotics-ai/xense-taccap-lerobot`
- `.github/workflows/docker-publish.yml`, `docker/push_ghcr.sh`: comments only. Both already derive the owner dynamically (`GITHUB_REPOSITORY_OWNER` / the `origin` URL), so the next publish lands in the new namespace without logic changes
- `README.md`, `CONTRIBUTING.md`, `docker/README.md`, `docker/MAINTAINING.md`, `doc/pico_camera_integration.md`, `CLAUDE.md`, `setup_env.sh`, `src/lerobot/datasets/card_template.md`: clone / release / issue / image URLs

## Image migration

Tags `0.0.3` .. `0.0.8` and `latest` are being copied from `ghcr.io/vertax42/...` to `ghcr.io/xenserobotics-ai/...` with identical digests (registry-to-registry, no rebuild). The old package is kept so rigs that have not updated their checkout keep pulling. The new package must be set to **public** in its package settings before customers can `docker compose pull` anonymously.

## After merging

Existing clones: `git remote set-url origin git@github.com:XenseRobotics-AI/xense-taccap-lerobot.git && git submodule sync --recursive`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
