### PR TITLE
feat(taccap): make the headset a robot type, not a flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,11 +114,28 @@ is busy. **Not** a tactile/camera/bandwidth issue. Permanent fix is a udev rule
 ignoring `1a86` (`ID_MM_DEVICE_IGNORE=1`) — see README → "Hardware bring-up
 sequence". (`brltty` grabs `1a86` the same way if installed.)
 
-## Pico headset camera (`--robot.enable_head_camera`, off by default)
+## Pico headset camera (bimanual: `--robot.type=xtac_umi_g1`; single-arm: `--robot.enable_head_camera`)
 
 Records `left_head` / `right_head` (one key per **eye** — on a bimanual rig
 `{side}_wrist` is per-arm, but there is one headset, so the prefix means
 something different) plus `head_camera.*`, the headset pose.
+
+- **On the bimanual rig the head is a robot type, not a flag.** `robot_type` in
+  `meta/info.json` is written from `robot.name`, a class attribute bound to the
+  draccus registry key, so a config field can change what is recorded but never
+  what the recording claims to be. A head-enabled run under `bi_taccap_gripper`
+  wrote 29 state dims and 8 cameras under a label meaning 20 and 6; twelve
+  datasets on disk were mislabelled that way. `XtacUmiG1Config` inherits
+  `BiTaccapGripperConfig` and pins `records_head = True`; the base
+  `__post_init__` refuses any `enable_head_camera` that contradicts the class,
+  in both directions, naming the type to switch to.
+  `taccap_gripper` (single-arm) is unchanged — it keeps the flag, and has no
+  headset variant type, because no single-arm head recording exists.
+- **Removing the head must move the label back.** `convert_8_to_6_cameras`
+  relabels `xtac_umi_g1` → `bi_taccap_gripper`, and `modify_features` does the
+  same when the head image keys are among those removed
+  (`robot_type_without_head` / `robot_type_after_removing` in `dataset_tools.py`).
+  Without that, the same mismatch reappears from the other direction.
 
 - **`head_camera.*` is remapped like the tracker.** Same `PICO_TO_WORLD_R`
   conjugation, same xyzw→wxyz reorder, so it lands in the world frame `tcp.*`

--- a/README.md
+++ b/README.md
@@ -276,18 +276,30 @@ mmcli -L                                                               # gripper
 Revert by deleting the rule file and reloading. (Alternatively, on a dedicated
 robot PC with no cellular modem: `sudo systemctl disable --now ModemManager`.)
 
-## 🥽 Pico headset camera (optional)
+## 🥽 Pico headset camera
 
-Off by default. `--robot.enable_head_camera=true` records the headset's stereo
-camera as **one key per eye** — `left_head` and `right_head` — plus the headset
-pose under `head_camera.*`. Works on both `taccap_gripper` and
-`bi_taccap_gripper`.
+On a bimanual rig the headset is chosen by **robot type**, not by a flag:
+`--robot.type=xtac_umi_g1` is the same two TacCap grippers *plus* the headset,
+recording its stereo camera as **one key per eye** — `left_head` and
+`right_head` — plus the headset pose under `head_camera.*`. Use
+`--robot.type=bi_taccap_gripper` for the same grippers without it.
 
 ```bash
-lerobot-record --robot.type=bi_taccap_gripper \
-    --robot.enable_head_camera=true \
+lerobot-record --robot.type=xtac_umi_g1 \
     --dataset.repo_id=<org>/<name> --dataset.single_task='...'
 ```
+
+**Why a type and not a flag.** A dataset's `robot_type` is written from
+`robot.name`, a class attribute, so a config flag could change *what was
+recorded* but never *what the recording claimed to be*. A head-enabled run under
+`bi_taccap_gripper` therefore wrote 29 state dims and 8 cameras under a label
+meaning 20 and 6, with nothing at record time able to notice — twelve datasets
+were mislabelled that way before the mismatch was spotted downstream. Passing
+`--robot.enable_head_camera` in a way that contradicts the type is now an error
+that names the type to use instead.
+
+The single-arm `taccap_gripper` keeps `--robot.enable_head_camera=true`; it has
+no headset variant type, and no single-arm head recording exists to migrate.
 
 - **The names are the headset's eyes, not the arms.** On a bimanual rig
   `{side}_wrist` is per-arm, but there is one headset, so the prefix means

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ robot PC with no cellular modem: `sudo systemctl disable --now ModemManager`.)
 ## 🥽 Pico headset camera
 
 On a bimanual rig the headset is chosen by **robot type**, not by a flag:
-`--robot.type=xtac_umi_g1` is the same two TacCap grippers *plus* the headset,
+`--robot.type=xtac_umi_g1` is the same two TacCap grippers _plus_ the headset,
 recording its stereo camera as **one key per eye** — `left_head` and
 `right_head` — plus the headset pose under `head_camera.*`. Use
 `--robot.type=bi_taccap_gripper` for the same grippers without it.
@@ -290,8 +290,8 @@ lerobot-record --robot.type=xtac_umi_g1 \
 ```
 
 **Why a type and not a flag.** A dataset's `robot_type` is written from
-`robot.name`, a class attribute, so a config flag could change *what was
-recorded* but never *what the recording claimed to be*. A head-enabled run under
+`robot.name`, a class attribute, so a config flag could change _what was
+recorded_ but never _what the recording claimed to be_. A head-enabled run under
 `bi_taccap_gripper` therefore wrote 29 state dims and 8 cameras under a label
 meaning 20 and 6, with nothing at record time able to notice — twelve datasets
 were mislabelled that way before the mismatch was spotted downstream. Passing

--- a/src/lerobot/__init__.py
+++ b/src/lerobot/__init__.py
@@ -123,6 +123,7 @@ available_policies_per_env: dict[str, list[str]] = {}
 available_robots = [
     "taccap_gripper",
     "bi_taccap_gripper",
+    "xtac_umi_g1",
 ]
 
 # lists all available cameras from `lerobot/cameras`

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -26,7 +26,7 @@ This module provides utilities for:
 import copy
 import logging
 import shutil
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -81,6 +81,41 @@ TACCAP_HEAD_CAMERA_FEATURE_KEYS = frozenset(
 TACCAP_8_CAMERA_FEATURE_KEYS = TACCAP_6_CAMERA_FEATURE_KEYS | TACCAP_HEAD_CAMERA_FEATURE_KEYS
 
 HEAD_CAMERA_STATE_NAME_PREFIX = "head_camera."
+
+HEAD_ROBOT_TYPE = "xtac_umi_g1"
+"""The robot type that records the headset; ``NO_HEAD_ROBOT_TYPE`` is the same
+rig without it. Stripping the head changes which of the two a dataset *is*, so
+the conversion below relabels it — see ``robot_type_without_head``."""
+
+NO_HEAD_ROBOT_TYPE = "bi_taccap_gripper"
+
+
+def robot_type_without_head(robot_type: str | None) -> str | None:
+    """The label a dataset should carry once its head cameras are removed.
+
+    The head is part of the robot type, not a flag: ``robot_type`` is written
+    from ``robot.name``, so a dataset that keeps ``xtac_umi_g1`` after losing its
+    head cameras claims 29 state dims and 8 streams while holding 20 and 6. That
+    is exactly the mismatch the split of these two types was introduced to make
+    impossible, so the conversion must not reintroduce it from the other side.
+
+    Any other robot type is returned untouched — this only knows about the pair
+    it owns.
+    """
+    return NO_HEAD_ROBOT_TYPE if robot_type == HEAD_ROBOT_TYPE else robot_type
+
+
+def robot_type_after_removing(robot_type: str | None, removed_keys: Iterable[str]) -> str | None:
+    """Same relabel, for the general feature-removal path.
+
+    Conditional here because ``modify_features`` removes whatever it is asked to:
+    dropping an unrelated feature must not relabel the robot, and dropping the
+    head cameras must. Deleting the head image keys by hand is one of the ways a
+    dataset on disk ended up carrying head pose dimensions with no head video.
+    """
+    if TACCAP_HEAD_CAMERA_FEATURE_KEYS & set(removed_keys):
+        return robot_type_without_head(robot_type)
+    return robot_type
 
 
 def _load_episode_with_stats(src_dataset: LeRobotDataset, episode_idx: int) -> dict:
@@ -379,7 +414,7 @@ def modify_features(
         repo_id=repo_id,
         fps=dataset.meta.fps,
         features=new_features,
-        robot_type=dataset.meta.robot_type,
+        robot_type=robot_type_after_removing(dataset.meta.robot_type, video_keys_to_remove),
         root=output_dir,
         use_videos=len(remaining_video_keys) > 0,
     )
@@ -564,7 +599,7 @@ def convert_8_to_6_cameras(
         repo_id=repo_id,
         fps=dataset.meta.fps,
         features=new_features,
-        robot_type=dataset.meta.robot_type,
+        robot_type=robot_type_without_head(dataset.meta.robot_type),
         root=output_dir,
         use_videos=len(remaining_video_keys) > 0,
         chunks_size=dataset.meta.chunks_size,

--- a/src/lerobot/robots/bi_taccap_gripper/README.md
+++ b/src/lerobot/robots/bi_taccap_gripper/README.md
@@ -138,7 +138,8 @@ and/or `--robot.right_tracker_serial=<SN>`. A pinned side uses its serial **verb
 enumeration, no rule check); un-pinned sides still auto-discover by the second-to-last-digit
 rule. Use this for a tracker whose serial does not follow the rule, or when enumeration is flaky.
 
-Enable the head camera with `--robot.enable_head_camera=true`. It records `width=640`,
+The head camera is part of the robot type: record with `--robot.type=xtac_umi_g1`
+rather than a flag on this type (see the note below). It records `width=640`,
 `height=480` at dataset FPS 30 as **two keys, one per eye** — `left_head` and
 `right_head`, each 480x640. `--robot.head_camera_eyes=left` (or `right`) records a
 single eye, halving both the JPEG decoding and the encoder load.
@@ -192,9 +193,8 @@ add `--robot.enable_tracker=false` to record tactile + gripper only:
 
 ```bash
 lerobot-record \
-    --robot.type=bi_taccap_gripper \
+    --robot.type=xtac_umi_g1 \
     --robot.id=0 \
-    --robot.enable_head_camera=true \
     --dataset.repo_id=Xense/<dataset_name> \
     --dataset.single_task="Pick up the cube" \
     --dataset.num_episodes=20 \

--- a/src/lerobot/robots/bi_taccap_gripper/README.md
+++ b/src/lerobot/robots/bi_taccap_gripper/README.md
@@ -4,9 +4,12 @@ Bimanual TacCap-Gripper handheld data-collection rig — two `taccap_gripper` un
 (left + right) driven as one robot. Passive/self-driven: `send_action()` is a no-op
 (jaw motors stay disabled, encoders read-only); pose comes from a per-side Pico4
 Ultra tracker, tactile + wrist cameras go through the standard `cameras` framework.
-An optional Pico headset camera uses the same robot observation path and contributes
-a stereo RGB frame plus the headset pose; no head-to-gripper extrinsic calibration is
-required at capture time.
+The Pico headset is a **separate robot type**, [`xtac_umi_g1`](../xtac_umi_g1/), which
+subclasses this one and always records the headset — a stereo RGB frame plus the headset
+pose, through the same observation path, with no head-to-gripper extrinsic calibration
+required at capture time. It is a type rather than a flag because a dataset's
+`robot_type` is written from `robot.name`, a class attribute, so a flag could change what
+was recorded but never what the recording claimed to be.
 
 Implemented with the **reimplement-with-prefixes** pattern (cf. `bi_elite_cs66_rt`):
 one `Robot` class, per-side handles in dicts keyed `"left"`/`"right"`, and every
@@ -25,13 +28,15 @@ Per side `{s}` ∈ {left, right}:
 | `{s}_wrist`                              | `{s}_enable_wrist_camera`                       | wrist UVC frame                                                                                            |
 | `{s}_tactile_left` / `{s}_tactile_right` | auto-discovered                                 | **recorded** tactile frame from the left / right finger sensor (`rectify`)                                 |
 | `{s}_tactile_{left,right}_difference`    | `tactile_display_output_types='["difference"]'` | **display-only** amplified-deformation view of the same read — Rerun only, never recorded (off by default) |
-| `left_head` / `right_head`               | `enable_head_camera`                            | headset camera, one key per **eye** (not per arm) — `head_camera_eyes` can select one                      |
-| `head_camera.x/y/z`                      | `enable_head_camera`                            | headset position, same world frame as `{s}_tcp.*`                                                          |
-| `head_camera.r1..r6`                     | `enable_head_camera`                            | headset orientation as the first two rotation-matrix columns                                               |
+| `left_head` / `right_head`               | `--robot.type=xtac_umi_g1`                      | headset camera, one key per **eye** (not per arm) — `head_camera_eyes` can select one                      |
+| `head_camera.x/y/z`                      | `--robot.type=xtac_umi_g1`                      | headset position, same world frame as `{s}_tcp.*`                                                          |
+| `head_camera.r1..r6`                     | `--robot.type=xtac_umi_g1`                      | headset orientation as the first two rotation-matrix columns                                               |
 
-`action_features` = the per-side gripper pose + `{s}_gripper.pos` subset; the head
-camera pose and all images remain observation-only. With both Pico4 trackers, both
-grippers and the head camera enabled, `observation.state` has 29 dimensions (20 + 9).
+`action_features` = the per-side gripper pose + `{s}_gripper.pos` subset; all images
+remain observation-only, though the head pose is also an action. With both Pico4 trackers
+and both grippers, `observation.state` has **20 dimensions** under `bi_taccap_gripper` and
+**29** (20 + the 9-component head pose) under `xtac_umi_g1` — the type and the width move
+together, which is the point of the split.
 
 **Recorded and displayed are the same stream by default.** `tactile_output_types` and
 `tactile_display_output_types` both name `rectify`, so each sensor is read once, the
@@ -139,7 +144,7 @@ enumeration, no rule check); un-pinned sides still auto-discover by the second-t
 rule. Use this for a tracker whose serial does not follow the rule, or when enumeration is flaky.
 
 The head camera is part of the robot type: record with `--robot.type=xtac_umi_g1`
-rather than a flag on this type (see the note below). It records `width=640`,
+rather than a flag on this type. It records `width=640`,
 `height=480` at dataset FPS 30 as **two keys, one per eye** — `left_head` and
 `right_head`, each 480x640. `--robot.head_camera_eyes=left` (or `right`) records a
 single eye, halving both the JPEG decoding and the encoder load.

--- a/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
+++ b/src/lerobot/robots/bi_taccap_gripper/config_bi_taccap_gripper.py
@@ -36,10 +36,12 @@ auto-discover by rule.
 """
 
 from dataclasses import dataclass, field
+from typing import ClassVar
 
 from ..config import RobotConfig
 from ..taccap_gripper.common import (
     build_head_camera_configs,
+    head_camera_type_mismatch_message,
     validate_robot_id,
     validate_wrist_undistort_size,
 )
@@ -249,11 +251,26 @@ class BiTaccapGripperConfig(RobotConfig):
     to OpenCV; ``"YUYV"`` forces the uncompressed stream."""
 
     # ---- Pico head camera ---------------------------------------------------
+    records_head: ClassVar[bool] = False
+    """Whether *this robot type* records the head. Not a field — it is fixed by
+    the class, and ``enable_head_camera`` must agree with it.
+
+    The head used to be a free flag on this type, which meant a head-enabled run
+    recorded 29 state dims and 8 cameras while still writing
+    ``robot_type: bi_taccap_gripper`` into ``meta/info.json`` — ``robot_type``
+    comes from ``robot.name``, a class attribute, so no flag could ever move it.
+    Twelve datasets on disk were mislabelled that way before anyone noticed.
+    Making the head part of the type is what makes the recorded label and the
+    recorded shape unable to disagree; see ``XtacUmiG1Config``."""
+
     enable_head_camera: bool = False
     """Stream the headset's stereo camera as ``left_head`` /
     ``right_head`` (one key per eye), plus the headset
     pose as ``head_camera.*``. Shares the Pico SDK connection with the
-    trackers, so it needs the headset app streaming either way."""
+    trackers, so it needs the headset app streaming either way.
+
+    Derived from the robot type rather than chosen: passing a value that
+    contradicts ``records_head`` is an error naming the type to use instead."""
     head_camera_eyes: str = "both"
     """``"both"`` records the eyes side by side, ``"left"``/``"right"`` one of
     them. Merged frames are ``head_camera_height x (2 * head_camera_width)``."""
@@ -297,6 +314,8 @@ class BiTaccapGripperConfig(RobotConfig):
             "slave",
         ):
             raise ValueError(f"role must be leader or follower, got {self.role!r}.")
+        if self.enable_head_camera != self.records_head:
+            raise ValueError(head_camera_type_mismatch_message(self.type, self.records_head))
         if self.enable_head_camera:
             # Delegate to the camera config so there is one definition of what
             # a valid mode is, rather than a copy here that can drift from it.

--- a/src/lerobot/robots/taccap_gripper/README.md
+++ b/src/lerobot/robots/taccap_gripper/README.md
@@ -679,7 +679,11 @@ decision instead of drifting apart.
   per eye**. `--robot.head_camera_width/_height` accept `640x480` (default), `1024x768` or
   `1280x960`, and must match the headset app's Resolution setting;
   `--robot.head_camera_eyes=left` (or `right`) records a single eye. It shares the
-  XenseVR SDK connection with the tracker, so the headset app must be streaming. There is
+  XenseVR SDK connection with the tracker, so the headset app must be streaming.
+  **This flag survives only on the single arm.** The bimanual rig records the headset by
+  robot type instead — `--robot.type=xtac_umi_g1` — so that the recorded `robot_type`
+  and the recorded shape cannot disagree; see [`xtac_umi_g1`](../xtac_umi_g1/README.md).
+  There is
   **one headset**, so this is the same view the bimanual robot records — running two
   single-arm processes does not give two independent head views. Details:
   [`bi_taccap_gripper`](../bi_taccap_gripper/README.md).

--- a/src/lerobot/robots/taccap_gripper/common.py
+++ b/src/lerobot/robots/taccap_gripper/common.py
@@ -344,6 +344,37 @@ def swap_tactile_display_features(
 # ------------------------------------------------------------------ head camera
 
 
+def head_camera_type_mismatch_message(robot_type: str, records_head: bool) -> str:
+    """Explain that the head belongs to the robot type, and name the type to use.
+
+    Shared so both directions read the same way and neither can drift: a type
+    that records the head refusing ``enable_head_camera=false``, and one that
+    does not refusing ``true``.
+
+    The reason this is an error rather than a warning is that the wrong answer
+    is silent and permanent. ``robot_type`` in ``meta/info.json`` comes from
+    ``robot.name`` — a class attribute — so a head-enabled run under a
+    no-head type produced a dataset whose recorded label contradicted its own
+    29 state dims and 8 cameras, with nothing at record time to say so.
+    """
+    if records_head:
+        return (
+            f"{robot_type} always records the headset: its stereo cameras "
+            "(left_head / right_head) and the head_camera.* pose are part of the "
+            "robot type, not a flag, so --robot.enable_head_camera=false is not a "
+            "valid combination. To record the same grippers without the headset, "
+            "use --robot.type=bi_taccap_gripper."
+        )
+    return (
+        f"{robot_type} does not record the headset, so "
+        "--robot.enable_head_camera=true is not a valid combination. Use "
+        "--robot.type=xtac_umi_g1, which records the headset's stereo cameras "
+        "(left_head / right_head) and the head_camera.* pose. Recording the head "
+        f"under {robot_type} is what wrote a robot_type into meta/info.json that "
+        "disagreed with the shape actually recorded."
+    )
+
+
 def build_head_camera_configs(config: Any) -> dict[str, Any]:
     """One ``PicoCameraConfig`` per recorded eye, keyed by observation name.
 

--- a/src/lerobot/robots/xtac_umi_g1/README.md
+++ b/src/lerobot/robots/xtac_umi_g1/README.md
@@ -1,0 +1,58 @@
+# xtac_umi_g1
+
+The XTac-UMI-G1 rig: the bimanual [`bi_taccap_gripper`](../bi_taccap_gripper/) plus the
+Pico headset, always recording it.
+
+```bash
+lerobot-teleoperate --robot.type=xtac_umi_g1 --robot.id=0 --fps=30 --display_data=true
+
+lerobot-record --robot.type=xtac_umi_g1 --robot.id=0 \
+    --dataset.repo_id=<org>/<name> --dataset.single_task='...'
+```
+
+## What it records
+
+Everything `bi_taccap_gripper` records, plus:
+
+| Key                        | Meaning                                                          |
+| -------------------------- | ---------------------------------------------------------------- |
+| `left_head` / `right_head` | headset camera, one key per **eye** (not per arm)                |
+| `head_camera.x/y/z`        | headset position, same world frame as `{side}_tcp.*`             |
+| `head_camera.r1..r6`       | headset orientation, first two rotation-matrix columns           |
+
+So **29 state dimensions** (20 + 9) and **8 camera keys** (6 + 2), against 20 and 6 for
+`bi_taccap_gripper`. The head pose is an action as well as an observation — where the
+operator looked while demonstrating is part of the demonstration.
+
+Headset knobs (`--robot.head_camera_eyes`, `head_camera_width` / `height` / `fps`,
+`head_camera_pair_max_skew_ms`) are inherited unchanged; see the
+[bimanual README](../bi_taccap_gripper/README.md) for what they accept.
+
+## Why this is a type and not a flag
+
+`enable_head_camera` used to be an ordinary config field on `bi_taccap_gripper`. It could
+change what was recorded, but never what the recording *claimed* to be: a dataset's
+`robot_type` comes from `robot.name`, a class attribute bound to the draccus registry key,
+so `lerobot-record` wrote `bi_taccap_gripper` no matter what the flag said.
+
+A head-enabled run therefore produced 29 state dimensions and 8 cameras under a label
+meaning 20 and 6, with nothing at record time able to notice. Twelve datasets on disk were
+mislabelled that way before the mismatch was caught downstream, by a viewer that checks a
+dataset's shape against its declared robot type.
+
+With the headset in the type, `--robot.type=` decides the shape and the label together and
+they cannot disagree. `enable_head_camera` is still a field — the robot code branches on
+it in five places, and the single-arm `taccap_gripper` still exposes it — but on this type
+and on `bi_taccap_gripper` a value contradicting the class is rejected at config time,
+naming the type to switch to.
+
+Removing the head has to move the label back, or the same mismatch reappears from the other
+direction. `convert_8_to_6_cameras` relabels `xtac_umi_g1` → `bi_taccap_gripper`, and
+`modify_features` does the same when the head image keys are among those removed.
+
+## `--robot.id`
+
+A bare number expands to `xtac_umi_g1_<n>`, not `bi_taccap_<n>`. The station label is kept
+distinct on purpose: `meta/hardware.json` keys provenance on `robot_id`, and two robot
+types answering to one station id would leave a run's own manifest unable to say which rig
+recorded it.

--- a/src/lerobot/robots/xtac_umi_g1/README.md
+++ b/src/lerobot/robots/xtac_umi_g1/README.md
@@ -14,11 +14,11 @@ lerobot-record --robot.type=xtac_umi_g1 --robot.id=0 \
 
 Everything `bi_taccap_gripper` records, plus:
 
-| Key                        | Meaning                                                          |
-| -------------------------- | ---------------------------------------------------------------- |
-| `left_head` / `right_head` | headset camera, one key per **eye** (not per arm)                |
-| `head_camera.x/y/z`        | headset position, same world frame as `{side}_tcp.*`             |
-| `head_camera.r1..r6`       | headset orientation, first two rotation-matrix columns           |
+| Key                        | Meaning                                                |
+| -------------------------- | ------------------------------------------------------ |
+| `left_head` / `right_head` | headset camera, one key per **eye** (not per arm)      |
+| `head_camera.x/y/z`        | headset position, same world frame as `{side}_tcp.*`   |
+| `head_camera.r1..r6`       | headset orientation, first two rotation-matrix columns |
 
 So **29 state dimensions** (20 + 9) and **8 camera keys** (6 + 2), against 20 and 6 for
 `bi_taccap_gripper`. The head pose is an action as well as an observation — where the
@@ -31,7 +31,7 @@ Headset knobs (`--robot.head_camera_eyes`, `head_camera_width` / `height` / `fps
 ## Why this is a type and not a flag
 
 `enable_head_camera` used to be an ordinary config field on `bi_taccap_gripper`. It could
-change what was recorded, but never what the recording *claimed* to be: a dataset's
+change what was recorded, but never what the recording _claimed_ to be: a dataset's
 `robot_type` comes from `robot.name`, a class attribute bound to the draccus registry key,
 so `lerobot-record` wrote `bi_taccap_gripper` no matter what the flag said.
 

--- a/src/lerobot/robots/xtac_umi_g1/__init__.py
+++ b/src/lerobot/robots/xtac_umi_g1/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The XenseRobotics Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+from .config_xtac_umi_g1 import XtacUmiG1Config
+from .xtac_umi_g1 import XtacUmiG1

--- a/src/lerobot/robots/xtac_umi_g1/config_xtac_umi_g1.py
+++ b/src/lerobot/robots/xtac_umi_g1/config_xtac_umi_g1.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The XenseRobotics Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Configuration for the XTac-UMI-G1 rig: the bimanual TacCap grippers plus the
+Pico headset.
+
+Physically this is ``bi_taccap_gripper`` with the headset streaming, and the
+class says exactly that by inheriting from it. It exists as a *registered robot
+type* rather than a flag because ``robot_type`` in a recorded dataset comes from
+``robot.name`` — a class attribute bound to the draccus registry key — so a
+config field could change what was recorded but never what the recording claimed
+to be. Head-enabled runs under ``bi_taccap_gripper`` therefore wrote 29 state
+dims and 8 cameras under a label meaning 20 and 6, and nothing at record time
+could notice. Twelve datasets on disk were mislabelled this way.
+
+With the head part of the type, ``--robot.type=`` alone decides the shape and the
+label, and the two cannot disagree.
+"""
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from ..bi_taccap_gripper.config_bi_taccap_gripper import BiTaccapGripperConfig
+from ..config import RobotConfig
+
+
+@RobotConfig.register_subclass("xtac_umi_g1")
+@dataclass
+class XtacUmiG1Config(BiTaccapGripperConfig):
+    """Bimanual TacCap grippers + Pico headset.
+
+    Every gripper, tactile, tracker and wrist-camera field is inherited
+    unchanged — this type differs from ``bi_taccap_gripper`` in one respect, and
+    the class should keep showing that. The recorded shape is 29 state dims
+    (20 + the 9-component head pose) and 8 cameras (6 + ``left_head`` /
+    ``right_head``).
+    """
+
+    records_head: ClassVar[bool] = True
+
+    enable_head_camera: bool = True
+    """Fixed by the type. ``BiTaccapGripperConfig.__post_init__`` rejects a value
+    that contradicts ``records_head``, so this cannot be turned off here — record
+    with ``--robot.type=bi_taccap_gripper`` for the no-headset shape."""

--- a/src/lerobot/robots/xtac_umi_g1/xtac_umi_g1.py
+++ b/src/lerobot/robots/xtac_umi_g1/xtac_umi_g1.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The XenseRobotics Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""The XTac-UMI-G1 robot: ``BiTaccapGripper`` with the headset always on."""
+
+from ..bi_taccap_gripper.bi_taccap_gripper import BiTaccapGripper
+from .config_xtac_umi_g1 import XtacUmiG1Config
+
+
+class XtacUmiG1(BiTaccapGripper):
+    """Bimanual TacCap grippers + Pico headset.
+
+    No behaviour of its own: every head branch in ``BiTaccapGripper`` already
+    keys off ``config.enable_head_camera``, which the config pins to True for
+    this type. What this class contributes is ``name``, and ``name`` is the
+    whole point — it is what ``lerobot-record`` writes as the dataset's
+    ``robot_type``, so a headset recording finally says so on disk.
+
+    Calibration is shared with ``bi_taccap_gripper`` in the only sense that
+    matters: there is none. ``calibrate()`` is a no-op and the encoder zero lives
+    in each unit's firmware, so the per-name calibration directory
+    ``Robot.__init__`` creates stays empty for both types.
+    """
+
+    config_class = XtacUmiG1Config
+    name = "xtac_umi_g1"

--- a/src/lerobot/scripts/client_commands.md
+++ b/src/lerobot/scripts/client_commands.md
@@ -29,8 +29,8 @@ camera shares that same connection, so it needs the headset app streaming too.
 
 ## Teleoperate (live Rerun visualization)
 
-`taccap_gripper` / `bi_taccap_gripper` are **self-driven** (sensors only) — there is no
-taccap teleoperator, so **no `--teleop` is required**. `lerobot-teleoperate` just streams
+`taccap_gripper` / `bi_taccap_gripper` / `xtac_umi_g1` are all **self-driven** (sensors
+only) — there is no taccap teleoperator, so **no `--teleop` is required**. `lerobot-teleoperate` just streams
 `get_observation()` to Rerun.
 
 `--display_data=true` applies a blueprint rather than letting Rerun auto-lay-out, which
@@ -51,17 +51,43 @@ live Pico4 pose, trailing the path it has swept — the same effect as the SDK's
 drops that view only, leaving the rest of the layout in place, and it auto-skips when
 `--robot.enable_tracker=false` since there is no pose to draw. Same flag on `lerobot-record`.
 
-### Bimanual (`bi_taccap_gripper`)
+### Bimanual, no headset (`bi_taccap_gripper`)
 
 ```bash
 lerobot-teleoperate \
     --robot.type=bi_taccap_gripper \
     --robot.id=0 \
     --fps=30 \
-    --display_data=true \
-    --robot.enable_tracker=false \
-    --robot.enable_head_camera=false
+    --display_data=true
 ```
+
+Two grippers, four tactile pads, two wrist cameras, two Pico4 trackers — 20 state
+dimensions and 6 camera keys.
+
+### Bimanual + headset (`xtac_umi_g1`)
+
+```bash
+lerobot-teleoperate \
+    --robot.type=xtac_umi_g1 \
+    --robot.id=0 \
+    --fps=30 \
+    --display_data=true
+```
+
+The same rig plus the Pico headset: 29 state dimensions (20 + the 9-component
+`head_camera.*` pose) and 8 camera keys (6 + `left_head` / `right_head`). The 3D view
+gains the headset marker.
+
+**The headset is the robot type, not a flag.** `--robot.enable_head_camera` is no longer
+something you set — passing a value that contradicts the type is an error naming the type
+to use instead. It reads as bureaucracy until you see what it prevents: `robot_type` in a
+recorded dataset is written from `robot.name`, a class attribute, so a head-enabled run
+under `bi_taccap_gripper` recorded 29 dimensions and 8 cameras under a label meaning 20
+and 6, and nothing at record time could notice. Twelve datasets were mislabelled that way
+before it was caught downstream.
+
+The single-arm `taccap_gripper` still takes `--robot.enable_head_camera=true`; it has no
+headset variant type.
 
 ['PC2310MLL4150713G', 'PC2310MLL4150387G']
 
@@ -89,15 +115,8 @@ A pinned side is used verbatim (no enumeration, no rule check); un-pinned sides 
 auto-discover. Other knobs: `--robot.role=follower` (bind follower units), `--robot.gripper_open_rad`,
 `--robot.tactile_fps`, `--robot.wrist_camera_width/height/fps`.
 
-The bimanual rig records the Pico headset by switching robot type — the headset is
-part of the type, not a flag, so the recorded `robot_type` and the recorded shape
-cannot disagree:
-
-```bash
-    --robot.type=xtac_umi_g1 \
-    --robot.head_camera_eyes=both \
-```
-
+Headset options apply to `--robot.type=xtac_umi_g1` (and to `taccap_gripper` with
+`--robot.enable_head_camera=true`). `--robot.head_camera_eyes=both` is the default;
 `head_camera_width`/`height` are **per eye** and default to 640x480, the headset app's
 own default. Only that, 1024x768 and 1280x960 are accepted — all 4:3, matching the sensor
 — and an unlisted size is an error rather than a silent resize, as is a first frame whose
@@ -133,11 +152,15 @@ Recording is self-driven (`self_driven_record_loop`, shifted-frame: `action[t]` 
 `--robot.id` is a **required station label** — one per rig, and a bimanual rig is
 one rig. It names the seat, not the hardware in it, so it survives a gripper swap.
 
-**Pass a number.** `--robot.id=0` is stored as `taccap_0` on a single rig and
-`bi_taccap_0` on a bimanual one: a bare number is expanded against `--robot.type`
-minus its `_gripper` suffix, so the label cannot disagree with the rig it names.
-Anything not all digits is taken verbatim, so an existing `--robot.id=taccap_0`
-keeps working.
+**Pass a number.** `--robot.id=0` is stored as `taccap_0` on a single rig,
+`bi_taccap_0` on a bimanual one and `xtac_umi_g1_0` on the headset rig: a bare number is
+expanded against `--robot.type` minus any `_gripper` suffix, so the label cannot disagree
+with the rig it names. Anything not all digits is taken verbatim, so an existing
+`--robot.id=taccap_0` keeps working.
+
+The headset rig gets a station label of its own rather than sharing `bi_taccap_<n>`,
+because the manifest below keys provenance on `robot_id` — two robot types answering to
+one station id would leave a run's own manifest unable to say which rig recorded it.
 
 Upstream leaves it optional; both TacCap configs reject a
 missing or blank one in `__post_init__`, so the run stops at CLI-parse time rather
@@ -266,7 +289,30 @@ many-core server:
 turn it back on if the hardware is capable. On a GPU-less host it is not, so the
 suggestion does not apply — leaving it off is deliberate.
 
-### Bimanual (`bi_taccap_gripper`)
+### Bimanual, no headset (`bi_taccap_gripper`)
+
+Records 20 state dimensions and 6 camera keys.
+
+```bash
+lerobot-record \
+    --robot.type=bi_taccap_gripper \
+    --robot.id=0 \
+    --dataset.repo_id=Xense/taccap-g1-test-0722 \
+    --dataset.single_task="Pick up the cube" \
+    --dataset.num_episodes=2 \
+    --dataset.fps=30 \
+    --dataset.episode_time_s=60 \
+    --dataset.reset_time_s=30 \
+    --dataset.streaming_encoding=true \
+    --dataset.push_to_hub=false \
+    --display_data=false
+```
+
+### Bimanual + headset (`xtac_umi_g1`)
+
+Same command with the type swapped. Records 29 state dimensions and 8 camera keys, and
+`meta/info.json` says `xtac_umi_g1` — the label and the shape move together, which is the
+whole reason this is a type rather than a flag.
 
 ```bash
 lerobot-record \
@@ -293,9 +339,10 @@ lerobot-record \
 One gripper, its two tactile pads and its wrist camera, recorded through the same
 `self_driven_record_loop`. Keys are **unprefixed** (`tcp.*`, `gripper.pos`,
 `tactile_left` / `tactile_right`, `wrist_cam`), so a single-arm dataset is not a
-column subset of a bimanual one. `--robot.enable_head_camera` works here too, and the
-head keys are unprefixed the same way on both robots (`left_head` / `right_head` name the
-headset's eyes, not the arms).
+column subset of a bimanual one. `--robot.enable_head_camera=true` still works **here**
+— the single arm has no headset variant type — and the head keys are unprefixed the same
+way on both robots (`left_head` / `right_head` name the headset's eyes, not the arms).
+On the bimanual rig the equivalent is `--robot.type=xtac_umi_g1`.
 
 `--robot.side` is only needed when both grippers are plugged in; a lone unit
 auto-resolves, and so does its Pico4 tracker (side from the serial's 2nd-to-last

--- a/src/lerobot/scripts/client_commands.md
+++ b/src/lerobot/scripts/client_commands.md
@@ -89,10 +89,12 @@ A pinned side is used verbatim (no enumeration, no rule check); un-pinned sides 
 auto-discover. Other knobs: `--robot.role=follower` (bind follower units), `--robot.gripper_open_rad`,
 `--robot.tactile_fps`, `--robot.wrist_camera_width/height/fps`.
 
-The bimanual rig can add the Pico headset camera with:
+The bimanual rig records the Pico headset by switching robot type — the headset is
+part of the type, not a flag, so the recorded `robot_type` and the recorded shape
+cannot disagree:
 
 ```bash
-    --robot.enable_head_camera=true \
+    --robot.type=xtac_umi_g1 \
     --robot.head_camera_eyes=both \
 ```
 
@@ -268,9 +270,8 @@ suggestion does not apply — leaving it off is deliberate.
 
 ```bash
 lerobot-record \
-    --robot.type=bi_taccap_gripper \
+    --robot.type=xtac_umi_g1 \
     --robot.id=0 \
-    --robot.enable_head_camera=true \
     --dataset.repo_id=Xense/taccap-g1-test-0722 \
     --dataset.single_task="Pick up the cube" \
     --dataset.num_episodes=2 \

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -71,6 +71,7 @@ from lerobot.robots import (  # noqa: F401
     bi_taccap_gripper,
     make_robot_from_config,
     taccap_gripper,
+    xtac_umi_g1,
 )
 from lerobot.robots.taccap_gripper.common import check_dataset_station, write_hardware_manifest
 from lerobot.robots.taccap_gripper.visualization import TaccapTrajectoryViz
@@ -279,7 +280,7 @@ def _session_lines(cfg: "RecordConfig", robot: Robot, dataset: LeRobotDataset) -
 # logs the device's own demonstrated state (the ``action_features`` subset of
 # the observation) as the action — shifted-frame, so action[t] pairs with
 # obs[t-1] — instead of a separate ``teleop.get_action()``.
-SELF_DRIVEN_RECORD_ROBOTS = frozenset({"taccap_gripper", "bi_taccap_gripper"})
+SELF_DRIVEN_RECORD_ROBOTS = frozenset({"taccap_gripper", "bi_taccap_gripper", "xtac_umi_g1"})
 
 
 @dataclass

--- a/src/lerobot/scripts/lerobot_replay.py
+++ b/src/lerobot/scripts/lerobot_replay.py
@@ -63,6 +63,7 @@ from lerobot.robots import (  # noqa: F401
     bi_taccap_gripper,
     make_robot_from_config,
     taccap_gripper,
+    xtac_umi_g1,
 )
 from lerobot.utils.constants import ACTION
 from lerobot.utils.import_utils import register_third_party_plugins

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -55,6 +55,7 @@ from lerobot.robots import (  # noqa: F401
     bi_taccap_gripper,
     make_robot_from_config,
     taccap_gripper,
+    xtac_umi_g1,
 )
 from lerobot.robots.taccap_gripper.visualization import TaccapTrajectoryViz
 from lerobot.teleoperators import (  # noqa: F401
@@ -84,7 +85,7 @@ logger = get_logger("Teleoperate")
 # lerobot-teleoperate just streams get_observation() to Rerun (data-stream + viz).
 # An optional --teleop satisfies the CLI but is never read. Mirrors v0.4.4's
 # xense_flare / bi_xense_flare_grippers data-collection path.
-SELF_DRIVEN_TELEOP_ROBOTS = frozenset({"taccap_gripper", "bi_taccap_gripper"})
+SELF_DRIVEN_TELEOP_ROBOTS = frozenset({"taccap_gripper", "bi_taccap_gripper", "xtac_umi_g1"})
 
 
 @dataclass

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -31,6 +31,8 @@ from lerobot.datasets.dataset_tools import (
     modify_features,
     modify_tasks,
     remove_feature,
+    robot_type_after_removing,
+    robot_type_without_head,
     split_dataset,
 )
 from lerobot.scripts.lerobot_edit_dataset import convert_image_to_video_dataset
@@ -1453,3 +1455,28 @@ def test_convert_image_to_video_dataset_subset_episodes(tmp_path):
 
         if output_dir.exists():
             shutil.rmtree(output_dir)
+
+
+class TestRobotTypeFollowsTheHead:
+    """The head is part of the robot type, so removing the head cameras has to
+    move the label with it. Without this, the split that made a head-enabled
+    recording impossible to mislabel would reintroduce the same mismatch from
+    the other direction: an ``xtac_umi_g1`` dataset holding 20 state dims and 6
+    cameras."""
+
+    def test_stripping_the_head_relabels_the_dataset(self):
+        assert robot_type_without_head("xtac_umi_g1") == "bi_taccap_gripper"
+
+    def test_other_robot_types_are_untouched(self):
+        for robot_type in ("bi_taccap_gripper", "taccap_gripper", "bi_arx5", None):
+            assert robot_type_without_head(robot_type) == robot_type
+
+    def test_removing_the_head_cameras_relabels(self):
+        removed = ["observation.images.left_head", "observation.images.right_head"]
+        assert robot_type_after_removing("xtac_umi_g1", removed) == "bi_taccap_gripper"
+
+    def test_removing_something_else_does_not_relabel(self):
+        """modify_features removes whatever it is asked to; only the head moves
+        the label."""
+        assert robot_type_after_removing("xtac_umi_g1", ["observation.images.left_wrist"]) == "xtac_umi_g1"
+        assert robot_type_after_removing("xtac_umi_g1", []) == "xtac_umi_g1"

--- a/tests/robots/test_action_features.py
+++ b/tests/robots/test_action_features.py
@@ -28,6 +28,8 @@ from lerobot.robots.bi_taccap_gripper.bi_taccap_gripper import BiTaccapGripper
 from lerobot.robots.bi_taccap_gripper.config_bi_taccap_gripper import BiTaccapGripperConfig
 from lerobot.robots.taccap_gripper.config_taccap_gripper import TaccapGripperConfig
 from lerobot.robots.taccap_gripper.taccap_gripper import TaccapGripper
+from lerobot.robots.xtac_umi_g1.config_xtac_umi_g1 import XtacUmiG1Config
+from lerobot.robots.xtac_umi_g1.xtac_umi_g1 import XtacUmiG1
 
 TACTILES = {
     "left": {"left": "GSPS01A28Z0005", "right": "GSPS01A28Z0006"},
@@ -46,7 +48,10 @@ def build(cls, config, trackers):
     cv2's vendored libtiff), which is why lerobot_record preloads it. Neither
     matters here: nothing below reaches a code path that calls into the SDK.
     """
-    module = cls.__module__
+    # The module that defines ``__init__``, not ``cls.__module__``: a subclass
+    # such as XtacUmiG1 inherits the constructor, so the availability flags it
+    # reads live in its parent's namespace, not its own.
+    module = cls.__init__.__module__
     with (
         patch(f"{module}.TACCAP_SDK_AVAILABLE", True),
         patch(f"{module}.PICO4_TRACKER_AVAILABLE", True),
@@ -146,29 +151,66 @@ class TestEnableTactile:
 
 
 class TestBimanualActionFeatures:
+    """The head is chosen by robot *type*, so these read it off the two types
+    rather than off a flag — ``bi_taccap_gripper`` records no head and
+    ``xtac_umi_g1`` always does."""
+
     def _robot(self, **kwargs):
         return build(BiTaccapGripper, BiTaccapGripperConfig(id="taccap_0", **kwargs), {"left": "PC1", "right": "PC2"})
 
-    def test_head_pose_is_absent_without_the_head_camera(self):
-        assert head_keys(self._robot(enable_head_camera=False).action_features) == set()
+    def _head_robot(self, **kwargs):
+        return build(XtacUmiG1, XtacUmiG1Config(id="taccap_0", **kwargs), {"left": "PC1", "right": "PC2"})
 
-    def test_head_pose_is_an_action_when_the_head_camera_is_on(self):
-        keys = head_keys(self._robot(enable_head_camera=True).action_features)
+    def test_head_pose_is_absent_without_the_head_camera(self):
+        assert head_keys(self._robot().action_features) == set()
+
+    def test_head_pose_is_an_action_on_the_head_type(self):
+        keys = head_keys(self._head_robot().action_features)
         assert keys == {f"head_camera.{s}" for s in POSE_SUFFIXES}
 
     def test_head_pose_is_unprefixed_and_appears_once(self):
         """One headset serves both arms, so it is not per-side — unlike
         {side}_tcp.*, which the same rig reports twice."""
-        features = self._robot(enable_head_camera=True).action_features
+        features = self._head_robot().action_features
         assert not any(k.startswith(("left_head_camera", "right_head_camera")) for k in features)
         assert len(head_keys(features)) == len(POSE_SUFFIXES)
 
     def test_per_side_keys_are_unaffected(self):
-        """Turning the head camera on must not disturb the arm columns."""
-        without = self._robot(enable_head_camera=False).action_features
-        with_head = self._robot(enable_head_camera=True).action_features
+        """The headset must not disturb the arm columns."""
+        without = self._robot().action_features
+        with_head = self._head_robot().action_features
         sided = {k for k in with_head if k.startswith(("left_", "right_"))}
         assert sided == set(without)
+
+
+class TestHeadIsPartOfTheRobotType:
+    """``robot_type`` in a recorded dataset comes from ``robot.name``, a class
+    attribute, so a config flag could change what was recorded but never what
+    the recording claimed to be. Both contradictions are refused at config time,
+    before any device is touched."""
+
+    def test_the_plain_bimanual_type_refuses_the_head(self):
+        with pytest.raises(ValueError, match="--robot.type=xtac_umi_g1"):
+            BiTaccapGripperConfig(id="taccap_0", enable_head_camera=True)
+
+    def test_the_head_type_refuses_to_drop_the_head(self):
+        with pytest.raises(ValueError, match="--robot.type=bi_taccap_gripper"):
+            XtacUmiG1Config(id="taccap_0", enable_head_camera=False)
+
+    def test_the_head_type_needs_no_flag(self):
+        assert XtacUmiG1Config(id="taccap_0").enable_head_camera is True
+
+    def test_the_recorded_label_matches_the_recorded_shape(self):
+        """The bug this type exists to close: 29 state dims and 8 cameras under
+        a name meaning 20 and 6."""
+        robot = build(XtacUmiG1, XtacUmiG1Config(id="taccap_0"), {"left": "PC1", "right": "PC2"})
+        assert robot.name == "xtac_umi_g1"
+        # lerobot_record passes robot.name straight to LeRobotDataset.create.
+        assert robot.robot_type == "xtac_umi_g1"
+        assert head_keys(robot.observation_features) == {f"head_camera.{s}" for s in POSE_SUFFIXES}
+        # The configs the robot decided to open, not ``cameras`` — the camera
+        # factory is stubbed out here, so only the decision is observable.
+        assert {"left_head", "right_head"} <= set(robot._camera_configs)
 
 
 class TestRobotIdIsRequired:
@@ -202,14 +244,14 @@ class TestRobotIdIsRequired:
         assert make(id="  taccap_1 ").id == "taccap_1"
 
 
-@pytest.mark.parametrize("enable_head_camera", [False, True])
-def test_action_features_is_a_subset_of_observation_features(enable_head_camera):
+@pytest.mark.parametrize(
+    ("cls", "config_cls"),
+    [(BiTaccapGripper, BiTaccapGripperConfig), (XtacUmiG1, XtacUmiG1Config)],
+    ids=["no_head", "head"],
+)
+def test_action_features_is_a_subset_of_observation_features(cls, config_cls):
     """The record loop builds the action by selecting action_features out of the
     observation it already sampled, so a key here that the observation does not
     carry would silently drop out of the dataset."""
-    robot = build(
-        BiTaccapGripper,
-        BiTaccapGripperConfig(id="taccap_0", enable_head_camera=enable_head_camera),
-        {"left": "PC1", "right": "PC2"},
-    )
+    robot = build(cls, config_cls(id="taccap_0"), {"left": "PC1", "right": "PC2"})
     assert set(robot.action_features) <= set(robot.observation_features)

--- a/tests/robots/test_taccap_helpers.py
+++ b/tests/robots/test_taccap_helpers.py
@@ -626,6 +626,13 @@ class TestValidateRobotId:
             ("12", "taccap_gripper", "taccap_12"),
             ("0", "bi_taccap_gripper", "bi_taccap_0"),
             ("3", "bi_taccap_gripper", "bi_taccap_3"),
+            # No ``_gripper`` to strip, so the type is used whole. The headset
+            # rig gets a station label of its own rather than sharing
+            # ``bi_taccap_<n>``: meta/hardware.json keys provenance on
+            # robot_id, and two robot types answering to one station id would
+            # make a run's own manifest unable to say which rig recorded it.
+            ("0", "xtac_umi_g1", "xtac_umi_g1_0"),
+            ("7", "xtac_umi_g1", "xtac_umi_g1_7"),
         ],
     )
     def test_a_bare_number_is_expanded_against_the_type(self, raw, robot_type, expected):


### PR DESCRIPTION
## The bug

A dataset's `robot_type` is written from `robot.name` (`lerobot_record.py:601`) — a **class attribute** bound to the draccus registry key. `enable_head_camera` was an independent config field, so it could change *what was recorded* but never *what the recording claimed to be*.

A head-enabled run under `bi_taccap_gripper` therefore wrote **29 state dims and 8 cameras under a label meaning 20 and 6**, with nothing at record time able to notice. This is not intermittent — it is structural: no value of the flag could ever move the label.

Found from downstream. XenseRobotics-AI/xense-lerobot-viewer#32 added a shape check that validates a dataset against its own declared robot type, and it flagged these.

**12 of 1075 TacCap-family datasets on this machine are mislabelled**, in three states — 5 with head cameras + head pose, 6 with head cameras only, 1 with head pose only.

## The fix

`xtac_umi_g1` — `BiTaccapGripper` with the headset always on — becomes a registered robot type, so `--robot.type=` alone decides both the shape and the label.

```bash
lerobot-record --robot.type=xtac_umi_g1 ...   # 29 dim / 8 streams
lerobot-record --robot.type=bi_taccap_gripper ...   # 20 dim / 6 streams
```

The config carries a `records_head` ClassVar and the shared `BiTaccapGripperConfig.__post_init__` **refuses any `enable_head_camera` that contradicts it, in both directions**, naming the type to switch to. Adding the type without that refusal would have fixed nothing — the old invocation would still be available and still silently wrong.

**Removing the head has to move the label back**, or the same mismatch reappears from the other side: an `xtac_umi_g1` dataset holding 20 dims and 6 cameras. `convert_8_to_6_cameras` now relabels unconditionally; `modify_features` does so when the head image keys are among those removed — deleting those keys by hand is one of the ways a dataset ended up with head pose dimensions and no head video.

## Scope

**Single-arm `taccap_gripper` is deliberately untouched.** It keeps the flag and gains no variant type: no single-arm head recording exists on disk, so a second new type would be unevidenced.

Registry lists updated alongside the type, each of which is a real breakage if missed:

| | consequence if missed |
| --- | --- |
| `SELF_DRIVEN_TELEOP_ROBOTS` | **teleoperate breaks** for the type |
| `SELF_DRIVEN_RECORD_ROBOTS` | silently loses the `copy_frames = False` optimisation |
| `available_robots` | absent from the documented registry |
| subpackage import in record / teleoperate / replay | the type never registers |

`--robot.id=0` expands to `xtac_umi_g1_0`, not `bi_taccap_0`. Kept deliberately: `meta/hardware.json` keys provenance on `robot_id`, and two robot types answering to one station id would leave a run's own manifest unable to say which rig recorded it. Calibration needs no special handling — `calibrate()` is a no-op for TacCap, `is_calibrated` just returns `is_connected`, and the on-disk calibration directory is empty for both types.

## Migration

Existing head-enabled datasets labelled `bi_taccap_gripper` cannot be resumed after this change — `sanity_check_dataset_robot_compatibility` raises on the mismatch. The 4 such datasets in the live corpus have been relabelled to `xtac_umi_g1` (`meta/info.json`, atomic write, `.bak` kept), which is what makes them resumable under the new type. Any dataset that also carries `meta/hardware.json` needs both files changed; those 4 do not have one.

## Testing

- `pytest tests/` — **735 passed, 13 skipped**. `ruff check` / `ruff format --check` clean on every changed file.
- New tests: both contradiction directions are refused at config time; the head type needs no flag; the recorded label matches the recorded shape (`robot.name == "xtac_umi_g1"` alongside the 29-dim head pose and the two head camera configs); `convert_8_to_6_cameras` / `modify_features` relabelling, including that removing an *unrelated* feature does **not** relabel.
- The four existing head tests moved from `BiTaccapGripperConfig(enable_head_camera=True)` onto the new type — that construction is now an error, which is the point.
- `build()` in `test_action_features.py` had to stop using `cls.__module__` for its patch targets: a subclass inherits `__init__`, so the availability flags it reads live in the parent's namespace.

**Not verified on hardware.** The record path needs the TacCap SDK and the Pico headset; this machine has neither (its vendored `_taccap_native` is stale and `import lerobot.robots.bi_taccap_gripper` fails outside pytest — pre-existing, unrelated to this change). The tests build the real robot objects with discovery patched out. A recording on the rig should confirm `meta/info.json` says `xtac_umi_g1` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)