### PR TITLE
fix(xense): stop reader before camera release

### DIFF
--- a/src/lerobot/cameras/xense/camera_xense.py
+++ b/src/lerobot/cameras/xense/camera_xense.py
@@ -589,6 +589,12 @@ class XenseTactileCamera(Camera):
 
         if self.sensor is not None:
             try:
+                # xensesdk 2.1.2/2.1.3 can close its OpenCV backend while the
+                # SDK's own fetch thread is still reading from it. Suspending
+                # joins that thread before Sensor.release() closes the backend.
+                sdk_camera = self.sensor.ctx.get_handle("cam")
+                if sdk_camera is not None:
+                    sdk_camera.suspend_stream()
                 self.sensor.release()
             except Exception as e:
                 logger.warn(f"Error releasing {self}: {e}")

--- a/tests/cameras/test_xense.py
+++ b/tests/cameras/test_xense.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lerobot.cameras.xense.camera_xense import XenseTactileCamera
+
+
+def test_disconnect_suspends_sdk_stream_before_release():
+    calls = []
+
+    class FakeSDKCamera:
+        def suspend_stream(self):
+            calls.append("suspend")
+
+    class FakeContext:
+        def get_handle(self, key):
+            assert key == "cam"
+            return FakeSDKCamera()
+
+    class FakeSensor:
+        ctx = FakeContext()
+
+        def release(self):
+            calls.append("release")
+
+    camera = object.__new__(XenseTactileCamera)
+    camera.serial_number = "GSPS01A29Z0021"
+    camera.sensor = FakeSensor()
+    camera.thread = None
+
+    camera.disconnect()
+
+    assert calls == ["suspend", "release"]
+    assert camera.sensor is None


### PR DESCRIPTION
## Summary

- prevent intermittent SIGSEGV while disconnecting Xense tactile cameras
- stop xensesdk's internal camera fetch thread before releasing its OpenCV backend
- add a hardware-free regression test for suspend-before-release ordering

## Root cause

`xensesdk` 2.1.2 and 2.1.3 can enter `LocalCamera.release()` while `_fetch_loop` is still inside `CameraBackend.read()`. GDB showed the crashing thread in `cv2.abi3.so` while the releasing thread was inside `LocalCamera.release()`.

## Testing

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/cameras/test_xense.py tests/robots/test_taccap_helpers.py` — 148 passed
- `pre-commit run --files src/lerobot/cameras/xense/camera_xense.py tests/cameras/test_xense.py` — all hooks passed
- host hardware A/B with four Xense sensors and 3 independent processes per group:
  - before: 3/3 processes hit SIGSEGV; 8/30 shutdown cycles completed
  - after: 0/3 processes hit SIGSEGV; 30/30 cycles completed (120 sensor shutdowns), with no residual `_fetch_loop`
- direct SDK stress test: 30/30 cycles passed after explicit `suspend_stream()`

## Breaking changes

None.
