### PR TITLE
fix(xense): keep releasing the sensor when the SDK suspend probe fails

### DIFF
--- a/src/lerobot/cameras/xense/camera_xense.py
+++ b/src/lerobot/cameras/xense/camera_xense.py
@@ -588,13 +588,24 @@ class XenseTactileCamera(Camera):
             self._stop_read_thread()
 
         if self.sensor is not None:
+            # xensesdk 2.1.2/2.1.3 can close its OpenCV backend while the SDK's
+            # own fetch thread is still reading from it. Suspending joins that
+            # thread before Sensor.release() closes the backend.
+            #
+            # In its own try: this reaches into SDK internals (`ctx.get_handle`)
+            # that only these versions are known to expose, and releasing the
+            # sensor is the part that must not be skipped. Sharing one try with
+            # release() would turn "this SDK has no such handle" into a leaked
+            # camera plus a warning — a worse outcome than the crash this
+            # guards against, and on a version that never had the crash.
             try:
-                # xensesdk 2.1.2/2.1.3 can close its OpenCV backend while the
-                # SDK's own fetch thread is still reading from it. Suspending
-                # joins that thread before Sensor.release() closes the backend.
                 sdk_camera = self.sensor.ctx.get_handle("cam")
                 if sdk_camera is not None:
                     sdk_camera.suspend_stream()
+            except Exception as e:
+                logger.warn(f"Could not suspend the SDK stream for {self} before release: {e}")
+
+            try:
                 self.sensor.release()
             except Exception as e:
                 logger.warn(f"Error releasing {self}: {e}")

--- a/tests/cameras/test_xense.py
+++ b/tests/cameras/test_xense.py
@@ -44,3 +44,79 @@ def test_disconnect_suspends_sdk_stream_before_release():
 
     assert calls == ["suspend", "release"]
     assert camera.sensor is None
+
+
+def _camera(sensor):
+    camera = object.__new__(XenseTactileCamera)
+    camera.serial_number = "GSPS01A29Z0021"
+    camera.sensor = sensor
+    camera.thread = None
+    return camera
+
+
+def test_release_still_runs_when_the_sdk_has_no_camera_handle():
+    """The suspend reaches into SDK internals that only xensesdk 2.1.2/2.1.3 are
+    known to expose. On any other version that probe must not cost us the
+    release: a leaked camera is worse than the crash the suspend guards
+    against, and that version never had the crash."""
+    calls = []
+
+    class FakeContext:
+        def get_handle(self, key):
+            raise AttributeError("no such handle")
+
+    class FakeSensor:
+        ctx = FakeContext()
+
+        def release(self):
+            calls.append("release")
+
+    camera = _camera(FakeSensor())
+    camera.disconnect()
+
+    assert calls == ["release"]
+    assert camera.sensor is None
+
+
+def test_release_still_runs_when_suspend_itself_fails():
+    calls = []
+
+    class FakeSDKCamera:
+        def suspend_stream(self):
+            raise RuntimeError("stream already gone")
+
+    class FakeContext:
+        def get_handle(self, key):
+            return FakeSDKCamera()
+
+    class FakeSensor:
+        ctx = FakeContext()
+
+        def release(self):
+            calls.append("release")
+
+    camera = _camera(FakeSensor())
+    camera.disconnect()
+
+    assert calls == ["release"]
+    assert camera.sensor is None
+
+
+def test_a_missing_handle_is_not_suspended():
+    """`get_handle` returning None is a normal answer, not an error."""
+    calls = []
+
+    class FakeContext:
+        def get_handle(self, key):
+            return None
+
+    class FakeSensor:
+        ctx = FakeContext()
+
+        def release(self):
+            calls.append("release")
+
+    camera = _camera(FakeSensor())
+    camera.disconnect()
+
+    assert calls == ["release"]


### PR DESCRIPTION
Follow-up to #70, found while reviewing it. #70 fixes a real crash and the hardware evidence in it is convincing — this only changes what happens when its new probe fails.

## The defect

#70 put the new `suspend_stream()` probe and the existing `release()` in the same `try`:

```python
try:
    sdk_camera = self.sensor.ctx.get_handle("cam")   # ← if this raises
    if sdk_camera is not None:
        sdk_camera.suspend_stream()
    self.sensor.release()                            # ← this never runs
except Exception as e:
    logger.warn(f"Error releasing {self}: {e}")
```

`ctx.get_handle` is an SDK internal that, by #70's own comment, only xensesdk 2.1.2/2.1.3 are known to expose. On any other version the shared handler turns *"this SDK has no such handle"* into **a leaked camera plus a warning** — a worse outcome than the SIGSEGV the probe guards against, and on a version that never had that crash.

## The fix

Give the probe its own `try`, so `release()` is unconditional. The suspend still warns on failure, which is all it can usefully do.

## Testing

- `pytest tests/` — **739 passed, 13 skipped**.
- Two new tests, `test_release_still_runs_when_the_sdk_has_no_camera_handle` and `test_release_still_runs_when_suspend_itself_fails`, **fail on the previous code** and pass here — verified by checking out the pre-fix file and re-running. A third pins the `get_handle` returning `None` path, which was already correct and is easy to lose the next time this block is edited.
- `pre-commit run --files …` — all hooks pass.

Not verified on hardware: no Xense sensors on this machine. The change is confined to the error path, and #70's hardware A/B still holds for the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)