### PR TITLE
refactor(taccap): stop recording tactile runtime bundles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,16 +88,13 @@ repeated per epoch so readers of older files keep working; `manifest_robot_ids`
 reads both. An unlabelled dataset (recorded before `--robot.id` was required) is
 not a mismatch — same reading as the open epoch above.
 
-Each tactile sensor's **runtime bundle** goes in beside it, at
-`meta/runtimes/<serial>-<local time>.bin` (`RUNTIME_DIR`), with the epoch's
-sensors pointing at their own. Deriving depth / force / difference from the
-recorded `rectify` stream needs the bundle that was current **when the episodes
-were recorded** — it carries the reference image captured at `Sensor.create()`,
-and a sensor that comes back from maintenance keeps its serial but produces a
-different bundle, which is why the name is timestamped and why a new bundle
-opens its own epoch. Solving against the wrong one does not fail: an untouched
-gel returns plausible depth and force. So `tactile_runtime_for_key` returning
-`None` means **skip derivation**, never "use whichever bundle is nearest".
+Tactile **runtime bundles are no longer recorded** (they used to sit at
+`meta/runtimes/<serial>-<time>.bin` with a `runtime` key per sensor). The only
+per-sensor part of a bundle is the reference image, and the dataset already
+carries it — the first `rectify` frame of each episode; everything else in the
+solver is fixed per sensor _model_. Downstream (TacFlow) rebuilds depth / force /
+difference from the stream plus the serial in this manifest, so the manifest is
+still the one thing that must survive every conversion.
 
 ### On mis-burned / mis-installed hardware
 

--- a/src/lerobot/cameras/xense/camera_xense.py
+++ b/src/lerobot/cameras/xense/camera_xense.py
@@ -572,33 +572,6 @@ class XenseTactileCamera(Camera):
         # Do NOT call _format_read_result() again, as it would double-convert BGR<->RGB.
         return data
 
-    def export_runtime_config(self) -> bytes | None:
-        """This sensor's runtime config as bytes, or ``None`` if unavailable.
-
-        The runtime bundle is what lets the multimodal tactile channels (depth,
-        force, difference) be rebuilt offline from the recorded ``rectify``
-        stream. It carries this unit's own calibration *and* the reference image
-        captured when the sensor came up, so it has to be taken from the sensor
-        that is recording — another unit's bundle, or this one's from another
-        session, does not fail loudly. It reports plausible depth and force from
-        an untouched gel.
-
-        Returns ``None`` rather than raising when the sensor is not connected or
-        the SDK cannot produce one: a missing bundle costs the derived channels
-        for those episodes, which is not a reason to lose the recording itself.
-        """
-        sensor = getattr(self, "sensor", None)
-        if sensor is None:
-            return None
-        try:
-            return sensor.exportRuntimeConfig(binary=True)
-        except Exception as e:  # noqa: BLE001 - vendor SDK, and no failure here is fatal
-            logger.warn(
-                f"{self}: could not export the runtime config ({e}); "
-                "tactile derivation will need this sensor's bundle from elsewhere."
-            )
-            return None
-
     def disconnect(self):
         """
         Disconnects from the sensor and cleans up resources.

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -58,7 +58,6 @@ from lerobot.utils.constants import (
     HF_LEROBOT_HOME,
     OBS_IMAGE,
     TACCAP_HARDWARE_MANIFEST_PATH,
-    TACCAP_RUNTIME_DIR,
 )
 
 TACCAP_6_CAMERA_FEATURE_KEYS = frozenset(
@@ -640,15 +639,13 @@ def _copy_taccap_local_metadata(src_root: Path, dst_root: Path) -> None:
     helpers above move only data, videos and episode metadata. Anything this fork
     adds under `meta/` is therefore dropped unless copied here.
 
-    Two things live there and both matter:
+    One thing lives there and it matters: `meta/hardware.json` maps each tactile
+    `observation_key` to the **physical sensor serial** that produced it.
 
-    * `meta/hardware.json` maps each tactile `observation_key` to the **physical
-      sensor serial** that produced it.
-    * `meta/runtimes/*.bin` holds those sensors' calibration bundles.
-
-    Losing them is not a cosmetic regression. Deriving depth / force / difference
-    from a tactile stream needs that sensor's own calibration, and solving a
-    stream against **another** unit's bundle does not fail loudly — measured on
+    Losing it is not a cosmetic regression. Deriving depth / force / difference
+    from a tactile stream is solved against that sensor's own reference (its
+    first `rectify` frame), and solving a stream against **another** unit's
+    reference does not fail loudly — measured on
     untouched gels it inflates `Depth` by ~800x and `ForceResultant` by ~1000x
     while reporting no error at all. A converted dataset that lost its manifest
     cannot be reconstructed from the dataset alone; the mapping only exists in
@@ -659,7 +656,7 @@ def _copy_taccap_local_metadata(src_root: Path, dst_root: Path) -> None:
     nothing in it to prune.
     """
     src_root, dst_root = Path(src_root), Path(dst_root)
-    for relative in (TACCAP_HARDWARE_MANIFEST_PATH, TACCAP_RUNTIME_DIR):
+    for relative in (TACCAP_HARDWARE_MANIFEST_PATH,):
         src = src_root / relative
         if not src.exists():
             continue

--- a/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/bi_taccap_gripper.py
@@ -249,30 +249,6 @@ class BiTaccapGripper(Robot):
         return configs
 
     @property
-    def tactile_runtimes(self) -> dict[str, bytes]:
-        """Each connected tactile sensor's runtime bundle, keyed by serial.
-
-        Recorded into the dataset so the derived channels (depth, force,
-        difference) can be rebuilt from the ``rectify`` stream later without the
-        physical sensor — and without the risk that it has since been
-        recalibrated, which changes the reference image the reconstruction is
-        measured against.
-
-        Sensors that cannot produce one are simply absent: that costs the derived
-        channels for those episodes, which is not a reason to fail a recording.
-        """
-        runtimes: dict[str, bytes] = {}
-        for camera in self.cameras.values():
-            export = getattr(camera, "export_runtime_config", None)
-            serial = getattr(camera, "serial_number", None)
-            if export is None or not serial:
-                continue
-            blob = export()
-            if blob:
-                runtimes[serial] = blob
-        return runtimes
-
-    @property
     def hardware_manifest(self) -> dict[str, Any]:
         """Which physical devices this rig is, for the recording to carry along.
 

--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -758,14 +758,12 @@ defaults it to `taccap_0`.
             {
               "finger": "left",
               "observation_key": "left_tactile_left",
-              "serial": "GSPS01A25Z0011",
-              "runtime": "meta/runtimes/GSPS01A25Z0011-20260822T160309.bin"
+              "serial": "GSPS01A25Z0011"
             },
             {
               "finger": "right",
               "observation_key": "left_tactile_right",
-              "serial": "GSPS01A25Z0012",
-              "runtime": "meta/runtimes/GSPS01A25Z0012-20260822T160309.bin"
+              "serial": "GSPS01A25Z0012"
             }
           ],
           "wrist_undistort": { "applied": false }
@@ -822,9 +820,9 @@ changed"_ is not _"it didn't"_.
   omitted; `enable_tactile=false` gives it an empty `tactile_sensors`.
 - It is a file of its own, **not** a key in `meta/info.json`: that schema is
   upstream's and a fork-local key in it would collide on the next v5.x sync.
-- `runtime` points at the tactile runtime bundle under `meta/runtimes/` that was
-  current when those episodes were recorded — what the derived channels have to
-  be rebuilt against.
+- Tactile runtime bundles are no longer written (older datasets may still show a
+  `runtime` key per sensor; it is ignored). The derived channels are rebuilt from
+  the stream's own first `rectify` frame plus the serial.
 - `wrist_undistort` says whether that unit's wrist frames were rectified and from
   whose intrinsics (`"unit"` or `"reference"`). Present whenever the unit has a
   wrist camera, including as `{"applied": false}`.

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -42,7 +42,7 @@ import numpy as np
 
 from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
 from lerobot.cameras.xense.configuration_xense import XenseTactileCameraConfig
-from lerobot.utils.constants import TACCAP_HARDWARE_MANIFEST_PATH, TACCAP_RUNTIME_DIR
+from lerobot.utils.constants import TACCAP_HARDWARE_MANIFEST_PATH
 
 # 6D rotation convention (matches ``vive_tracker``): r1..r3 is the first column
 # of the rotation matrix, r4..r6 the second. Position first, so the tuple is the
@@ -59,7 +59,6 @@ __all__ = [
     "HEAD_POSE_KEYS",
     "HEAD_CAMERA_KEYS",
     "HARDWARE_MANIFEST_PATH",
-    "RUNTIME_DIR",
     "GripperReadGuard",
     "HeadSkewMonitor",
     "build_hardware_manifest",
@@ -81,13 +80,11 @@ __all__ = [
     "resolve_wrist_camera_path",
     "split_camera_read",
     "swap_tactile_display_features",
-    "tactile_runtime_for_key",
     "tactile_serial_for_key",
     "tactile_camera_output_types",
     "tactile_display_key",
     "validate_robot_id",
     "write_hardware_manifest",
-    "write_tactile_runtimes",
 ]
 
 
@@ -1301,99 +1298,10 @@ def epoch_for_episode(manifest: dict[str, Any], episode_index: int) -> dict[str,
     return None
 
 
-RUNTIME_DIR = TACCAP_RUNTIME_DIR
-"""Where a dataset keeps the tactile runtime bundles its episodes need.
-
-Rebuilding depth / force / difference from the recorded ``rectify`` stream needs
-the recording sensor's own runtime config. Keeping it *in* the dataset is what
-makes that reconstruction possible from the dataset alone — no hunting down the
-physical unit months later, and no risk that the unit has since been recalibrated
-into a different reference.
-
-Files are named ``<serial>-<local timestamp>.bin``, because a serial alone is not
-unique over time: a sensor pulled for maintenance and reinstalled keeps its
-serial and comes back with a new reference image, so ``<serial>.bin`` would have
-the later run overwrite the earlier one — silently re-deriving those episodes
-against a calibration they were never recorded with.
-
-The timestamp rather than a content hash: every export is a fresh AES-GCM
-encryption with a random salt and IV, so two exports of the *same* sensor state
-have different bytes. A digest would therefore never collapse duplicates while
-also saying nothing a reader can use. The time is what the file actually is —
-this unit's calibration as of that moment.
-
-The name carries wall-clock time in ``CAPTURE_TZ`` (UTC+08:00, where the rigs
-run) and no offset marker, so it reads as the hour someone was standing at the
-bench. That makes it a label, not a timestamp to compute with — the authoritative
-value is ``recorded_at`` on the epoch, which is full ISO-8601 with offset. Two
-readers, two jobs; the ambiguous-looking one is the one nothing parses.
-
-One bundle per recording session is the right granularity, not an accident of
-naming: the reference image is captured fresh at every ``Sensor.create()``, so
-each session genuinely has its own. Measured on an untouched sensor, reusing the
-previous session's bundle moves ``Depth`` by 2.9e-4 and ``ForceResultant`` by
-7.3e-3 — the noise floor, and ~1000x smaller than the error from using another
-*unit's* bundle. Small, but there is no reason to accept it when the correct
-bundle costs 841 KB.
-"""
-
 #: Where the rigs are. Fixed offset rather than a named zone: China has observed
 #: no DST since 1991, so there is no ambiguous hour for a bare local time to land
 #: in, and a fixed offset needs no tz database to reproduce.
 CAPTURE_TZ = timezone(timedelta(hours=8), "UTC+08:00")
-
-
-def _runtime_filename(serial: str, taken_at: datetime) -> str:
-    return f"{serial}-{taken_at.astimezone(CAPTURE_TZ).strftime('%Y%m%dT%H%M%S')}.bin"
-
-
-def write_tactile_runtimes(
-    root: str | Path, runtimes: dict[str, bytes], taken_at: datetime | None = None
-) -> dict[str, str]:
-    """Write each sensor's runtime bundle and return ``{serial: relative path}``.
-
-    Every bundle from one call shares ``taken_at``, so a rig's sensors are named
-    for the session rather than for whichever microsecond each export finished
-    in. Paths are relative to the dataset root, which is what goes in the
-    manifest.
-    """
-    taken_at = taken_at or datetime.now(CAPTURE_TZ)
-    written: dict[str, str] = {}
-    for serial, blob in sorted(runtimes.items()):
-        if not blob:
-            continue
-        relative = f"{RUNTIME_DIR}/{_runtime_filename(serial, taken_at)}"
-        path = Path(root) / relative
-        path.parent.mkdir(parents=True, exist_ok=True)
-        # Two exports in the same second would otherwise land on one name and the
-        # second would win, leaving an epoch pointing at a bundle that is not its
-        # own. Rare, but the failure is silent, so it gets a suffix instead.
-        suffix = 1
-        while path.exists() and path.read_bytes() != blob:
-            relative = f"{RUNTIME_DIR}/{_runtime_filename(serial, taken_at)[:-4]}-{suffix}.bin"
-            path = Path(root) / relative
-            suffix += 1
-        if not path.exists():
-            path.write_bytes(blob)
-        written[serial] = relative
-    return written
-
-
-def _stamp_runtimes(units: list[dict[str, Any]], paths: dict[str, str]) -> list[dict[str, Any]]:
-    """Copy ``units`` with each tactile sensor pointing at its runtime bundle.
-
-    A sensor with no bundle is left without the key rather than given a null:
-    absent means "not recorded", and a null would read like "recorded as
-    nothing". Consumers check for the key.
-    """
-    stamped = []
-    for unit in units:
-        sensors = []
-        for sensor in unit.get("tactile_sensors") or []:
-            relative = paths.get(sensor.get("serial"))
-            sensors.append({**sensor, "runtime": relative} if relative else dict(sensor))
-        stamped.append({**unit, "tactile_sensors": sensors})
-    return stamped
 
 
 def _epoch_payload(manifest: dict[str, Any]) -> dict[str, Any]:
@@ -1418,10 +1326,11 @@ def tactile_serial_for_key(manifest: dict[str, Any], episode_index: int, observa
 
     The one lookup every consumer of this file actually wants, so it lives here
     rather than being re-derived — getting it wrong is not visible in the output.
-    Deriving the multimodal tactile channels (depth, force, difference) needs the
-    sensor's own runtime config, and solving a stream against another unit's
-    calibration does not fail loudly: it reports plausible depth and force from
-    an untouched gel.
+    Deriving the multimodal tactile channels (depth, force, difference) is solved
+    against the sensor's own reference image (the first ``rectify`` frame of the
+    episode; everything else in the solver is fixed per sensor *model*), and
+    solving a stream against another unit's reference does not fail loudly: it
+    reports plausible depth and force from an untouched gel.
 
     ``None`` means the manifest cannot answer — no epoch covers that episode, or
     no sensor in it feeds that key. Callers must treat that as "do not derive",
@@ -1434,27 +1343,6 @@ def tactile_serial_for_key(manifest: dict[str, Any], episode_index: int, observa
         for sensor in unit.get("tactile_sensors") or []:
             if sensor.get("observation_key") == observation_key:
                 return sensor.get("serial")
-    return None
-
-
-def tactile_runtime_for_key(manifest: dict[str, Any], episode_index: int, observation_key: str) -> str | None:
-    """Path (dataset-relative) of the runtime bundle needed to rebuild this
-    stream's derived channels, or ``None`` if the dataset does not carry one.
-
-    ``None`` covers both "no epoch claims that episode" and "recorded before
-    bundles were stored". Either way the honest move is to skip derivation for
-    those episodes rather than reach for another bundle: a bundle from a
-    different unit — or from the same unit after a recalibration — turns an
-    untouched gel into plausible depth and force, with nothing in the output
-    saying so.
-    """
-    epoch = epoch_for_episode(manifest, episode_index)
-    if epoch is None:
-        return None
-    for unit in epoch.get("units") or []:
-        for sensor in unit.get("tactile_sensors") or []:
-            if sensor.get("observation_key") == observation_key:
-                return sensor.get("runtime")
     return None
 
 
@@ -1491,9 +1379,9 @@ def _describe_change(previous: dict[str, Any] | None, current: dict[str, Any]) -
     # resumed by a run that has one.
     if previous.get("robot_id") != current.get("robot_id"):
         return f"Station label recorded ({previous.get('robot_id')} -> {current.get('robot_id')})"
-    # Same serials, same station: what differs is the runtime bundle, which the
-    # sensor re-captures at every ``Sensor.create()``. Calling that "hardware
-    # changed" would send someone hunting for a swap that never happened.
+    # Same serials, same station: what differs is the capture session
+    # (``recorded_at``). Calling that "hardware changed" would send someone
+    # hunting for a swap that never happened.
     return "New capture session on the same hardware"
 
 
@@ -1503,7 +1391,6 @@ def write_hardware_manifest(
     logger: Any,
     *,
     episode_index: int = 0,
-    runtimes: dict[str, bytes] | None = None,
 ) -> Path:
     """Write ``manifest`` to ``root/meta/hardware.json`` and return the path.
 
@@ -1543,12 +1430,11 @@ def write_hardware_manifest(
     solving a tactile stream against another sensor's calibration yields
     plausible depth and force from an untouched gel — no error, no signal.
 
-    ``runtimes`` maps a tactile serial to its runtime bundle
-    (``XenseCamera.export_runtime_config()``). Given one, each bundle is written
-    under ``meta/runtimes/`` and the epoch's sensors point at it, so the derived
-    tactile channels can be rebuilt from the dataset alone. A sensor that comes
-    back from maintenance with a new reference image produces a different bundle
-    under the same serial, which counts as a change and opens its own epoch.
+    Tactile runtime bundles are **not** recorded any more. The only per-sensor
+    part of a bundle is the reference image, and the dataset already holds it:
+    the first ``rectify`` frame of each episode. Everything else is fixed per
+    sensor model, so the derived channels are rebuilt from the stream plus the
+    serial recorded here.
 
     A truncated or unreadable file is still left alone: whatever episodes are
     already there have provenance we cannot reconstruct, and clobbering it would
@@ -1560,13 +1446,6 @@ def write_hardware_manifest(
     # once one is actually opened.
     recorded_at = datetime.now(CAPTURE_TZ)
     payload = _epoch_payload(manifest)
-    if runtimes:
-        # Written before the comparison below, so a re-calibrated sensor — same
-        # serial, new reference image, hence a new bundle path — is seen as a
-        # change and opens its own epoch. That is the point: the old episodes
-        # must keep pointing at the bundle that was current when they were
-        # recorded.
-        payload["units"] = _stamp_runtimes(payload["units"], write_tactile_runtimes(root, runtimes, recorded_at))
 
     if not path.exists():
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/lerobot/robots/taccap_gripper/taccap_gripper.py
+++ b/src/lerobot/robots/taccap_gripper/taccap_gripper.py
@@ -260,30 +260,6 @@ class TaccapGripper(Robot):
         return configs
 
     @property
-    def tactile_runtimes(self) -> dict[str, bytes]:
-        """Each connected tactile sensor's runtime bundle, keyed by serial.
-
-        Recorded into the dataset so the derived channels (depth, force,
-        difference) can be rebuilt from the ``rectify`` stream later without the
-        physical sensor — and without the risk that it has since been
-        recalibrated, which changes the reference image the reconstruction is
-        measured against.
-
-        Sensors that cannot produce one are simply absent: that costs the derived
-        channels for those episodes, which is not a reason to fail a recording.
-        """
-        runtimes: dict[str, bytes] = {}
-        for camera in self.cameras.values():
-            export = getattr(camera, "export_runtime_config", None)
-            serial = getattr(camera, "serial_number", None)
-            if export is None or not serial:
-                continue
-            blob = export()
-            if blob:
-                runtimes[serial] = blob
-        return runtimes
-
-    @property
     def hardware_manifest(self) -> dict[str, Any]:
         """Which physical device this unit is, for the recording to carry along.
 

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -646,9 +646,6 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                 robot.hardware_manifest,
                 logger,
                 episode_index=dataset.num_episodes,
-                # Each tactile sensor's runtime bundle goes in with it, so the
-                # derived channels can be rebuilt from this dataset alone later.
-                runtimes=getattr(robot, "tactile_runtimes", None) or None,
             )
 
         # The one block a session file can be read from without the machine:

--- a/src/lerobot/utils/constants.py
+++ b/src/lerobot/utils/constants.py
@@ -99,4 +99,3 @@ LIBERO_KEY_PIXELS_EYE_IN_HAND = "pixels/robot0_eye_in_hand_image"
 # `datasets/` can name them without importing `robots/` (which would invert the
 # dependency direction). `common.py` re-exports them for its existing callers.
 TACCAP_HARDWARE_MANIFEST_PATH = "meta/hardware.json"
-TACCAP_RUNTIME_DIR = "meta/runtimes"

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -34,7 +34,7 @@ from lerobot.datasets.dataset_tools import (
     split_dataset,
 )
 from lerobot.scripts.lerobot_edit_dataset import convert_image_to_video_dataset
-from lerobot.utils.constants import TACCAP_HARDWARE_MANIFEST_PATH, TACCAP_RUNTIME_DIR
+from lerobot.utils.constants import TACCAP_HARDWARE_MANIFEST_PATH
 
 
 def _taccap_8_camera_features() -> dict:
@@ -676,7 +676,7 @@ def test_convert_8_to_6_cameras(empty_lerobot_dataset_factory, tmp_path):
 
 
 def test_convert_8_to_6_cameras_keeps_the_taccap_hardware_metadata(empty_lerobot_dataset_factory, tmp_path):
-    """End-to-end: the sensor manifest and runtime bundles survive a real conversion.
+    """End-to-end: the sensor manifest survives a real conversion.
 
     Checked here rather than only on the copy helper because the loss was never in
     the helper — it was that no one called it. `LeRobotDatasetMetadata.create`
@@ -716,15 +716,11 @@ def test_convert_8_to_6_cameras_keeps_the_taccap_hardware_metadata(empty_lerobot
         }
     )
     (dataset.meta.root / TACCAP_HARDWARE_MANIFEST_PATH).write_text(manifest)
-    bundle = dataset.meta.root / TACCAP_RUNTIME_DIR / "GSPS01A29Z0017-20260824T101500.bin"
-    bundle.parent.mkdir(parents=True, exist_ok=True)
-    bundle.write_bytes(b"encrypted-runtime-bundle")
 
     converted = convert_8_to_6_cameras(dataset, output_dir=tmp_path / "converted_6cam", repo_id="test/6cam_hw")
 
     out = Path(converted.meta.root)
     assert (out / TACCAP_HARDWARE_MANIFEST_PATH).read_text() == manifest
-    assert (out / TACCAP_RUNTIME_DIR / bundle.name).read_bytes() == b"encrypted-runtime-bundle"
     # The manifest names sensors, not cameras — a head-camera removal must not
     # rewrite it, so it has to come through byte-identical.
     assert "GSPS01A29Z0017" in (out / TACCAP_HARDWARE_MANIFEST_PATH).read_text()

--- a/tests/datasets/test_taccap_local_metadata.py
+++ b/tests/datasets/test_taccap_local_metadata.py
@@ -32,17 +32,13 @@ from lerobot.datasets.dataset_tools import (
     _copy_taccap_local_metadata,
     _reject_merge_of_taccap_hardware_metadata,
 )
-from lerobot.utils.constants import TACCAP_HARDWARE_MANIFEST_PATH, TACCAP_RUNTIME_DIR
+from lerobot.utils.constants import TACCAP_HARDWARE_MANIFEST_PATH
 
 
-def make_source(root: Path, *, manifest: bool = True, runtimes: int = 0) -> Path:
+def make_source(root: Path, *, manifest: bool = True) -> Path:
     (root / "meta").mkdir(parents=True, exist_ok=True)
     if manifest:
         (root / TACCAP_HARDWARE_MANIFEST_PATH).write_text('{"robot_type": "bi_taccap_gripper"}')
-    for i in range(runtimes):
-        bundle = root / TACCAP_RUNTIME_DIR / f"GSPS01A29Z{i:04d}-20260824T101500.bin"
-        bundle.parent.mkdir(parents=True, exist_ok=True)
-        bundle.write_bytes(b"runtime-%d" % i)
     return root
 
 
@@ -53,18 +49,8 @@ class TestCopy:
         _copy_taccap_local_metadata(src, dst)
         assert (dst / TACCAP_HARDWARE_MANIFEST_PATH).read_text() == (src / TACCAP_HARDWARE_MANIFEST_PATH).read_text()
 
-    def test_the_runtime_bundles_survive(self, tmp_path):
-        """The manifest names the sensors; the bundles are what actually lets a
-        stream be re-solved. Carrying one without the other is half a record."""
-        src = make_source(tmp_path / "src", runtimes=3)
-        dst = tmp_path / "dst"
-        _copy_taccap_local_metadata(src, dst)
-        assert sorted(p.name for p in (dst / TACCAP_RUNTIME_DIR).iterdir()) == sorted(
-            p.name for p in (src / TACCAP_RUNTIME_DIR).iterdir()
-        )
-
     def test_a_source_without_them_is_not_an_error(self, tmp_path):
-        """Upstream datasets have neither. The copy is additive, never required."""
+        """Upstream datasets have no manifest. The copy is additive, never required."""
         src = make_source(tmp_path / "src", manifest=False)
         dst = tmp_path / "dst"
         _copy_taccap_local_metadata(src, dst)

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -18,9 +18,7 @@ pinning. Nothing below touches hardware or either vendor SDK.
 
 import functools
 import json
-import re
 import time
-from datetime import datetime, timedelta
 
 import numpy as np
 import pytest
@@ -29,12 +27,10 @@ from lerobot.cameras.pico import SUPPORTED_MODES
 from lerobot.robots.bi_taccap_gripper.config_bi_taccap_gripper import BiTaccapGripperConfig
 from lerobot.robots.taccap_gripper.camera_health import CameraReadGuard
 from lerobot.robots.taccap_gripper.common import (
-    CAPTURE_TZ,
     HARDWARE_MANIFEST_PATH,
     HEAD_CAMERA_KEYS,
     HEAD_POSE_KEYS,
     POSE_KEYS,
-    RUNTIME_DIR,
     GripperReadGuard,
     HeadSkewMonitor,
     build_hardware_manifest,
@@ -53,7 +49,6 @@ from lerobot.robots.taccap_gripper.common import (
     swap_tactile_display_features,
     tactile_camera_output_types,
     tactile_display_key,
-    tactile_runtime_for_key,
     tactile_serial_for_key,
     validate_robot_id,
     validate_wrist_undistort_size,
@@ -1076,137 +1071,6 @@ class TestManifestEpochs:
         — which is the failure this whole mechanism exists to prevent."""
         closed = {"epochs": [{"from_episode": 0, "to_episode": 57, "units": self.UNITS_A}]}
         assert epoch_for_episode(closed, 57) is None
-
-
-class TestTactileRuntimes:
-    """The bundles are what actually rebuild depth / force / difference, so the
-    cases that would hand an episode the wrong one are the ones worth pinning."""
-
-    def _manifest(self, serial="GSPS01A25Z0011"):
-        return build_hardware_manifest(
-            robot_type="taccap_gripper",
-            robot_id="taccap_0",
-            role="leader",
-            units=[
-                hardware_manifest_unit(
-                    "left",
-                    endpoints=FakeEndpoints("TCGU01A24Z0001m"),
-                    tactile_serials={"left": serial},
-                    key_prefix="",
-                )
-            ],
-        )
-
-    def test_the_bundle_lands_in_the_dataset_and_the_epoch_points_at_it(self, tmp_path):
-        write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), runtimes={"GSPS01A25Z0011": b"bundle-v1"})
-        relative = tactile_runtime_for_key(
-            json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text()), 0, "tactile_left"
-        )
-        assert relative.startswith(RUNTIME_DIR)
-        assert (tmp_path / relative).read_bytes() == b"bundle-v1"
-
-    def test_recalibration_keeps_both_bundles_and_splits_the_epoch(self, tmp_path):
-        """Same serial, new reference image. Naming the file by serial alone would
-        have the second run overwrite the first, silently re-deriving the earlier
-        episodes against a calibration they were not recorded with."""
-        write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), runtimes={"GSPS01A25Z0011": b"bundle-v1"})
-        write_hardware_manifest(
-            tmp_path,
-            self._manifest(),
-            FakeLogger(),
-            episode_index=40,
-            runtimes={"GSPS01A25Z0011": b"bundle-v2-after-maintenance"},
-        )
-
-        manifest = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
-        early = tactile_runtime_for_key(manifest, 39, "tactile_left")
-        late = tactile_runtime_for_key(manifest, 40, "tactile_left")
-        assert early != late
-        assert (tmp_path / early).read_bytes() == b"bundle-v1"
-        assert (tmp_path / late).read_bytes() == b"bundle-v2-after-maintenance"
-
-    def test_resuming_on_the_same_rig_is_not_reported_as_a_hardware_change(self, tmp_path):
-        """Every session exports different bytes even when nothing was touched:
-        the reference image is re-captured at ``Sensor.create()`` and the bundle
-        is freshly AES-GCM encrypted with a random salt and IV. So each resume
-        legitimately gets its own epoch and its own file — but calling that a
-        hardware change would send someone hunting for a swap that never
-        happened.
-
-        Measured on an untouched unit, the two sessions' bundles move ``Depth``
-        by 2.9e-4 and ``ForceResultant`` by 7.3e-3 — the noise floor, and ~1000x
-        smaller than using another *unit's* bundle. Keeping both is still right:
-        the correct one costs 841 KB.
-        """
-        logger = FakeLogger()
-        for episode, blob in ((0, b"session-1"), (20, b"session-2"), (40, b"session-3")):
-            write_hardware_manifest(
-                tmp_path,
-                self._manifest(),
-                logger,
-                episode_index=episode,
-                runtimes={"GSPS01A25Z0011": blob},
-            )
-        manifest = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
-        assert len(manifest["epochs"]) == 3
-        assert len(list((tmp_path / RUNTIME_DIR).iterdir())) == 3
-        bundles = [tactile_runtime_for_key(manifest, ep, "tactile_left") for ep in (0, 20, 40)]
-        assert len(set(bundles)) == 3
-        assert [(tmp_path / b).read_bytes() for b in bundles] == [b"session-1", b"session-2", b"session-3"]
-        assert not any("Hardware changed" in message for message in logger.infos)
-        assert all("same hardware" in message for message in logger.infos[1:])
-
-    def test_two_bundles_exported_in_the_same_second_do_not_collide(self, tmp_path):
-        """The name carries a whole-second timestamp, so a fast re-export would
-        otherwise land on one file and the second would win — leaving an epoch
-        pointing at a bundle that is not its own."""
-        for episode, blob in ((0, b"first"), (1, b"second")):
-            write_hardware_manifest(
-                tmp_path, self._manifest(), FakeLogger(), episode_index=episode, runtimes={"GSPS01A25Z0011": blob}
-            )
-        manifest = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
-        assert (tmp_path / tactile_runtime_for_key(manifest, 0, "tactile_left")).read_bytes() == b"first"
-        assert (tmp_path / tactile_runtime_for_key(manifest, 1, "tactile_left")).read_bytes() == b"second"
-
-    def test_the_filename_reads_as_bench_local_time(self, tmp_path):
-        """A content hash would never collapse duplicates (random salt) while
-        telling a reader nothing. The time is what the file actually is — and in
-        the timezone of the bench it was taken at, so it reads without arithmetic.
-        """
-        write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), runtimes={"GSPS01A25Z0011": b"b"})
-        (name,) = (p.name for p in (tmp_path / RUNTIME_DIR).iterdir())
-        assert re.fullmatch(r"GSPS01A25Z0011-\d{8}T\d{6}\.bin", name), name
-        stamped = datetime.strptime(name.split("-")[1][: -len(".bin")], "%Y%m%dT%H%M%S")
-        assert abs(stamped - datetime.now(CAPTURE_TZ).replace(tzinfo=None)) < timedelta(minutes=1)
-
-    def test_the_epoch_carries_the_unambiguous_time(self, tmp_path):
-        """The filename is a label a human reads; anything that computes with the
-        time uses this, which carries its offset."""
-        write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), runtimes={"GSPS01A25Z0011": b"b"})
-        (epoch,) = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())["epochs"]
-        recorded = datetime.fromisoformat(epoch["recorded_at"])
-        assert recorded.utcoffset() == timedelta(hours=8)
-        assert abs(recorded - datetime.now(CAPTURE_TZ)) < timedelta(minutes=1)
-
-    def test_the_clock_alone_does_not_open_an_epoch(self, tmp_path):
-        """``recorded_at`` differs on every run by construction. If it were part
-        of the rig comparison, every resume would look like a hardware change."""
-        for episode in (0, 20):
-            write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), episode_index=episode)
-        assert len(json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())["epochs"]) == 1
-
-    def test_a_sensor_without_a_bundle_is_absent_not_null(self, tmp_path):
-        """Absent means "not recorded"; a null would read like "recorded as
-        nothing". Consumers check for the key."""
-        write_hardware_manifest(tmp_path, self._manifest(), FakeLogger(), runtimes={})
-        manifest = json.loads((tmp_path / HARDWARE_MANIFEST_PATH).read_text())
-        sensor = manifest["epochs"][0]["units"][0]["tactile_sensors"][0]
-        assert "runtime" not in sensor
-        assert tactile_runtime_for_key(manifest, 0, "tactile_left") is None
-
-    def test_a_pre_bundle_dataset_reports_none_rather_than_guessing(self):
-        legacy = {"robot_type": "taccap_gripper", "units": self._manifest()["units"]}
-        assert tactile_runtime_for_key(legacy, 0, "tactile_left") is None
 
 
 class TestTactileSerialForKey:


### PR DESCRIPTION
## Why

The per-sensor runtime bundle (`meta/runtimes/<serial>-<time>.bin`, stamped into `hardware.json` as `tactile_sensors[].runtime`) is no longer needed to rebuild depth / force / difference from the recorded `rectify` stream.

Decrypting real bundles from the corpus (xensesdk2 `utils/encrypt.py`) showed what is actually inside: `ctx_patch` (58 keys) + `state_seed.img_ref_raw` (a 700×400×3 rectify frame). Between two sensors of the same model only three keys differ — `dev.serial_number`, `process.base_grid`, `process.rgb_bias` — and the last two are derived from the reference image. Everything else is fixed per sensor model (xpack). The reference image is already in every dataset as the first `rectify` frame of each episode, so TacFlow (decision D82) builds the solver from the model plus that first frame and calls `calibrateSensor(rectify_image=…)`.

Keeping the bundles cost ~0.8 MB per sensor per session (2.1 GB across 47 datasets) and, worse, a manifest key that pointed at files downstream has to carry around forever.

## What changed

Removed: `TACCAP_RUNTIME_DIR`, `RUNTIME_DIR`, `_runtime_filename`, `write_tactile_runtimes`, `_stamp_runtimes`, `tactile_runtime_for_key`, the `runtimes=` parameter of `write_hardware_manifest`, the robots' `tactile_runtimes` property, `XenseCamera.export_runtime_config`, the recorder call site in `lerobot_record.py`, and the `meta/runtimes` copy in `dataset_tools._copy_taccap_local_metadata`. Tests and docs updated accordingly.

Kept, unchanged: `hardware.json` itself — serials, `gripper_sn`, `tactile_sensors[].serial/finger/observation_key`, `wrist_undistort`, epochs and `recorded_at` — plus `epoch_for_episode`, `tactile_serial_for_key`, `resolve_wrist_undistorter`, and the manifest copy through conversions.

## Compatibility

Older datasets that still carry a `runtime` key are read exactly as before; the key is simply ignored. TacVerse's local and Hub copies had the bundles and the keys stripped on 2026-09-04.

## Checks

- `ruff check` / `ruff format --check` clean on the touched files; `pyupgrade --py312-plus` no rewrites
- `tests/robots/test_taccap_helpers.py`, `tests/datasets/test_taccap_local_metadata.py`, `tests/datasets/test_dataset_tools.py`: all pass in the `xense-taccap` env (256 tests; `test_convert_image_to_video_dataset` needs Hub access, passes with the proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)